### PR TITLE
Remove inaccurate comment in implementation of initialize( argc, argv )

### DIFF
--- a/packages/Utils/src/DTK_Core.cpp
+++ b/packages/Utils/src/DTK_Core.cpp
@@ -36,7 +36,8 @@ void initKokkos( Args &&... args )
 
         if ( !kokkosIsInitialized )
         {
-            // Unlike MPI_Init, Kokkos promises not to modify argc and argv.
+            // Kokkos will remove all arguments Kokkos recognizes which start
+            // with '--kokkos' (e.g.,--kokkos-threads)
             Kokkos::initialize( std::forward<Args>( args )... );
             dtkInitializedKokkos = true;
         }


### PR DESCRIPTION
This section of code is admittedly heavily inspired by tpetra/core/src/Tpetra_Core.cpp and this comment is actually present at [L83](https://github.com/trilinos/Trilinos/blob/master/packages/tpetra/core/src/Tpetra_Core.cpp#L83).

Resolves #273. Christian says Kokkos did not promise such thing :)