### PR TITLE
Set linker language for Fortran API test

### DIFF
--- a/packages/Adapters/Fortran_API/test/CMakeLists.txt
+++ b/packages/Adapters/Fortran_API/test/CMakeLists.txt
@@ -3,5 +3,6 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   Fortran_API_test
   SOURCES tstFortran_API.F90
   COMM serial mpi
+  LINKER_LANGUAGE Fortran
   STANDARD_PASS_OUTPUT
   )


### PR DESCRIPTION
Was not able to compile with intel compiler