### PR TITLE
Add missing include.

### DIFF
--- a/packages/Search/examples/bvh_driver/bvh_driver.cpp
+++ b/packages/Search/examples/bvh_driver/bvh_driver.cpp
@@ -17,6 +17,7 @@
 #include <DTK_LinearBVH.hpp>
 
 #include <cmath>
+#include <functional>
 #include <random>
 
 namespace details = DataTransferKit::Details;

--- a/packages/Search/test/tstDetailsTreeConstruction.cpp
+++ b/packages/Search/test/tstDetailsTreeConstruction.cpp
@@ -15,6 +15,7 @@
 
 #include <algorithm>
 #include <bitset>
+#include <functional>
 #include <sstream>
 #include <vector>
 


### PR DESCRIPTION
I can't compile DTK without these include with gcc 7.1. `Interface_Init` tests are not passing on my machine but I am still investigating.