### PR TITLE
C API: adding error message handling

### DIFF
--- a/packages/Interface/src/DTK_C_API.h
+++ b/packages/Interface/src/DTK_C_API.h
@@ -146,6 +146,19 @@ extern void DTK_finalize();
 
 /**@}*/
 
+/** \brief Get DTK error message.
+ *
+ * All DTK functions set \c errno error code upon completion. If DTK function
+ * fails, the code is nonzero. This function provides a way to get the the
+ * error message associated with the error code. If the error code is unknown,
+ * DTK returns a string stating that.
+ *
+ * \param err Error number (typically, errno)
+ * \return Returns corresponding error string. If the error code is 0 (success),
+ *         return empty string.
+ */
+extern const char *DTK_error( int err );
+
 // clang-format off ////////////////////////////////////////////////////////////
 // COMMENT: disabling clang-format because it keeps trying to put the comma on a
 // separate new line.


### PR DESCRIPTION
This is just an idea of what error message handling may look like.

Related to #74 (though that was for old interface).

Things to do:
- [x] Change DTK_error to return `const char *`
- [x] Do not change the signature for `DTK_set_function`
- [x] Set errno to 0 for all API functions
- [x] Add more tests for errno
  - Trigger a `DTK_UNINITIALIZED` error in tstInit.cpp
  - Call DTK_error() on success at least once and check that the message is an empty string.
- [ ] Figure out `DTK_UNKNOWN_ERROR`
