### PR TITLE
Fixing package order

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -5,10 +5,10 @@ TRIBITS_PACKAGE_DEFINE_DEPENDENCIES(
     BasicGeometryAdapters packages/Adapters/BasicGeometry SS  OPTIONAL
     IntrepidAdapters      packages/Adapters/Intrepid      SS  OPTIONAL
     Operators             packages/Operators              SS  REQUIRED
+    C_API                 packages/Adapters/C_API         SS  OPTIONAL
+    Fortran_API           packages/Adapters/Fortran_API   SS  OPTIONAL
     STKMeshAdapters       packages/Adapters/STKMesh       SS  OPTIONAL
     MoabAdapters          packages/Adapters/Moab          SS  OPTIONAL
     LibmeshAdapters       packages/Adapters/Libmesh       SS  OPTIONAL
     ClassicDTKAdapters    packages/Adapters/ClassicDTK    SS  OPTIONAL
-    C_API                 packages/Adapters/C_API         SS  OPTIONAL
-    Fortran_API           packages/Adapters/Fortran_API   SS  OPTIONAL
   )


### PR DESCRIPTION
I pasted below the CMake error log that Irina was getting.

CMake Error at
cmake/tribits/core/package_arch/TribitsAdjustPackageEnables.cmake:141 (MESSAGE):
  Error, the package 'DataTransferKitC_API' is listed as a dependency of the
  package 'DataTransferKitSTKMeshAdapters' is in the list
  'DataTransferKitSTKMeshAdapters_TEST_REQUIRED_DEP_PACKAGES' but the package
  'DataTransferKitC_API' is either not defined or is listed later in the
  package order.  Check the spelling of 'DataTransferKitC_API' or see how it
  is listed in Trilinos_PACKAGES_AND_DIRS_AND_CLASSIFICATIONS in relationship
  to 'DataTransferKitSTKMeshAdapters'.