### PR TITLE
Updated pre-commit hook

### DIFF
--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -28,7 +28,8 @@ format_failed=0;
 git_clang_name="GIT_CLANG_NAME"
 if [[ "$git_clang_name" != "" ]]; then
     gcf="$($git_clang_name --diff $against)"
-    if [[ ${gcf} != "no modified files to format" ]]; then
+    if  [[ ${gcf} != "no modified files to format" ]] &&
+        [[ ${gcf} != *" did not modify any files" ]]; then
         echo "${gcf}"
         lineno=`echo -e $gcf | wc -l`
         if [[ $lineno -gt 0 ]]; then format_failed=1; fi


### PR DESCRIPTION
clang-format check may actually fail for two reasons:

    1. There are no modified files, and
    2. There is nothing to do

The old version of the pre-commit only checked for 1. However, if
clang-format check passed, it failed.

My bad.