### PR TITLE
Fix strings comparison in C API for "Search Type"

### DIFF
--- a/packages/Adapters/C_API/src/DTK_C_API.cpp
+++ b/packages/Adapters/C_API/src/DTK_C_API.cpp
@@ -147,14 +147,14 @@ DTK_Map *DTK_Map_create( MPI_Comm comm, double const *src_coord,
         parameters.set( "Basis Type",
                         ptree.get<std::string>( "Basis Type", "Wendland" ) );
         parameters.set( "Basis Order", ptree.get<int>( "Basis Order", 2 ) );
-        parameters.set( "Type of Search",
-                        ptree.get<std::string>( "Search Type", "Radius" ) );
-        if ( "Radius" == ptree.get<std::string>( "Search Type", "Radius" ) )
+        std::string const search_type =
+            ptree.get<std::string>( "Search Type", "Radius" );
+        parameters.set( "Type of Search", search_type );
+        if ( search_type.compare( "Radius" ) == 0 )
         {
             parameters.set( "RBF Radius", ptree.get<double>( "RBF Radius" ) );
         }
-        else if ( "Nearest Neighbor" ==
-                  ptree.get<std::string>( "Search Type" ) )
+        else if ( search_type.compare( "Nearest Neighbor" ) == 0 )
         {
             parameters.set( "Num Neighbors",
                             ptree.get<int>( "Num Neighbors" ) );


### PR DESCRIPTION
When parsing the options for the type of search we were comparing a C string using the operator==.