### PR TITLE
Adding isLocallyOwned to Entity interface.

### DIFF
--- a/packages/Interface/src/Client/DTK_Entity.cpp
+++ b/packages/Interface/src/Client/DTK_Entity.cpp
@@ -126,6 +126,16 @@ void Entity::boundingBox( Teuchos::Tuple<double,6>& bounds ) const
 }
 
 //---------------------------------------------------------------------------//
+// Determine if an entity is owned by the calling process.
+bool Entity::isLocallyOwned() const
+{
+{
+    DTK_REQUIRE( Teuchos::nonnull(b_entity_impl) );
+    return b_entity_impl->isLocallyOwned();
+}
+}
+
+//---------------------------------------------------------------------------//
 // Determine if an entity is in the block with the given id.
 bool Entity::inBlock( const int block_id ) const
 {

--- a/packages/Interface/src/Client/DTK_Entity.hpp
+++ b/packages/Interface/src/Client/DTK_Entity.hpp
@@ -136,6 +136,11 @@ class Entity : public Teuchos::Describable
     void boundingBox( Teuchos::Tuple<double,6>& bounds ) const;
 
     /*!
+     * \brief Determine if an entity is owned by the calling process.
+     */
+    bool isLocallyOwned() const;
+    
+    /*!
      * \brief Determine if an entity is in the block with the given id.
      */
     bool inBlock( const int block_id ) const;

--- a/packages/Interface/src/Client/DTK_EntityImpl.hpp
+++ b/packages/Interface/src/Client/DTK_EntityImpl.hpp
@@ -108,6 +108,11 @@ class EntityImpl
     virtual void boundingBox( Teuchos::Tuple<double,6>& bounds ) const = 0;
 
     /*!
+     * \brief Determine if an entity is owned by the calling process.
+     */
+    virtual bool isLocallyOwned() const = 0;
+
+    /*!
      * \brief Determine if an entity is in the block with the given id.
      */
     virtual bool inBlock( const int block_id ) const = 0;

--- a/packages/Interface/src/OperatorVector/DTK_BasicEntityPredicates.cpp
+++ b/packages/Interface/src/OperatorVector/DTK_BasicEntityPredicates.cpp
@@ -84,7 +84,7 @@ bool BoundaryPredicate::operator()( Entity entity )
 // LocalEntity predicate.
 bool LocalEntityPredicate::operator()( Entity entity ) 
 { 
-    return ( d_my_rank == entity.ownerRank() );
+    return entity.isLocallyOwned();
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
Entities will need to implement this function instead of getOwnerRank()
to help specify parallel ownership. Not implemented yet for the adapters.