### PR TITLE
Fix Spline Interpolation Test

### DIFF
--- a/packages/Operators/test/tstSplineInterpolation.cpp
+++ b/packages/Operators/test/tstSplineInterpolation.cpp
@@ -86,6 +86,9 @@ TEUCHOS_UNIT_TEST( SplineInterpolationOperator, spline_test )
     const int space_dim = 3;
     int field_dim = 1;
 
+    // Seed the RNG
+    std::srand( 324903231 );
+
     // Make a set of domain points.
     int num_points = 10;
     int domain_mult = 100;
@@ -163,7 +166,7 @@ TEUCHOS_UNIT_TEST( SplineInterpolationOperator, spline_test )
     // Check the apply.
     for ( int i = 0; i < num_points; ++i )
     {
-	TEST_FLOATING_EQUALITY( gold_data[i], range_data[i], 1.0e-7 );
+	TEST_FLOATING_EQUALITY( gold_data[i], range_data[i], 1.0e-6 );
     }
 }
 


### PR DESCRIPTION
Adding a random number seed and loosening the tolerance. I think loosening the tolerance here is OK. The results are a function of the linear solve used within the spline operator and are therefore subject to that tolerance. This changed from 1e-7 to 1e-6.