### PR TITLE
Move the field/boundary names from set* interface to UserDataInterface

### DIFF
--- a/packages/Interface/src/DTK_UserApplication_def.hpp
+++ b/packages/Interface/src/DTK_UserApplication_def.hpp
@@ -207,9 +207,8 @@ void UserApplication<Scalar, ParallelModel>::getBoundary(
 {
     // Get the size of the boundary.
     size_t local_num_faces;
-    callUserFunction(
-        _user_functions->_boundary_size_funcs.find( boundary_name )->second,
-        local_num_faces );
+    callUserFunction( _user_functions->_boundary_size_func, boundary_name,
+                      local_num_faces );
 
     // Allocate the boundary.
     InputAllocators<Kokkos::LayoutLeft, ExecutionSpace>::allocateBoundary(
@@ -218,9 +217,8 @@ void UserApplication<Scalar, ParallelModel>::getBoundary(
     // Fill the boundary with user data.
     View<LocalOrdinal> boundary_cells( list.boundary_cells );
     View<unsigned> cell_faces_on_boundary( list.cell_faces_on_boundary );
-    callUserFunction(
-        _user_functions->_boundary_data_funcs.find( boundary_name )->second,
-        boundary_cells, cell_faces_on_boundary );
+    callUserFunction( _user_functions->_boundary_data_func, boundary_name,
+                      boundary_cells, cell_faces_on_boundary );
 }
 
 //---------------------------------------------------------------------------//
@@ -293,14 +291,11 @@ auto UserApplication<Scalar, ParallelModel>::getField(
     const std::string &field_name )
     -> Field<Scalar, Kokkos::LayoutLeft, ExecutionSpace>
 {
-    DTK_INSIST( _user_functions->_field_size_funcs.count( field_name ) );
-
     // Get the size of the field.
     unsigned field_dim;
     size_t local_num_dofs;
-    callUserFunction(
-        _user_functions->_field_size_funcs.find( field_name )->second,
-        field_dim, local_num_dofs );
+    callUserFunction( _user_functions->_field_size_func, field_name, field_dim,
+                      local_num_dofs );
 
     // Allocate the field.
     auto field = InputAllocators<Kokkos::LayoutLeft, ExecutionSpace>::
@@ -316,13 +311,10 @@ void UserApplication<Scalar, ParallelModel>::pullField(
     const std::string &field_name,
     Field<Scalar, Kokkos::LayoutLeft, ExecutionSpace> field )
 {
-    DTK_INSIST( _user_functions->_pull_field_funcs.count( field_name ) );
-
     // Get the field from the user.
     View<Scalar> field_dofs( field.dofs );
-    callUserFunction(
-        _user_functions->_pull_field_funcs.find( field_name )->second,
-        field_dofs );
+    callUserFunction( _user_functions->_pull_field_func, field_name,
+                      field_dofs );
 }
 
 //---------------------------------------------------------------------------//
@@ -332,13 +324,10 @@ void UserApplication<Scalar, ParallelModel>::pushField(
     const std::string &field_name,
     const Field<Scalar, Kokkos::LayoutLeft, ExecutionSpace> field )
 {
-    DTK_INSIST( _user_functions->_push_field_funcs.count( field_name ) );
-
     // Give the field to the user.
     View<Scalar> field_dofs( field.dofs );
-    callUserFunction(
-        _user_functions->_push_field_funcs.find( field_name )->second,
-        field_dofs );
+    callUserFunction( _user_functions->_push_field_func, field_name,
+                      field_dofs );
 }
 
 //---------------------------------------------------------------------------//
@@ -349,15 +338,12 @@ void UserApplication<Scalar, ParallelModel>::evaluateField(
     const EvaluationSet<Kokkos::LayoutLeft, ExecutionSpace> eval_set,
     Field<Scalar, Kokkos::LayoutLeft, ExecutionSpace> field )
 {
-    DTK_INSIST( _user_functions->_eval_field_funcs.count( field_name ) );
-
     // Ask the user to evaluate the field.
     View<Coordinate> evaluation_points( eval_set.evaluation_points );
     View<LocalOrdinal> object_ids( eval_set.object_ids );
     View<Scalar> values( field.dofs );
-    callUserFunction(
-        _user_functions->_eval_field_funcs.find( field_name )->second,
-        evaluation_points, object_ids, values );
+    callUserFunction( _user_functions->_eval_field_func, field_name,
+                      evaluation_points, object_ids, values );
 }
 
 //---------------------------------------------------------------------------//

--- a/packages/Interface/src/DTK_UserDataInterface.hpp
+++ b/packages/Interface/src/DTK_UserDataInterface.hpp
@@ -145,15 +145,16 @@ using MixedTopologyCellListDataFunction = std::function<void(
  * \brief Get the size parameters for a boundary.
  */
 using BoundarySizeFunction = std::function<void(
-    std::shared_ptr<void> user_data, size_t &local_num_faces )>;
+    std::shared_ptr<void> user_data, const std::string &boundary_name,
+    size_t &local_num_faces )>;
 
 //---------------------------------------------------------------------------//
 /*!
  * \brief Get the data for a boundary.
  */
 using BoundaryDataFunction = std::function<void(
-    std::shared_ptr<void> user_data, View<LocalOrdinal> boundary_cells,
-    View<unsigned> cell_faces_on_boundary )>;
+    std::shared_ptr<void> user_data, const std::string &boundary_name,
+    View<LocalOrdinal> boundary_cells, View<unsigned> cell_faces_on_boundary )>;
 
 //---------------------------------------------------------------------------//
 // Degree-of-freedom interface.
@@ -203,6 +204,7 @@ using MixedTopologyDOFMapDataFunction = std::function<void(
 template <class Scalar>
 using FieldSizeFunction =
     std::function<void( std::shared_ptr<void> user_data,
+                        const std::string &field_name,
                         unsigned &field_dimension, size_t &local_num_dofs )>;
 
 //---------------------------------------------------------------------------//
@@ -210,16 +212,20 @@ using FieldSizeFunction =
  * \brief Pull data from application into a field.
  */
 template <class Scalar>
-using PullFieldDataFunction = std::function<void(
-    std::shared_ptr<void> user_data, View<Scalar> field_dofs )>;
+using PullFieldDataFunction =
+    std::function<void( std::shared_ptr<void> user_data,
+                        const std::string &field_name,
+                        View<Scalar> field_dofs )>;
 
 //---------------------------------------------------------------------------//
 /*
  * \brief Push data from a field into the application.
  */
 template <class Scalar>
-using PushFieldDataFunction = std::function<void(
-    std::shared_ptr<void> user_data, const View<Scalar> field_dofs )>;
+using PushFieldDataFunction =
+    std::function<void( std::shared_ptr<void> user_data,
+                        const std::string &field_name,
+                        const View<Scalar> field_dofs )>;
 
 //---------------------------------------------------------------------------//
 /*
@@ -227,7 +233,8 @@ using PushFieldDataFunction = std::function<void(
  */
 template <class Scalar>
 using EvaluateFieldFunction = std::function<void(
-    std::shared_ptr<void> user_data, const View<Coordinate> evaluation_points,
+    std::shared_ptr<void> user_data, const std::string &field_name,
+    const View<Coordinate> evaluation_points,
     const View<LocalOrdinal> object_ids, View<Scalar> values )>;
 
 //---------------------------------------------------------------------------//

--- a/packages/Interface/src/DTK_UserFunctionRegistry.hpp
+++ b/packages/Interface/src/DTK_UserFunctionRegistry.hpp
@@ -67,11 +67,6 @@ class UserFunctionRegistry
     template <class CallableObject>
     using UserImpl = std::pair<CallableObject, std::shared_ptr<void>>;
 
-    //! Field function map.
-    template <class CallableObject>
-    using UserImplMap =
-        std::unordered_map<std::string, UserImpl<CallableObject>>;
-
     //@{
     //! Set geometry.
 
@@ -122,13 +117,11 @@ class UserFunctionRegistry
         std::shared_ptr<void> user_data = nullptr );
 
     // Boundary data function.
-    void setBoundarySizeFunction( const std::string &boundary_name,
-                                  BoundarySizeFunction &&func,
+    void setBoundarySizeFunction( BoundarySizeFunction &&func,
                                   std::shared_ptr<void> user_data = nullptr );
 
     // Boundary data function.
-    void setBoundaryDataFunction( const std::string &boundary_name,
-                                  BoundaryDataFunction &&func,
+    void setBoundaryDataFunction( BoundaryDataFunction &&func,
                                   std::shared_ptr<void> user_data = nullptr );
     //@}
 
@@ -158,23 +151,19 @@ class UserFunctionRegistry
     //! Set fields.
 
     // Field size.
-    void setFieldSizeFunction( const std::string &field_name,
-                               FieldSizeFunction<Scalar> &&func,
+    void setFieldSizeFunction( FieldSizeFunction<Scalar> &&func,
                                std::shared_ptr<void> user_data = nullptr );
 
     // Pull field.
-    void setPullFieldDataFunction( const std::string &field_name,
-                                   PullFieldDataFunction<Scalar> &&func,
+    void setPullFieldDataFunction( PullFieldDataFunction<Scalar> &&func,
                                    std::shared_ptr<void> user_data = nullptr );
 
     // Push field.
-    void setPushFieldDataFunction( const std::string &field_name,
-                                   PushFieldDataFunction<Scalar> &&func,
+    void setPushFieldDataFunction( PushFieldDataFunction<Scalar> &&func,
                                    std::shared_ptr<void> user_data = nullptr );
 
     // Evaluate field.
-    void setEvaluateFieldFunction( const std::string &field_name,
-                                   EvaluateFieldFunction<Scalar> &&func,
+    void setEvaluateFieldFunction( EvaluateFieldFunction<Scalar> &&func,
                                    std::shared_ptr<void> user_data = nullptr );
     //@}
 
@@ -212,11 +201,11 @@ class UserFunctionRegistry
     //! Mixed topology cell list data function.
     UserImpl<MixedTopologyCellListDataFunction> _mt_cell_list_data_func;
 
-    //! Boundary size functions.
-    UserImplMap<BoundarySizeFunction> _boundary_size_funcs;
+    //! Boundary size function.
+    UserImpl<BoundarySizeFunction> _boundary_size_func;
 
-    //! Boundary data functions.
-    UserImplMap<BoundaryDataFunction> _boundary_data_funcs;
+    //! Boundary data function.
+    UserImpl<BoundaryDataFunction> _boundary_data_func;
     //@}
 
     //@{
@@ -238,17 +227,17 @@ class UserFunctionRegistry
     //@{
     //! User Field functions.
 
-    //! Field size functions.
-    UserImplMap<FieldSizeFunction<Scalar>> _field_size_funcs;
+    //! Field size function.
+    UserImpl<FieldSizeFunction<Scalar>> _field_size_func;
 
-    //! Field pull data functions.
-    UserImplMap<PullFieldDataFunction<Scalar>> _pull_field_funcs;
+    //! Field pull data function.
+    UserImpl<PullFieldDataFunction<Scalar>> _pull_field_func;
 
-    //! Field push data functions.
-    UserImplMap<PushFieldDataFunction<Scalar>> _push_field_funcs;
+    //! Field push data function.
+    UserImpl<PushFieldDataFunction<Scalar>> _push_field_func;
 
-    //! Field evaluate data functions.
-    UserImplMap<EvaluateFieldFunction<Scalar>> _eval_field_funcs;
+    //! Field evaluate data function.
+    UserImpl<EvaluateFieldFunction<Scalar>> _eval_field_func;
     //@}
 };
 

--- a/packages/Interface/src/DTK_UserFunctionRegistry_def.hpp
+++ b/packages/Interface/src/DTK_UserFunctionRegistry_def.hpp
@@ -111,22 +111,18 @@ void UserFunctionRegistry<Scalar>::setMixedTopologyCellListDataFunction(
 // Boundary size function.
 template <class Scalar>
 void UserFunctionRegistry<Scalar>::setBoundarySizeFunction(
-    const std::string &boundary_name, BoundarySizeFunction &&func,
-    std::shared_ptr<void> user_data )
+    BoundarySizeFunction &&func, std::shared_ptr<void> user_data )
 {
-    _boundary_size_funcs.emplace( boundary_name,
-                                  std::make_pair( func, user_data ) );
+    _boundary_size_func = std::make_pair( func, user_data );
 }
 
 //---------------------------------------------------------------------------//
 // Boundary data function.
 template <class Scalar>
 void UserFunctionRegistry<Scalar>::setBoundaryDataFunction(
-    const std::string &boundary_name, BoundaryDataFunction &&func,
-    std::shared_ptr<void> user_data )
+    BoundaryDataFunction &&func, std::shared_ptr<void> user_data )
 {
-    _boundary_data_funcs.emplace( boundary_name,
-                                  std::make_pair( func, user_data ) );
+    _boundary_data_func = std::make_pair( func, user_data );
 }
 
 //---------------------------------------------------------------------------//
@@ -169,40 +165,36 @@ void UserFunctionRegistry<Scalar>::setMixedTopologyDOFMapDataFunction(
 // Field size.
 template <class Scalar>
 void UserFunctionRegistry<Scalar>::setFieldSizeFunction(
-    const std::string &field_name, FieldSizeFunction<Scalar> &&func,
-    std::shared_ptr<void> user_data )
+    FieldSizeFunction<Scalar> &&func, std::shared_ptr<void> user_data )
 {
-    _field_size_funcs.emplace( field_name, std::make_pair( func, user_data ) );
+    _field_size_func = std::make_pair( func, user_data );
 }
 
 //---------------------------------------------------------------------------//
 // Pull field.
 template <class Scalar>
 void UserFunctionRegistry<Scalar>::setPullFieldDataFunction(
-    const std::string &field_name, PullFieldDataFunction<Scalar> &&func,
-    std::shared_ptr<void> user_data )
+    PullFieldDataFunction<Scalar> &&func, std::shared_ptr<void> user_data )
 {
-    _pull_field_funcs.emplace( field_name, std::make_pair( func, user_data ) );
+    _pull_field_func = std::make_pair( func, user_data );
 }
 
 //---------------------------------------------------------------------------//
 // Push field.
 template <class Scalar>
 void UserFunctionRegistry<Scalar>::setPushFieldDataFunction(
-    const std::string &field_name, PushFieldDataFunction<Scalar> &&func,
-    std::shared_ptr<void> user_data )
+    PushFieldDataFunction<Scalar> &&func, std::shared_ptr<void> user_data )
 {
-    _push_field_funcs.emplace( field_name, std::make_pair( func, user_data ) );
+    _push_field_func = std::make_pair( func, user_data );
 }
 
 //---------------------------------------------------------------------------//
 // Evaluate field.
 template <class Scalar>
 void UserFunctionRegistry<Scalar>::setEvaluateFieldFunction(
-    const std::string &field_name, EvaluateFieldFunction<Scalar> &&func,
-    std::shared_ptr<void> user_data )
+    EvaluateFieldFunction<Scalar> &&func, std::shared_ptr<void> user_data )
 {
-    _eval_field_funcs.emplace( field_name, std::make_pair( func, user_data ) );
+    _eval_field_func = std::make_pair( func, user_data );
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
Instead of calling `setBoundary(name, ...)` we instead will rely on the
user provided function to do that themselves.