### PR TITLE
Use Travis CI to build the sphinx documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ notifications:
 env:
   - TEST_SUITE=format_cpp
   - TEST_SUITE=no_trailing_whitespaces_or_tabs
+  - TEST_SUITE=build_sphinx_documentation
 
 before_install:
   - docker pull dalg24/clang-format

--- a/docker/travis/Dockerfile_clang-format
+++ b/docker/travis/Dockerfile_clang-format
@@ -1,6 +1,6 @@
 from ubuntu:16.04
 
-RUN apt-get update && apt-get install -y wget git && \
+RUN apt-get update && apt-get install -y wget git python-sphinx && \
     echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-3.9 main" > /etc/apt/sources.list.d/llvm.list && \
     wget -q -O - http://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
     apt-get update && apt-get install -y clang-format-3.9 && \

--- a/docker/travis/check_build_sphinx_documentation.sh
+++ b/docker/travis/check_build_sphinx_documentation.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+sphinx-build -W -b html docs/source /tmp/html

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -139,7 +139,7 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+#html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied


### PR DESCRIPTION
Partially addressing #193.

The sphinx documentation is built by ReadTheDocs when changes are pushed on master.
This will ensure that the doc can be generated without errors.

Make sure the matrix build on Travis CI already ran the check before you merge.