### PR TITLE
Making the node-to-node operator a nearest-point operator

### DIFF
--- a/packages/Operators/src/PointCloud/DTK_NodeToNodeOperator.hpp
+++ b/packages/Operators/src/PointCloud/DTK_NodeToNodeOperator.hpp
@@ -128,6 +128,9 @@ class NodeToNodeOperator : virtual public MapOperator
                               Teuchos::ArrayRCP<GO> &support_ids ) const;
 
   private:
+    // Flag for matching point clouds.
+    bool d_matching_nodes;
+
     // Exporter
     Teuchos::RCP<Tpetra::CrsMatrix<Scalar, LO, GO>> d_coupling_matrix;
 };

--- a/packages/Operators/test/CMakeLists.txt
+++ b/packages/Operators/test/CMakeLists.txt
@@ -197,7 +197,7 @@ TRIBITS_COPY_FILES_TO_BINARY_DIR(
 
 TRIBITS_COPY_FILES_TO_BINARY_DIR(
   NodeToNodeOperatorXML
-  SOURCE_FILES node_to_node_test.xml
+  SOURCE_FILES matching_node_test.xml non_matching_node_test.xml
   SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}
   DEST_DIR ${CMAKE_CURRENT_BINARY_DIR}
   EXEDEPS NodeToNodeOperator_test

--- a/packages/Operators/test/matching_node_test.xml
+++ b/packages/Operators/test/matching_node_test.xml
@@ -1,0 +1,8 @@
+<ParameterList name="Moving Least Square Unit Test">
+  <Parameter name="Map Type" type="string" value="Point Cloud"/>
+  <ParameterList name="Point Cloud">
+    <Parameter name="Map Type" type="string" value="Node To Node"/>
+    <Parameter name="Spatial Dimension" type="int" value="3"/>
+    <Parameter name="Matching Nodes" type="bool" value="true"/>
+  </ParameterList>
+</ParameterList>

--- a/packages/Operators/test/non_matching_node_test.xml
+++ b/packages/Operators/test/non_matching_node_test.xml
@@ -3,5 +3,6 @@
   <ParameterList name="Point Cloud">
     <Parameter name="Map Type" type="string" value="Node To Node"/>
     <Parameter name="Spatial Dimension" type="int" value="3"/>
+    <Parameter name="Matching Nodes" type="bool" value="false"/>
   </ParameterList>
 </ParameterList>

--- a/packages/Operators/test/tstNodeToNodeOperator.cpp
+++ b/packages/Operators/test/tstNodeToNodeOperator.cpp
@@ -213,14 +213,15 @@ TEUCHOS_UNIT_TEST( NodeToNodeOperator, non_matching_node_test )
 //---------------------------------------------------------------------------//
 TEUCHOS_UNIT_TEST( NodeToNodeOperator, exception_test )
 {
+#if HAVE_DTK_DBC
     // Run the test assuming matching nodes but add a perturbation.
     Teuchos::Array<double> gold_data;
     Teuchos::Array<double> test_result;
 
-    bool caught_exception = false;
     TEST_THROW( setupAndRunTest( "matching_node_test.xml", gold_data,
                                  test_result, true ),
                 DataTransferKit::DataTransferKitException );
+#endif
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
The node-to-node operator can be made a nearest point operator if the check on coordinate equality is removed. If the meshes are the same, this still preserves the node-to-node transfer behavior. If they are different, the value at a given point is assigned to be the value of its nearest neighbor in other mesh.