### PR TITLE
Update documentation.

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -11,7 +11,7 @@ The following third party libraries (TPLs) are used by DTK:
 +------------------------+------------+---------+
 | Packages               | Dependency | Version |
 +========================+============+=========+
-| Boost                  | Optional   | 1.59.0  |
+| Boost                  | Required   | 1.59.0  |
 +------------------------+------------+---------+
 | BLAS/LAPACK            | Required   | N/A     |
 +------------------------+------------+---------+

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -57,8 +57,11 @@ DTK has the following packages:
     General utilities for software development including exception
     handling, MPI-based tools, and functional programming tools.
 
-**Kokkos**
-    Core DTK package using Kokkos. Under rapid development.
+**Interface**
+    Implement interface with user applications.
+
+**Search**
+    Implement the search algorithms.
 
 
 Questions, Bug Reporting, and Issue Tracking


### PR DESCRIPTION
I have change MPI to required because I don't think that we want to test that DTK works in serial (doesn't matter for now but it will once we add global search) but I can change it back. 