### PR TITLE
Adding option to keep range data for missed points instead of zero to consistent interpolation op

### DIFF
--- a/packages/Interface/src/OperatorVector/DTK_MapOperator.cpp
+++ b/packages/Interface/src/OperatorVector/DTK_MapOperator.cpp
@@ -99,13 +99,10 @@ void MapOperator::apply( const TpetraMultiVector& X,
 			 const double alpha,
 			 const double beta ) const
 {
-    // Pull data from the application.
+    // Pull data from the applications.
     const FieldMultiVector& X_fmv = dynamic_cast<const FieldMultiVector&>( X );
     const_cast<FieldMultiVector&>( X_fmv ).pullDataFromApplication();
-    if ( beta != Teuchos::ScalarTraits<double>::zero() )
-    {
-	dynamic_cast<FieldMultiVector&>( Y ).pullDataFromApplication();
-    }
+    dynamic_cast<FieldMultiVector&>( Y ).pullDataFromApplication();
     
     // Apply the operator.
     applyImpl( X, Y, mode, alpha, beta );

--- a/packages/Operators/src/SharedDomain/DTK_ConsistentInterpolationOperator.hpp
+++ b/packages/Operators/src/SharedDomain/DTK_ConsistentInterpolationOperator.hpp
@@ -50,6 +50,7 @@
 
 #include <Tpetra_Map.hpp>
 #include <Tpetra_CrsMatrix.hpp>
+#include <Tpetra_Vector.hpp>
 
 namespace DataTransferKit
 {
@@ -131,6 +132,10 @@ class ConsistentInterpolationOperator : virtual public MapOperator
     // Range entity topological dimension. Default is 0 (vertex).
     int d_range_entity_dim;
 
+    // Boolean for keeping the original range data when range entities are not
+    // mapped.
+    bool d_keep_missed_sol;
+
     // Search sublist.
     Teuchos::ParameterList d_search_list;
 
@@ -140,6 +145,9 @@ class ConsistentInterpolationOperator : virtual public MapOperator
     // An array of range entity ids that were not mapped during the last call
     // to setup.
     Teuchos::Array<EntityId> d_missed_range_entity_ids;
+
+    // The missed range entity update vector.
+    Teuchos::RCP<Tpetra::Vector<Scalar,LO,GO> > d_keep_range_vec;
 };
 
 //---------------------------------------------------------------------------//

--- a/packages/Operators/test/tstConsistentInterpolationOperator.cpp
+++ b/packages/Operators/test/tstConsistentInterpolationOperator.cpp
@@ -548,8 +548,8 @@ TEUCHOS_UNIT_TEST( ConsistentInterpolationOperator, many_to_many_test )
 	TEST_EQUALITY( test_val, point_dofs[i] );
     }
 
-    // Check that proc zero had some points not found.
-    int num_missed = (comm_rank != comm_size-1) ? 0 : 5;
+    // Check that the last proc had some points not found.
+    int num_missed = (comm_rank == comm_size-1) ? 5 : 0;
     Teuchos::Array<EntityId> missed_ids(
 	map_op->getMissedRangeEntityIds() );
     TEST_EQUALITY( missed_ids.size(), num_missed );
@@ -880,7 +880,7 @@ TEUCHOS_UNIT_TEST( ConsistentInterpolationOperator, keep_range_data_test )
 
     // DOMAIN SETUP
     // Don't put domain entities on proc 0.
-    int num_boxes = (comm->getRank() != 0) ? 5 : 0;
+    int num_boxes = (comm_rank != 0) ? 5 : 0;
     Teuchos::Array<DataTransferKit::SupportId> box_ids( num_boxes );
     Teuchos::ArrayRCP<double> box_dofs( num_boxes );
     Teuchos::Array<Entity> boxes( num_boxes );
@@ -956,12 +956,12 @@ TEUCHOS_UNIT_TEST( ConsistentInterpolationOperator, keep_range_data_test )
     // Check the results of the mapping.
     for ( int i = 0; i < num_points; ++i )
     {
-	double test_val = (comm_rank != comm_size-1) ? 2.0*point_ids[i] : 2.2;
+	double test_val = (comm_rank == comm_size-1) ? 2.2 : 2.0*point_ids[i];
 	TEST_EQUALITY( test_val, point_dofs[i] );
     }
 
-    // Check that proc zero had all points not found.
-    int num_missed = (comm_rank != comm_size-1) ? 0 : 5;
+    // Check that the last proc had all points not found.
+    int num_missed = (comm_rank == comm_size-1) ? 5 : 0;
     Teuchos::Array<EntityId> missed_ids(
 	map_op->getMissedRangeEntityIds() );
     TEST_EQUALITY( missed_ids.size(), num_missed );


### PR DESCRIPTION
This option lets users keep the part of the range vector that has
missing points when enabled. This automatically adds tracking of
missed range entities as well as this is needed for making the vector.
To enable this in a general way the map operator now always pulls
data from the range vector application before applying the implementation
operator. We will want to review the performance of this later.