### PR TITLE
Enable access to computed distances for nearest queries on BVH

### DIFF
--- a/packages/Search/src/details/DTK_DetailsTreeTraversal.hpp
+++ b/packages/Search/src/details/DTK_DetailsTreeTraversal.hpp
@@ -153,11 +153,15 @@ KOKKOS_FUNCTION int nearest_query( BVH<DeviceType> const bvh,
     {
         // get the node that is on top of the priority list (i.e. is the
         // closest to the query point)
-        node = queue.top().first; // std::tie(node, std::ignore) = ...
+        node = queue.top().first;
+        node_distance = queue.top().second;
+        // NOTE: it would be nice to be able to do something like
+        // tie( node, node_distance = queue.top();
         queue.pop();
         if ( TreeTraversal<DeviceType>::isLeaf( bvh, node ) )
         {
-            insert( TreeTraversal<DeviceType>::getIndex( bvh, node ) );
+            insert( TreeTraversal<DeviceType>::getIndex( bvh, node ),
+                    node_distance );
             count++;
         }
         else

--- a/packages/Search/src/details/DTK_DetailsUtils.hpp
+++ b/packages/Search/src/details/DTK_DetailsUtils.hpp
@@ -1,0 +1,59 @@
+/****************************************************************************
+ * Copyright (c) 2012-2017 by the DataTransferKit authors                   *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the DataTransferKit library. DataTransferKit is     *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ ****************************************************************************/
+
+#ifndef DTK_DETAILS_UTILS_HPP
+#define DTK_DETAILS_UTILS_HPP
+
+#include <DTK_DBC.hpp>
+
+#include <Kokkos_Parallel.hpp>
+#include <Kokkos_View.hpp>
+
+namespace DataTransferKit
+{
+
+/** \brief Assigns the given value to all elements in the view.
+ */
+template <typename T, typename DeviceType>
+void fill( Kokkos::View<T *, DeviceType> out, T const &value )
+{
+    using ExecutionSpace = typename DeviceType::execution_space;
+    Kokkos::parallel_for(
+        "fill", Kokkos::RangePolicy<ExecutionSpace>( 0, out.extent( 0 ) ),
+        KOKKOS_LAMBDA( int i ) { out( i ) = value; } );
+    Kokkos::fence();
+}
+
+/** \brief Computes an exclusive scan.
+ *
+ *  When \c in and \c out are the same view, the scan is performed in-place.
+ *
+ *  \pre \c in and \c out must have the same size.
+ */
+template <typename T, typename DeviceType>
+void exclusive_prefix_sum( Kokkos::View<T *, DeviceType> in,
+                           Kokkos::View<T *, DeviceType> out )
+{
+    using ExecutionSpace = typename DeviceType::execution_space;
+    DTK_INSIST( in.extent( 0 ) == out.extent( 0 ) );
+    Kokkos::parallel_scan(
+        "exclusive_scan",
+        Kokkos::RangePolicy<ExecutionSpace>( 0, in.extent( 0 ) ),
+        KOKKOS_LAMBDA( int i, int &update, bool final_pass ) {
+            int const in_i = in( i );
+            if ( final_pass )
+                out( i ) = update;
+            update += in_i;
+        } );
+    Kokkos::fence();
+}
+
+} // end namespace DataTransferKit
+
+#endif

--- a/packages/Search/src/details/DTK_DetailsUtils.hpp
+++ b/packages/Search/src/details/DTK_DetailsUtils.hpp
@@ -54,6 +54,24 @@ void exclusive_prefix_sum( Kokkos::View<T *, DeviceType> in,
     Kokkos::fence();
 }
 
+/** \brief Get a copy of the last element on the host.
+ *
+ *  Returns a copy of the last element in the view on the host.  Note that it
+ *  may require communication between host and device (e.g. if the view passed
+ *  as an argument lives on the device).
+ *
+ *  \pre \c in is not empty.
+ */
+template <typename T, typename DeviceType>
+T last_element( Kokkos::View<T *, DeviceType> in )
+{
+    DTK_INSIST( in.extent( 0 ) > 0 );
+    auto in_subview = Kokkos::subview( in, in.extent( 0 ) - 1 );
+    auto in_host = Kokkos::create_mirror_view( in_subview );
+    Kokkos::deep_copy( in_host, in_subview );
+    return in_host( 0 );
+}
+
 } // end namespace DataTransferKit
 
 #endif

--- a/packages/Search/src/details/DTK_DetailsUtils.hpp
+++ b/packages/Search/src/details/DTK_DetailsUtils.hpp
@@ -32,15 +32,19 @@ void fill( Kokkos::View<T *, DeviceType> out, T const &value )
 
 /** \brief Computes an exclusive scan.
  *
- *  When \c in and \c out are the same view, the scan is performed in-place.
+ *  When \c out is not provided or if \c in and \c out are the same view, the
+ *  scan is performed in-place.
  *
  *  \pre \c in and \c out must have the same size.
  */
 template <typename T, typename DeviceType>
-void exclusive_prefix_sum( Kokkos::View<T *, DeviceType> in,
-                           Kokkos::View<T *, DeviceType> out )
+void exclusive_prefix_sum(
+    Kokkos::View<T *, DeviceType> in,
+    Kokkos::View<T *, DeviceType> out = Kokkos::View<T *, DeviceType>() )
 {
     using ExecutionSpace = typename DeviceType::execution_space;
+    if ( out.size() == 0 )
+        out = in;
     DTK_INSIST( in.extent( 0 ) == out.extent( 0 ) );
     Kokkos::parallel_scan(
         "exclusive_scan",

--- a/packages/Search/test/CMakeLists.txt
+++ b/packages/Search/test/CMakeLists.txt
@@ -35,6 +35,14 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   FAIL_REGULAR_EXPRESSION "data race;leak;runtime error"
   )
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  DetailsUtils
+  SOURCES tstDetailsUtils.cpp unit_test_main.cpp
+  COMM serial mpi
+  NUM_MPI_PROCS 1
+  STANDARD_PASS_OUTPUT
+  FAIL_REGULAR_EXPRESSION "data race;leak;runtime error"
+  )
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
   FineSearch
   SOURCES tstFineSearch.cpp unit_test_main.cpp
   COMM serial mpi

--- a/packages/Search/test/tstDetailsUtils.cpp
+++ b/packages/Search/test/tstDetailsUtils.cpp
@@ -55,6 +55,19 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DetailsUtils, prefix_sum, DeviceType )
                 DataTransferKit::DataTransferKitException );
 }
 
+TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DetailsUtils, last_element, DeviceType )
+{
+    Kokkos::View<int *, DeviceType> v( "v", 2 );
+    auto v_host = Kokkos::create_mirror_view( v );
+    v_host( 0 ) = 33;
+    v_host( 1 ) = 24;
+    Kokkos::deep_copy( v, v_host );
+    TEST_EQUALITY( DataTransferKit::last_element( v ), 24 );
+    Kokkos::View<int *, DeviceType> w( "w", 0 );
+    TEST_THROW( DataTransferKit::last_element( w ),
+                DataTransferKit::DataTransferKitException );
+}
+
 // Include the test macros.
 #include "DataTransferKitSearch_ETIHelperMacros.h"
 
@@ -64,6 +77,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DetailsUtils, prefix_sum, DeviceType )
     TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT( DetailsUtils, fill,                  \
                                           DeviceType##NODE )                   \
     TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT( DetailsUtils, prefix_sum,            \
+                                          DeviceType##NODE )                   \
+    TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT( DetailsUtils, last_element,          \
                                           DeviceType##NODE )
 
 // Demangle the types

--- a/packages/Search/test/tstDetailsUtils.cpp
+++ b/packages/Search/test/tstDetailsUtils.cpp
@@ -1,0 +1,73 @@
+/****************************************************************************
+ * Copyright (c) 2012-2017 by the DataTransferKit authors                   *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the DataTransferKit library. DataTransferKit is     *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ ****************************************************************************/
+
+#include <DTK_DetailsUtils.hpp>
+
+#include <Teuchos_UnitTestHarness.hpp>
+
+#include <algorithm>
+#include <vector>
+
+TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DetailsUtils, fill, DeviceType )
+{
+    int const n = 10;
+    Kokkos::View<float *, DeviceType> v( "v", n );
+    float const pi = 3.14;
+    DataTransferKit::fill( v, pi );
+    auto v_host = Kokkos::create_mirror_view( v );
+    Kokkos::deep_copy( v_host, v );
+    TEST_COMPARE_ARRAYS( std::vector<float>( n, pi ), v_host );
+}
+
+TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DetailsUtils, prefix_sum, DeviceType )
+{
+    int const n = 10;
+    Kokkos::View<int *, DeviceType> x( "x", n );
+    std::vector<int> x_ref( n, 1 );
+    x_ref.back() = 0;
+    auto x_host = Kokkos::create_mirror_view( x );
+    for ( int i = 0; i < n; ++i )
+        x_host( i ) = x_ref[i];
+    Kokkos::deep_copy( x, x_host );
+    Kokkos::View<int *, DeviceType> y( "y", n );
+    DataTransferKit::exclusive_prefix_sum( x, y );
+    std::vector<int> y_ref( n );
+    std::iota( y_ref.begin(), y_ref.end(), 0 );
+    auto y_host = Kokkos::create_mirror_view( y );
+    Kokkos::deep_copy( y_host, y );
+    Kokkos::deep_copy( x_host, x );
+    TEST_COMPARE_ARRAYS( y_host, y_ref );
+    TEST_COMPARE_ARRAYS( x_host, x_ref );
+    // in-place
+    DataTransferKit::exclusive_prefix_sum( x, x );
+    Kokkos::deep_copy( x_host, x );
+    TEST_COMPARE_ARRAYS( x_host, y_ref );
+    int const m = 11;
+    TEST_INEQUALITY( n, m );
+    Kokkos::View<int *, DeviceType> z( "z", m );
+    TEST_THROW( DataTransferKit::exclusive_prefix_sum( x, z ),
+                DataTransferKit::DataTransferKitException );
+}
+
+// Include the test macros.
+#include "DataTransferKitSearch_ETIHelperMacros.h"
+
+// Create the test group
+#define UNIT_TEST_GROUP( NODE )                                                \
+    using DeviceType##NODE = typename NODE::device_type;                       \
+    TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT( DetailsUtils, fill,                  \
+                                          DeviceType##NODE )                   \
+    TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT( DetailsUtils, prefix_sum,            \
+                                          DeviceType##NODE )
+
+// Demangle the types
+DTK_ETI_MANGLING_TYPEDEFS()
+
+// Instantiate the tests
+DTK_INSTANTIATE_N( UNIT_TEST_GROUP )

--- a/packages/Search/test/tstLinearBVH.cpp
+++ b/packages/Search/test/tstLinearBVH.cpp
@@ -60,13 +60,14 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( LinearBVH, tag_dispatching, DeviceType )
     Kokkos::fence();
 
     DataTransferKit::BVH<DeviceType> bvh( boxes );
-    auto do_nothing = KOKKOS_LAMBDA( int ){};
+    auto do_nothing_1 = KOKKOS_LAMBDA( int ){};
+    auto do_nothing_2 = KOKKOS_LAMBDA( int, double ){};
     DataTransferKit::Point p1 = {{0., 0., 0.}};
     details::TreeTraversal<DeviceType>::query( bvh, details::nearest( p1, 1 ),
-                                               do_nothing );
+                                               do_nothing_2 );
 
     details::TreeTraversal<DeviceType>::query( bvh, details::within( p1, 0.5 ),
-                                               do_nothing );
+                                               do_nothing_1 );
 }
 
 TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( LinearBVH, bounds, DeviceType )


### PR DESCRIPTION
This improvement is called for in #272 to avoid recomputing them.

Note that the nearest queries are now performed within a single pass.
