### PR TITLE
Added pre-commit hook to test whitespaces and formatting

### DIFF
--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,0 +1,44 @@
+#!/bin/sh
+#
+# An example hook script to verify what is about to be committed.
+# Called by "git commit" with no arguments.  The hook should
+# exit with non-zero status after issuing an appropriate message if
+# it wants to stop the commit.
+#
+# To enable this hook, rename this file to "pre-commit".
+
+if git rev-parse --verify HEAD >/dev/null 2>&1
+then
+    against=HEAD
+else
+    # Initial commit: diff against an empty tree object
+    against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
+fi
+
+# If there are whitespace errors, print the offending file names and fail.
+git diff-index --cached --check $against
+if [[ $? != 0 ]]; then
+    whitespace_failed=1
+else
+    whitespace_failed=0;
+fi
+
+# If there are formatting errors, print the offending file names and fail.
+format_failed=0;
+git_clang_name="GIT_CLANG_NAME"
+if [[ "$git_clang_name" != "" ]]; then
+    gcf="$($git_clang_name --diff $against)"
+    if [[ ${gcf} != "no modified files to format" ]]; then
+        echo "${gcf}"
+        lineno=`echo -e $gcf | wc -l`
+        if [[ $lineno -gt 0 ]]; then format_failed=1; fi
+    fi
+fi
+
+# Final check
+if [[ $whitespace_failed != 0 ]] || [[ $format_failed != 0 ]]; then
+    echo "Before committing, please fix:"
+    [[ $whitespace_failed != 0 ]] && echo "    - whitespace errors"
+    [[ $format_failed     != 0 ]] && echo "    - formatting errors"
+    exit 1
+fi

--- a/scripts/setup_hooks.sh
+++ b/scripts/setup_hooks.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+cwd=`pwd`
+if [[ "$cwd" != *"/scripts" ]]; then
+    echo "./setup_hooks.sh must be called from scripts dir"
+    exit 1
+fi
+
+cp hooks/pre-commit ../.git/hooks/pre-commit
+
+## If there are formatting errors, print the offending lines and fail.
+# Find clang-format that is used with git
+git_clang_name=""
+for name in "git-clang-format-mp-3.9" "git-clang-format-3.9" "git-clang-format" ; do
+    which $name > /dev/null 2>&1
+    if [[ $? == 0 ]]; then
+        git_clang_name="$name"
+        break;
+    fi
+done
+
+# Fix the git-clang-format name in the hook (even if it's empty)
+sed -i "" "s/GIT_CLANG_NAME/$git_clang_name/" ../.git/hooks/pre-commit
+
+if [[ $git_clang_name == "" ]]; then
+    echo "Did not find git-clang-format"
+    exit 0
+fi
+
+# We actually do have some version of clang-format
+clang_format=""
+for name in "clang-format-mp-3.9" "clang-format-3.9" "clang-format"; do
+    which $name > /dev/null 2>&1
+    if [[ $? == 0 ]]; then
+        clang_format="$name"
+        break
+    fi
+done
+if [[ $clang_format == "" ]]; then
+    # Found git-clang-format but not clang-format, weird.
+    echo "Found git-clang-format but not clang-format, weird"
+    exit 1
+fi
+
+# Check clang-format version (only work with 3.9)
+clang_version=`$clang_format --version | awk '{print $3}' | cut -f 1,2 -d .`
+if [[ $clang_version != "3.9" ]]; then
+    echo "Clang-format version is bad: $clang_version"
+    git_clang_name=""
+    clang_format=""
+fi
+
+git config clangFormat.style file
+git config clangFormat.extension .hpp,.cpp
+git config clangFormat.binary $clang_format


### PR DESCRIPTION
Fixes #162.

At the moment, whitespace failures have to be fixed manually, while
formatting failures can be fixed by running
```bash
git clang-format
```