### PR TITLE
BVH: fixing insufficient array size checks

### DIFF
--- a/packages/Kokkos/src/details/DTK_DetailsTreeTraversal.hpp
+++ b/packages/Kokkos/src/details/DTK_DetailsTreeTraversal.hpp
@@ -1,6 +1,8 @@
 #ifndef DTK_DETAILS_TREE_TRAVERSAL_HPP
 #define DTK_DETAILS_TREE_TRAVERSAL_HPP
 
+#include <DTK_DBC.hpp>
+
 #include <details/DTK_DetailsAlgorithms.hpp>
 #include <details/DTK_Predicate.hpp>
 #include <details/DTK_PriorityQueue.hpp>
@@ -39,10 +41,11 @@ spatial_query( BVH<NO> const bvh, Predicate const &predicate, int *indices,
 #if HAVE_DTK_DBC
             if ( n_indices > max_n_indices )
                 printf( "Increase the size of indices array\n" );
-            assert( n_indices > max_n_indices );
-#else
-            (void)max_n_indices;
 #endif
+            assert( n_indices < max_n_indices );
+            // and just to make compilers happy if NDEBUG
+            (void)max_n_indices;
+
             indices[n_indices++] = BVHQuery<NO>::getIndex( bvh, node );
         }
         else
@@ -114,10 +117,11 @@ nearest_query( BVH<NO> const bvh, Point const &query_point, int k, int *indices,
 #if HAVE_DTK_DBC
             if ( n_indices > max_n_indices )
                 printf( "Increase the size of indices array\n" );
-            assert( n_indices > max_n_indices );
-#else
-            (void)max_n_indices;
 #endif
+            assert( n_indices < max_n_indices );
+            // and just to make compilers happy if NDEBUG
+            (void)max_n_indices;
+
             indices[n_indices++] = BVHQuery<NO>::getIndex( bvh, node );
         }
         else


### PR DESCRIPTION
1. HAVE_DTK_DBC only works with included DTK_DBC header.
2. Fixed the asserts.

Regarding 1., it feels that DTK_DBC should *always* be included in *all*
DTK files. Otherwise, mistakes like this would keep happening.

This patch does not deal with a fundamental problem, however. The real
issue is that this particular error really belongs to
program-terminating kind of error (or at least it does with the current
API, without proper propagation of errors back to users). Therefore,
using assert is a fundamental problem here as it can be hidden by
NDEBUG, which could be triggered invisibly during DTK configuration by
CMake's RELEASE or RELWITHDEBINFO build types.