### PR TITLE
Fixed the shebang for pre-commit hook

### DIFF
--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # An example hook script to verify what is about to be committed.
 # Called by "git commit" with no arguments.  The hook should


### PR DESCRIPTION
The initial hook was copied from the sample hook where `/bin/sh` was
sufficient. However, I started using `[[...]]` comparisons, which lead
to errors in some situations. This commit updates the bang to always use
bash.