### PR TITLE
Add suffix to CI container for Jenkins matrix builds

### DIFF
--- a/docker/jenkins/config.dict
+++ b/docker/jenkins/config.dict
@@ -2,7 +2,7 @@
   'api_calls_timeout_seconds': 300,
   'image': 'dalg24/dtk-stack',
   'tag': 'latest',
-  'name': os.getenv("BUILD_TAG"),
+  'name': os.getenv("BUILD_TAG").replace(",", "-").replace('=', '-'),
   'cmd': [
     'bash -c "patch -d /scratch/source/trilinos/release -p1 -i /scratch/source/trilinos/release/DataTransferKit/docker/jenkins/trilinos_stk.patch"',
     'bash -xe /scratch/source/trilinos/release/DataTransferKit/docker/jenkins/build.sh',


### PR DESCRIPTION
This PR will allow us to use the Jenkins matrix build plugin.
There will be a single DTK-experimental build that will spawn multiple builds with different configurations, collect statuses and report. This is similar to what we already have with Travis.