### PR TITLE
Let the user specify clang-format executable

### DIFF
--- a/cmake/CodeFormat.cmake
+++ b/cmake/CodeFormat.cmake
@@ -3,6 +3,7 @@ if(NOT CLANG_FORMAT_EXECUTABLE)
         NAMES
         clang-format-3.9
         clang-format-mp-3.9
+        clang-format
     )
     if(CLANG_FORMAT_EXECUTABLE)
         message("-- Found clang-format: ${CLANG_FORMAT_EXECUTABLE}")

--- a/cmake/CodeFormat.cmake
+++ b/cmake/CodeFormat.cmake
@@ -1,21 +1,40 @@
-find_program(CLANG_FORMAT_EXECUTABLE
-    NAMES
-    clang-format-3.9
-    clang-format-mp-3.9
-)
-if(CLANG_FORMAT_EXECUTABLE)
-    message("-- Found clang-format: ${CLANG_FORMAT_EXECUTABLE}")
+if(NOT CLANG_FORMAT_EXECUTABLE)
+    find_program(CLANG_FORMAT_EXECUTABLE
+        NAMES
+        clang-format-3.9
+        clang-format-mp-3.9
+    )
+    if(CLANG_FORMAT_EXECUTABLE)
+        message("-- Found clang-format: ${CLANG_FORMAT_EXECUTABLE}")
+    else()
+        message(FATAL_ERROR "-- clang-format not found")
+    endif()
 else()
-    message(FATAL_ERROR "-- clang-format not found")
+    message("-- Using clang-format: ${CLANG_FORMAT_EXECUTABLE}")
+    if(NOT EXISTS ${CLANG_FORMAT_EXECUTABLE})
+        message(FATAL_ERROR "-- clang-format path is invalid")
+    endif()
 endif()
+
+# Check that the vesion of clang-format is 3.9
+execute_process(
+    COMMAND ${CLANG_FORMAT_EXECUTABLE} -version
+    OUTPUT_VARIABLE CLANG_FORMAT_VERSION
+)
+if(NOT CLANG_FORMAT_VERSION MATCHES "3.9")
+    message(FATAL_ERROR "You must use clang-format version 3.9")
+endif()
+# Download diff-clang-format.py from ORNL-CEES/Cap
 file(DOWNLOAD
     https://raw.githubusercontent.com/ORNL-CEES/Cap/master/diff-clang-format.py
     ${CMAKE_BINARY_DIR}/diff-clang-format.py
 )
+# Download docopt command line argument parser
 file(DOWNLOAD
     https://raw.githubusercontent.com/docopt/docopt/0.6.2/docopt.py
     ${CMAKE_BINARY_DIR}/docopt.py
 )
+# Add a custom target that applies the C++ code formatting style to the source
 add_custom_target(format-cpp
     ${PYTHON_EXECUTABLE} ${CMAKE_BINARY_DIR}/diff-clang-format.py
         --file-extension='.hpp'
@@ -26,6 +45,7 @@ add_custom_target(format-cpp
         --apply-patch
         ${${PACKAGE_NAME}_SOURCE_DIR}/packages
 )
+# Add a test that checks the code is formatted properly
 file(WRITE
     ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/check_format_cpp.sh
     "#!/usr/bin/env bash\n"


### PR DESCRIPTION
This resolves #148.
The user may specify the path to the clang-format executable using
-D CLANG_FORMAT_EXECUTABLE=<...> and we check that the version is 3.9 as
required.