### PR TITLE
Add pip requirements file for ReadTheDocs to use

### DIFF
--- a/docs/source/requirements.readthedocs.txt
+++ b/docs/source/requirements.readthedocs.txt
@@ -1,0 +1,2 @@
+sphinx=1.4
+breathe=4.6


### PR DESCRIPTION
Merging #244 broke our build on ReadTheDocs.  See [here](https://readthedocs.org/projects/datatransferkit/builds/5561095/)