### PR TITLE
Fix CUDA Errors

### DIFF
--- a/packages/Kokkos/src/DTK_KokkosHelpers.hpp
+++ b/packages/Kokkos/src/DTK_KokkosHelpers.hpp
@@ -43,10 +43,6 @@
 
 #include <Kokkos_Core.hpp>
 
-#include <cfloat>
-#include <climits>
-#include <typeinfo>
-
 namespace DataTransferKit
 {
 //---------------------------------------------------------------------------//
@@ -71,125 +67,7 @@ class KokkosHelpers
     {
         return ( left < right ) ? left : right;
     }
-
-    //! Return the maximum value representable by a given floating point or
-    //! integer type. std::numeric_limits<SC>::max() is not available in CUDA
-    //! 8 so we recreate that functionality here.
-    template <class SC>
-    KOKKOS_INLINE_FUNCTION static SC numericLimitsMax();
-
-    //! Return the epsilon representable by a given floating point
-    //! type. std::numeric_limits<SC>::epsilon() is not available in CUDA 8 so
-    //! we recreate that functionality here.
-    template <class SC>
-    KOKKOS_INLINE_FUNCTION static SC numericLimitsEpsilon();
 };
-
-//---------------------------------------------------------------------------//
-// Specializations of numericLimitsMax
-//---------------------------------------------------------------------------//
-// integer
-template <>
-KOKKOS_INLINE_FUNCTION int KokkosHelpers::numericLimitsMax<int>()
-{
-    return INT_MAX;
-}
-
-//---------------------------------------------------------------------------//
-// unsigned integer
-template <>
-KOKKOS_INLINE_FUNCTION unsigned int
-KokkosHelpers::numericLimitsMax<unsigned int>()
-{
-    return UINT_MAX;
-}
-
-//---------------------------------------------------------------------------//
-// long integer
-template <>
-KOKKOS_INLINE_FUNCTION long int KokkosHelpers::numericLimitsMax<long int>()
-{
-    return LONG_MAX;
-}
-
-//---------------------------------------------------------------------------//
-// unsigned long integer
-template <>
-KOKKOS_INLINE_FUNCTION unsigned long int
-KokkosHelpers::numericLimitsMax<unsigned long int>()
-{
-    return ULONG_MAX;
-}
-
-//---------------------------------------------------------------------------//
-// long long integer
-template <>
-KOKKOS_INLINE_FUNCTION long long int
-KokkosHelpers::numericLimitsMax<long long int>()
-{
-    return LLONG_MAX;
-}
-
-//---------------------------------------------------------------------------//
-// unsigned long long integer
-template <>
-KOKKOS_INLINE_FUNCTION unsigned long long int
-KokkosHelpers::numericLimitsMax<unsigned long long int>()
-{
-    return ULLONG_MAX;
-}
-
-//---------------------------------------------------------------------------//
-// float
-template <>
-KOKKOS_INLINE_FUNCTION float KokkosHelpers::numericLimitsMax<float>()
-{
-    return FLT_MAX;
-}
-
-//---------------------------------------------------------------------------//
-// double
-template <>
-KOKKOS_INLINE_FUNCTION double KokkosHelpers::numericLimitsMax<double>()
-{
-    return DBL_MAX;
-}
-
-//---------------------------------------------------------------------------//
-// long double
-template <>
-KOKKOS_INLINE_FUNCTION long double
-KokkosHelpers::numericLimitsMax<long double>()
-{
-    return LDBL_MAX;
-}
-
-//---------------------------------------------------------------------------//
-// Specializations of numericLimitsMax
-//---------------------------------------------------------------------------//
-// float
-template <>
-KOKKOS_INLINE_FUNCTION float KokkosHelpers::numericLimitsEpsilon<float>()
-{
-    return FLT_EPSILON;
-}
-
-//---------------------------------------------------------------------------//
-// double
-template <>
-KOKKOS_INLINE_FUNCTION double KokkosHelpers::numericLimitsEpsilon<double>()
-{
-    return DBL_EPSILON;
-}
-
-//---------------------------------------------------------------------------//
-// long double
-template <>
-KOKKOS_INLINE_FUNCTION long double
-KokkosHelpers::numericLimitsEpsilon<long double>()
-{
-    return LDBL_EPSILON;
-}
 
 //---------------------------------------------------------------------------//
 

--- a/packages/Kokkos/src/DTK_KokkosHelpers.hpp
+++ b/packages/Kokkos/src/DTK_KokkosHelpers.hpp
@@ -43,6 +43,10 @@
 
 #include <Kokkos_Core.hpp>
 
+#include <cfloat>
+#include <climits>
+#include <typeinfo>
+
 namespace DataTransferKit
 {
 //---------------------------------------------------------------------------//
@@ -67,7 +71,125 @@ class KokkosHelpers
     {
         return ( left < right ) ? left : right;
     }
+
+    //! Return the maximum value representable by a given floating point or
+    //! integer type. std::numeric_limits<SC>::max() is not available in CUDA
+    //! 8 so we recreate that functionality here.
+    template <class SC>
+    KOKKOS_INLINE_FUNCTION static SC numericLimitsMax();
+
+    //! Return the epsilon representable by a given floating point
+    //! type. std::numeric_limits<SC>::epsilon() is not available in CUDA 8 so
+    //! we recreate that functionality here.
+    template <class SC>
+    KOKKOS_INLINE_FUNCTION static SC numericLimitsEpsilon();
 };
+
+//---------------------------------------------------------------------------//
+// Specializations of numericLimitsMax
+//---------------------------------------------------------------------------//
+// integer
+template <>
+KOKKOS_INLINE_FUNCTION int KokkosHelpers::numericLimitsMax<int>()
+{
+    return INT_MAX;
+}
+
+//---------------------------------------------------------------------------//
+// unsigned integer
+template <>
+KOKKOS_INLINE_FUNCTION unsigned int
+KokkosHelpers::numericLimitsMax<unsigned int>()
+{
+    return UINT_MAX;
+}
+
+//---------------------------------------------------------------------------//
+// long integer
+template <>
+KOKKOS_INLINE_FUNCTION long int KokkosHelpers::numericLimitsMax<long int>()
+{
+    return LONG_MAX;
+}
+
+//---------------------------------------------------------------------------//
+// unsigned long integer
+template <>
+KOKKOS_INLINE_FUNCTION unsigned long int
+KokkosHelpers::numericLimitsMax<unsigned long int>()
+{
+    return ULONG_MAX;
+}
+
+//---------------------------------------------------------------------------//
+// long long integer
+template <>
+KOKKOS_INLINE_FUNCTION long long int
+KokkosHelpers::numericLimitsMax<long long int>()
+{
+    return LLONG_MAX;
+}
+
+//---------------------------------------------------------------------------//
+// unsigned long long integer
+template <>
+KOKKOS_INLINE_FUNCTION unsigned long long int
+KokkosHelpers::numericLimitsMax<unsigned long long int>()
+{
+    return ULLONG_MAX;
+}
+
+//---------------------------------------------------------------------------//
+// float
+template <>
+KOKKOS_INLINE_FUNCTION float KokkosHelpers::numericLimitsMax<float>()
+{
+    return FLT_MAX;
+}
+
+//---------------------------------------------------------------------------//
+// double
+template <>
+KOKKOS_INLINE_FUNCTION double KokkosHelpers::numericLimitsMax<double>()
+{
+    return DBL_MAX;
+}
+
+//---------------------------------------------------------------------------//
+// long double
+template <>
+KOKKOS_INLINE_FUNCTION long double
+KokkosHelpers::numericLimitsMax<long double>()
+{
+    return LDBL_MAX;
+}
+
+//---------------------------------------------------------------------------//
+// Specializations of numericLimitsMax
+//---------------------------------------------------------------------------//
+// float
+template <>
+KOKKOS_INLINE_FUNCTION float KokkosHelpers::numericLimitsEpsilon<float>()
+{
+    return FLT_EPSILON;
+}
+
+//---------------------------------------------------------------------------//
+// double
+template <>
+KOKKOS_INLINE_FUNCTION double KokkosHelpers::numericLimitsEpsilon<double>()
+{
+    return DBL_EPSILON;
+}
+
+//---------------------------------------------------------------------------//
+// long double
+template <>
+KOKKOS_INLINE_FUNCTION long double
+KokkosHelpers::numericLimitsEpsilon<long double>()
+{
+    return LDBL_EPSILON;
+}
 
 //---------------------------------------------------------------------------//
 

--- a/packages/Kokkos/src/DTK_PointCloud_def.hpp
+++ b/packages/Kokkos/src/DTK_PointCloud_def.hpp
@@ -48,6 +48,7 @@
 #include <Teuchos_CommHelpers.hpp>
 #include <Teuchos_Ptr.hpp>
 
+#include <Kokkos_ArithTraits.hpp>
 #include <Kokkos_Core.hpp>
 
 #include <type_traits>
@@ -104,8 +105,8 @@ class LocalBoundingBoxFunctor
     {
         for ( size_t d = 0; d < 3; ++d )
         {
-            dst[d] = KokkosHelpers::numericLimitsMax<SC>();
-            dst[d + 3] = -KokkosHelpers::numericLimitsMax<SC>();
+            dst[d] = Kokkos::Details::ArithTraits<SC>::max();
+            dst[d + 3] = -Kokkos::Details::ArithTraits<SC>::max();
         }
     }
 

--- a/packages/Kokkos/src/DTK_PointCloud_def.hpp
+++ b/packages/Kokkos/src/DTK_PointCloud_def.hpp
@@ -50,7 +50,6 @@
 
 #include <Kokkos_Core.hpp>
 
-#include <limits>
 #include <type_traits>
 
 namespace DataTransferKit
@@ -105,8 +104,8 @@ class LocalBoundingBoxFunctor
     {
         for ( size_t d = 0; d < 3; ++d )
         {
-            dst[d] = std::numeric_limits<SC>::max();
-            dst[d + 3] = -std::numeric_limits<SC>::max();
+            dst[d] = KokkosHelpers::numericLimitsMax<SC>();
+            dst[d + 3] = -KokkosHelpers::numericLimitsMax<SC>();
         }
     }
 
@@ -228,7 +227,7 @@ Kokkos::Array<SC, 6> PointCloud<SC, LO, GO, NO>::globalBoundingBox() const
  * \return The point global ids. Dimensions: (Point)
  */
 template <class SC, class LO, class GO, class NO>
-const auto PointCloud<SC, LO, GO, NO>::globalIds() const -> const global_id_view
+auto PointCloud<SC, LO, GO, NO>::globalIds() const -> const global_id_view
 {
     return _global_ids;
 }
@@ -239,8 +238,7 @@ const auto PointCloud<SC, LO, GO, NO>::globalIds() const -> const global_id_view
  * \return The point coordinates. Dimensions: (Point,SpaceDim)
  */
 template <class SC, class LO, class GO, class NO>
-const auto PointCloud<SC, LO, GO, NO>::coordinates() const
-    -> const coordinate_view
+auto PointCloud<SC, LO, GO, NO>::coordinates() const -> const coordinate_view
 {
     return _coordinates;
 }

--- a/packages/Kokkos/test/CMakeLists.txt
+++ b/packages/Kokkos/test/CMakeLists.txt
@@ -7,6 +7,14 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   )
 
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  KokkosHelpers_test
+  SOURCES tstKokkosHelpers.cpp unit_test_main.cpp
+  COMM serial mpi
+  STANDARD_PASS_OUTPUT
+  FAIL_REGULAR_EXPRESSION "data race;leak;runtime error"
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
   PointCloud_test
   SOURCES tstPointCloud.cpp unit_test_main.cpp
   COMM serial mpi

--- a/packages/Kokkos/test/tstKokkosHelpers.cpp
+++ b/packages/Kokkos/test/tstKokkosHelpers.cpp
@@ -45,9 +45,6 @@
 
 #include <Teuchos_UnitTestHarness.hpp>
 
-#include <limits>
-#include <type_traits>
-
 //---------------------------------------------------------------------------//
 // TEST FUNCTORS
 //---------------------------------------------------------------------------//
@@ -56,12 +53,6 @@ struct MinValue
 {
 };
 struct MaxValue
-{
-};
-struct LimitsMax
-{
-};
-struct LimitsEpsilon
 {
 };
 
@@ -89,24 +80,6 @@ KOKKOS_INLINE_FUNCTION
     typename View::traits::value_type zero = 0;
     typename View::traits::value_type one = 1;
     return DataTransferKit::KokkosHelpers::min( zero, one );
-}
-
-// Fill with the max value representable.
-template <class View>
-KOKKOS_INLINE_FUNCTION
-    typename View::traits::value_type fillFunction( LimitsMax )
-{
-    return DataTransferKit::KokkosHelpers::numericLimitsMax<
-        typename View::traits::value_type>();
-}
-
-// Fill with the smallest epsilon representable.
-template <class View>
-KOKKOS_INLINE_FUNCTION
-    typename View::traits::value_type fillFunction( LimitsEpsilon )
-{
-    return DataTransferKit::KokkosHelpers::numericLimitsEpsilon<
-        typename View::traits::value_type>();
 }
 
 //---------------------------------------------------------------------------//
@@ -173,38 +146,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_2_DECL( KokkosHelpers, helper_functions, Scalar,
         for ( int i = 0; i < size; ++i )
         {
             TEST_EQUALITY( host_data( i ), 0 );
-        }
-    }
-
-    // Test the limits max
-    {
-        Kokkos::parallel_for( Kokkos::RangePolicy<ExecutionSpace>( 0, size ),
-                              FillFunctor<ViewType, LimitsMax>( data ) );
-        Kokkos::fence();
-
-        typename ViewType::HostMirror host_data =
-            Kokkos::create_mirror_view( data );
-        Kokkos::deep_copy( host_data, data );
-        for ( int i = 0; i < size; ++i )
-        {
-            TEST_EQUALITY( host_data( i ), std::numeric_limits<Scalar>::max() );
-        }
-    }
-
-    // Test the limits floating point epsilon
-    if ( std::is_floating_point<Scalar>::value )
-    {
-        Kokkos::parallel_for( Kokkos::RangePolicy<ExecutionSpace>( 0, size ),
-                              FillFunctor<ViewType, LimitsEpsilon>( data ) );
-        Kokkos::fence();
-
-        typename ViewType::HostMirror host_data =
-            Kokkos::create_mirror_view( data );
-        Kokkos::deep_copy( host_data, data );
-        for ( int i = 0; i < size; ++i )
-        {
-            TEST_EQUALITY( host_data( i ),
-                           std::numeric_limits<Scalar>::epsilon() );
         }
     }
 }

--- a/packages/Kokkos/test/tstKokkosHelpers.cpp
+++ b/packages/Kokkos/test/tstKokkosHelpers.cpp
@@ -73,8 +73,8 @@ fillFunction( Algorithm alg );
 
 // Fill with the max of 0 and 1
 template <class View>
-KOKKOS_INLINE_FUNCTION typename View::traits::value_type
-fillFunction( MaxValue alg )
+KOKKOS_INLINE_FUNCTION
+    typename View::traits::value_type fillFunction( MaxValue )
 {
     typename View::traits::value_type zero = 0;
     typename View::traits::value_type one = 1;
@@ -83,8 +83,8 @@ fillFunction( MaxValue alg )
 
 // Fill with the min of 0 and 1
 template <class View>
-KOKKOS_INLINE_FUNCTION typename View::traits::value_type
-fillFunction( MinValue alg )
+KOKKOS_INLINE_FUNCTION
+    typename View::traits::value_type fillFunction( MinValue )
 {
     typename View::traits::value_type zero = 0;
     typename View::traits::value_type one = 1;
@@ -93,8 +93,8 @@ fillFunction( MinValue alg )
 
 // Fill with the max value representable.
 template <class View>
-KOKKOS_INLINE_FUNCTION typename View::traits::value_type
-fillFunction( LimitsMax alg )
+KOKKOS_INLINE_FUNCTION
+    typename View::traits::value_type fillFunction( LimitsMax )
 {
     return DataTransferKit::KokkosHelpers::numericLimitsMax<
         typename View::traits::value_type>();
@@ -102,8 +102,8 @@ fillFunction( LimitsMax alg )
 
 // Fill with the smallest epsilon representable.
 template <class View>
-KOKKOS_INLINE_FUNCTION typename View::traits::value_type
-fillFunction( LimitsEpsilon alg )
+KOKKOS_INLINE_FUNCTION
+    typename View::traits::value_type fillFunction( LimitsEpsilon )
 {
     return DataTransferKit::KokkosHelpers::numericLimitsEpsilon<
         typename View::traits::value_type>();

--- a/packages/Kokkos/test/tstKokkosHelpers.cpp
+++ b/packages/Kokkos/test/tstKokkosHelpers.cpp
@@ -1,0 +1,232 @@
+//---------------------------------------------------------------------------//
+/*
+  Copyright (c) 2012, Stuart R. Slattery
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are
+  met:
+
+  *: Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+
+  *: Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+
+  *: Neither the name of the University of Wisconsin - Madison nor the
+  names of its contributors may be used to endorse or promote products
+  derived from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+//---------------------------------------------------------------------------//
+/*!
+ * \file   tstKokkosHelpers.cpp
+ * \author Stuart Slattery
+ * \brief  Kokkos helpers unit tests.
+ */
+//---------------------------------------------------------------------------//
+
+#include "DTK_DBC.hpp"
+#include "DTK_KokkosHelpers.hpp"
+
+#include <Kokkos_Core.hpp>
+
+#include <Teuchos_UnitTestHarness.hpp>
+
+#include <limits>
+#include <type_traits>
+
+//---------------------------------------------------------------------------//
+// TEST FUNCTORS
+//---------------------------------------------------------------------------//
+// Algorithm tags.
+struct MinValue
+{
+};
+struct MaxValue
+{
+};
+struct LimitsMax
+{
+};
+struct LimitsEpsilon
+{
+};
+
+//---------------------------------------------------------------------------//
+// Fill function - specialize this for different fill operations.
+template <class View, class Algorithm>
+KOKKOS_INLINE_FUNCTION typename View::traits::value_type
+fillFunction( Algorithm alg );
+
+// Fill with the max of 0 and 1
+template <class View>
+KOKKOS_INLINE_FUNCTION typename View::traits::value_type
+fillFunction( MaxValue alg )
+{
+    typename View::traits::value_type zero = 0;
+    typename View::traits::value_type one = 1;
+    return DataTransferKit::KokkosHelpers::max( zero, one );
+}
+
+// Fill with the min of 0 and 1
+template <class View>
+KOKKOS_INLINE_FUNCTION typename View::traits::value_type
+fillFunction( MinValue alg )
+{
+    typename View::traits::value_type zero = 0;
+    typename View::traits::value_type one = 1;
+    return DataTransferKit::KokkosHelpers::min( zero, one );
+}
+
+// Fill with the max value representable.
+template <class View>
+KOKKOS_INLINE_FUNCTION typename View::traits::value_type
+fillFunction( LimitsMax alg )
+{
+    return DataTransferKit::KokkosHelpers::numericLimitsMax<
+        typename View::traits::value_type>();
+}
+
+// Fill with the smallest epsilon representable.
+template <class View>
+KOKKOS_INLINE_FUNCTION typename View::traits::value_type
+fillFunction( LimitsEpsilon alg )
+{
+    return DataTransferKit::KokkosHelpers::numericLimitsEpsilon<
+        typename View::traits::value_type>();
+}
+
+//---------------------------------------------------------------------------//
+// Fill a view with a given algorithm tag.
+template <class View, class Algorithm>
+class FillFunctor
+{
+  public:
+    FillFunctor( View data )
+        : _data( data )
+    { /* ... */
+    }
+
+    KOKKOS_INLINE_FUNCTION
+    void operator()( const size_t i ) const
+    {
+        _data( i ) = fillFunction<View>( Algorithm() );
+    }
+
+  private:
+    View _data;
+};
+
+//---------------------------------------------------------------------------//
+// TEST TEMPLATE DECLARATIONS
+//---------------------------------------------------------------------------//
+// Test helper functions.
+TEUCHOS_UNIT_TEST_TEMPLATE_2_DECL( KokkosHelpers, helper_functions, Scalar,
+                                   Node )
+{
+    // Get types.
+    using DeviceType = typename Node::device_type;
+    using ExecutionSpace = typename DeviceType::execution_space;
+
+    // Create a view in the execution space.
+    using ViewType = Kokkos::View<Scalar *, DeviceType>;
+    const int size = 10;
+    ViewType data( "data", size );
+
+    // Test the max
+    {
+        Kokkos::parallel_for( Kokkos::RangePolicy<ExecutionSpace>( 0, size ),
+                              FillFunctor<ViewType, MaxValue>( data ) );
+        Kokkos::fence();
+
+        typename ViewType::HostMirror host_data =
+            Kokkos::create_mirror_view( data );
+        Kokkos::deep_copy( host_data, data );
+        for ( int i = 0; i < size; ++i )
+        {
+            TEST_EQUALITY( host_data( i ), 1 );
+        }
+    }
+
+    // Test the min
+    {
+        Kokkos::parallel_for( Kokkos::RangePolicy<ExecutionSpace>( 0, size ),
+                              FillFunctor<ViewType, MinValue>( data ) );
+        Kokkos::fence();
+
+        typename ViewType::HostMirror host_data =
+            Kokkos::create_mirror_view( data );
+        Kokkos::deep_copy( host_data, data );
+        for ( int i = 0; i < size; ++i )
+        {
+            TEST_EQUALITY( host_data( i ), 0 );
+        }
+    }
+
+    // Test the limits max
+    {
+        Kokkos::parallel_for( Kokkos::RangePolicy<ExecutionSpace>( 0, size ),
+                              FillFunctor<ViewType, LimitsMax>( data ) );
+        Kokkos::fence();
+
+        typename ViewType::HostMirror host_data =
+            Kokkos::create_mirror_view( data );
+        Kokkos::deep_copy( host_data, data );
+        for ( int i = 0; i < size; ++i )
+        {
+            TEST_EQUALITY( host_data( i ), std::numeric_limits<Scalar>::max() );
+        }
+    }
+
+    // Test the limits floating point epsilon
+    if ( std::is_floating_point<Scalar>::value )
+    {
+        Kokkos::parallel_for( Kokkos::RangePolicy<ExecutionSpace>( 0, size ),
+                              FillFunctor<ViewType, LimitsEpsilon>( data ) );
+        Kokkos::fence();
+
+        typename ViewType::HostMirror host_data =
+            Kokkos::create_mirror_view( data );
+        Kokkos::deep_copy( host_data, data );
+        for ( int i = 0; i < size; ++i )
+        {
+            TEST_EQUALITY( host_data( i ),
+                           std::numeric_limits<Scalar>::epsilon() );
+        }
+    }
+}
+
+//---------------------------------------------------------------------------//
+// TEST TEMPLATE INSTANTIATIONS
+//---------------------------------------------------------------------------//
+
+// Include the test macros.
+#include "DataTransferKitKokkos_ETIHelperMacros.h"
+
+// Create the test group
+#define UNIT_TEST_GROUP_SN( SCALAR, NODE )                                     \
+    TEUCHOS_UNIT_TEST_TEMPLATE_2_INSTANT( KokkosHelpers, helper_functions,     \
+                                          SCALAR, NODE )
+
+// Demangle the types
+DTK_ETI_MANGLING_TYPEDEFS()
+
+// Instantiate the tests
+DTK_INSTANTIATE_SN( UNIT_TEST_GROUP_SN )
+
+//---------------------------------------------------------------------------//
+// end tstKokkosView.cpp
+//---------------------------------------------------------------------------//

--- a/packages/Kokkos/test/tstKokkosView.cpp
+++ b/packages/Kokkos/test/tstKokkosView.cpp
@@ -153,6 +153,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_2_DECL( View, basic_for_kernel, Scalar, Node )
     // Mirror the view to the host space and check the results.
     typename ViewType::HostMirror host_data =
         Kokkos::create_mirror_view( data );
+    Kokkos::deep_copy( host_data, data );
     for ( int i = 0; i < size; ++i )
     {
         TEST_EQUALITY( host_data( i ), i );
@@ -195,6 +196,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_2_DECL( View, layout_assign_kernel, Scalar, Node )
     // Check the second view on the host.
     typename ViewType2::HostMirror host_data =
         Kokkos::create_mirror_view( data_2 );
+    Kokkos::deep_copy( host_data, data_2 );
     for ( int i = 0; i < size; ++i )
     {
         for ( int d = 0; d < dim; ++d )
@@ -231,6 +233,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_2_DECL( View, basic_reduce_kernel, Scalar, Node )
     // Mirror the view to the host space and check the result.
     typename ViewType::HostMirror host_data =
         Kokkos::create_mirror_view( data );
+    Kokkos::deep_copy( host_data, data );
     double test_sum = 0.0;
     for ( int i = 0; i < size; ++i )
     {


### PR DESCRIPTION
It was discovered non-portable code was added by #161. Some C++ STL functions were being called inside of functions defined as `KOKKOS_INLINE_FUNCTION` and therefore were not callable by the CUDA compiler. This PR fixes that behavior as well as other errors and adds a test.

Yet another reason to get CUDA in the docker image and CI server as soon as possible.