### PR TITLE
User Data Geometry Interface Refactor

### DIFF
--- a/packages/Interface/src/DTK_BoundingVolumeList.hpp
+++ b/packages/Interface/src/DTK_BoundingVolumeList.hpp
@@ -38,15 +38,6 @@ class BoundingVolumeList
     //! MPI rank. This view is rank-3 and should be sized as (number of
     //! bounding volumes, spatial dimension, 2 [for low and high coordinate]).
     Kokkos::View<Coordinate * * [2], ViewProperties...> bounding_volumes;
-
-    //! View indicating if the given bounding volume is owned by the local
-    //! process or is a ghost. This information is not necessary for all
-    //! algorithms and therefore this view can optionally be of size 0 or NULL
-    //! to indicate that no ghost information is available thereby indicating
-    //! that all bounding volumes provided are locally-owned by this MPI
-    //! rank. This view is rank-1 and of length of the number of bounding
-    //! volumes in the list.
-    Kokkos::View<bool *, ViewProperties...> is_ghost_volume;
 };
 
 //---------------------------------------------------------------------------//

--- a/packages/Interface/src/DTK_C_API.cpp
+++ b/packages/Interface/src/DTK_C_API.cpp
@@ -72,45 +72,44 @@ void BoundingVolumeListDataFunctionWrapper( std::shared_ptr<void> user_data,
 void PolyhedronListSizeFunctionWrapper(
     std::shared_ptr<void> user_data, unsigned &space_dim,
     size_t &local_num_nodes, size_t &local_num_faces, size_t &total_face_nodes,
-    size_t &local_num_cells, size_t &total_cell_faces, bool &has_ghosts )
+    size_t &local_num_cells, size_t &total_cell_faces )
 {
     auto u = get_function<DTK_PolyhedronListSizeFunction>( user_data );
     u.first( u.second, &space_dim, &local_num_nodes, &local_num_faces,
-             &total_face_nodes, &local_num_cells, &total_cell_faces,
-             &has_ghosts );
+             &total_face_nodes, &local_num_cells, &total_cell_faces );
 }
 
-void PolyhedronListDataFunctionWrapper(
-    std::shared_ptr<void> user_data, View<Coordinate> coordinates,
-    View<LocalOrdinal> faces, View<unsigned> nodes_per_face,
-    View<LocalOrdinal> cells, View<unsigned> faces_per_cell,
-    View<int> face_orientation, View<bool> is_ghost_cell )
+void PolyhedronListDataFunctionWrapper( std::shared_ptr<void> user_data,
+                                        View<Coordinate> coordinates,
+                                        View<LocalOrdinal> faces,
+                                        View<unsigned> nodes_per_face,
+                                        View<LocalOrdinal> cells,
+                                        View<unsigned> faces_per_cell,
+                                        View<int> face_orientation )
 {
     auto u = get_function<DTK_PolyhedronListDataFunction>( user_data );
     u.first( u.second, coordinates.data(), faces.data(), nodes_per_face.data(),
-             cells.data(), faces_per_cell.data(), face_orientation.data(),
-             is_ghost_cell.data() );
+             cells.data(), faces_per_cell.data(), face_orientation.data() );
 }
 
 void CellListSizeFunctionWrapper( std::shared_ptr<void> user_data,
                                   unsigned &space_dim, size_t &local_num_nodes,
                                   size_t &local_num_cells,
-                                  size_t &total_cell_nodes, bool &has_ghosts )
+                                  size_t &total_cell_nodes )
 {
     auto u = get_function<DTK_CellListSizeFunction>( user_data );
     u.first( u.second, &space_dim, &local_num_nodes, &local_num_cells,
-             &total_cell_nodes, &has_ghosts );
+             &total_cell_nodes );
 }
 
 void CellListDataFunctionWrapper( std::shared_ptr<void> user_data,
                                   View<Coordinate> coordinates,
                                   View<LocalOrdinal> cells,
-                                  View<DTK_CellTopology> cell_topologies,
-                                  View<bool> is_ghost_cell )
+                                  View<DTK_CellTopology> cell_topologies )
 {
     auto u = get_function<DTK_CellListDataFunction>( user_data );
-    u.first( u.second, coordinates.data(), cells.data(), cell_topologies.data(),
-             is_ghost_cell.data() );
+    u.first( u.second, coordinates.data(), cells.data(),
+             cell_topologies.data() );
 }
 
 void BoundarySizeFunctionWrapper( std::shared_ptr<void> user_data,

--- a/packages/Interface/src/DTK_C_API.cpp
+++ b/packages/Interface/src/DTK_C_API.cpp
@@ -71,13 +71,12 @@ void BoundingVolumeListDataFunctionWrapper( std::shared_ptr<void> user_data,
 
 void PolyhedronListSizeFunctionWrapper(
     std::shared_ptr<void> user_data, unsigned &space_dim,
-    size_t &local_num_nodes, size_t &local_num_faces,
-    size_t &total_nodes_per_face, size_t &local_num_cells,
-    size_t &total_faces_per_cell, bool &has_ghosts )
+    size_t &local_num_nodes, size_t &local_num_faces, size_t &total_face_nodes,
+    size_t &local_num_cells, size_t &total_cell_faces, bool &has_ghosts )
 {
     auto u = get_function<DTK_PolyhedronListSizeFunction>( user_data );
     u.first( u.second, &space_dim, &local_num_nodes, &local_num_faces,
-             &total_nodes_per_face, &local_num_cells, &total_faces_per_cell,
+             &total_face_nodes, &local_num_cells, &total_cell_faces,
              &has_ghosts );
 }
 

--- a/packages/Interface/src/DTK_C_API.cpp
+++ b/packages/Interface/src/DTK_C_API.cpp
@@ -130,6 +130,24 @@ void BoundaryDataFunctionWrapper( std::shared_ptr<void> user_data,
              cell_faces_on_boundary.data() );
 }
 
+void AdjacencyListSizeFunctionWrapper( std::shared_ptr<void> user_data,
+                                       size_t &total_adjacencies )
+{
+    auto u = get_function<DTK_AdjacencyListSizeFunction>( user_data );
+    u.first( u.second, &total_adjacencies );
+}
+
+void AdjacencyListDataFunctionWrapper(
+    std::shared_ptr<void> user_data, View<GlobalOrdinal> global_cell_ids,
+    View<GlobalOrdinal> adjacent_global_cell_ids,
+    View<unsigned> adjacencies_per_cell )
+
+{
+    auto u = get_function<DTK_AdjacencyListDataFunction>( user_data );
+    u.first( u.second, global_cell_ids.data(), adjacent_global_cell_ids.data(),
+             adjacencies_per_cell.data() );
+}
+
 void DOFMapSizeFunctionWrapper( std::shared_ptr<void> user_data,
                                 size_t &local_num_dofs,
                                 size_t &local_num_objects,
@@ -384,6 +402,14 @@ void DTK_set_function( DTK_UserApplicationHandle handle, DTK_FunctionType type,
         case DTK_BOUNDARY_DATA_FUNCTION:
             dtk->_registry->setBoundaryDataFunction(
                 BoundaryDataFunctionWrapper, data );
+            break;
+        case DTK_ADJACENCY_LIST_SIZE_FUNCTION:
+            dtk->_registry->setAdjacencyListSizeFunction(
+                AdjacencyListSizeFunctionWrapper, data );
+            break;
+        case DTK_ADJACENCY_LIST_DATA_FUNCTION:
+            dtk->_registry->setAdjacencyListDataFunction(
+                AdjacencyListDataFunctionWrapper, data );
             break;
         case DTK_DOF_MAP_SIZE_FUNCTION:
             dtk->_registry->setDOFMapSizeFunction( DOFMapSizeFunctionWrapper,

--- a/packages/Interface/src/DTK_C_API.cpp
+++ b/packages/Interface/src/DTK_C_API.cpp
@@ -113,21 +113,18 @@ void CellListDataFunctionWrapper( std::shared_ptr<void> user_data,
 }
 
 void BoundarySizeFunctionWrapper( std::shared_ptr<void> user_data,
-                                  const std::string &boundary_name,
                                   size_t &local_num_faces )
 {
     auto u = get_function<DTK_BoundarySizeFunction>( user_data );
-    u.first( u.second, boundary_name.c_str(), &local_num_faces );
+    u.first( u.second, &local_num_faces );
 }
 
 void BoundaryDataFunctionWrapper( std::shared_ptr<void> user_data,
-                                  const std::string &boundary_name,
                                   View<LocalOrdinal> boundary_cells,
                                   View<unsigned> cell_faces_on_boundary )
 {
     auto u = get_function<DTK_BoundaryDataFunction>( user_data );
-    u.first( u.second, boundary_name.c_str(), boundary_cells.data(),
-             cell_faces_on_boundary.data() );
+    u.first( u.second, boundary_cells.data(), cell_faces_on_boundary.data() );
 }
 
 void AdjacencyListSizeFunctionWrapper( std::shared_ptr<void> user_data,

--- a/packages/Interface/src/DTK_C_API.cpp
+++ b/packages/Interface/src/DTK_C_API.cpp
@@ -41,36 +41,32 @@ std::pair<Function, void *> get_function( std::shared_ptr<void> user_data )
 }
 
 void NodeListSizeFunctionWrapper( std::shared_ptr<void> user_data,
-                                  unsigned &space_dim, size_t &local_num_nodes,
-                                  bool &has_ghosts )
+                                  unsigned &space_dim, size_t &local_num_nodes )
 {
     auto u = get_function<DTK_NodeListSizeFunction>( user_data );
-    u.first( u.second, &space_dim, &local_num_nodes, &has_ghosts );
+    u.first( u.second, &space_dim, &local_num_nodes );
 }
 
 void NodeListDataFunctionWrapper( std::shared_ptr<void> user_data,
-                                  View<Coordinate> coordinates,
-                                  View<bool> is_ghost_node )
+                                  View<Coordinate> coordinates )
 {
     auto u = get_function<DTK_NodeListDataFunction>( user_data );
-    u.first( u.second, coordinates.data(), is_ghost_node.data() );
+    u.first( u.second, coordinates.data() );
 }
 
 void BoundingVolumeListSizeFunctionWrapper( std::shared_ptr<void> user_data,
                                             unsigned &space_dim,
-                                            size_t &local_num_volumes,
-                                            bool &has_ghosts )
+                                            size_t &local_num_volumes )
 {
     auto u = get_function<DTK_BoundingVolumeListSizeFunction>( user_data );
-    u.first( u.second, &space_dim, &local_num_volumes, &has_ghosts );
+    u.first( u.second, &space_dim, &local_num_volumes );
 }
 
 void BoundingVolumeListDataFunctionWrapper( std::shared_ptr<void> user_data,
-                                            View<Coordinate> bounding_volumes,
-                                            View<bool> is_ghost_volume )
+                                            View<Coordinate> bounding_volumes )
 {
     auto u = get_function<DTK_BoundingVolumeListDataFunction>( user_data );
-    u.first( u.second, bounding_volumes.data(), is_ghost_volume.data() );
+    u.first( u.second, bounding_volumes.data() );
 }
 
 void PolyhedronListSizeFunctionWrapper(

--- a/packages/Interface/src/DTK_C_API.h
+++ b/packages/Interface/src/DTK_C_API.h
@@ -280,13 +280,11 @@ typedef void ( *DTK_BoundingVolumeListDataFunction )(
  *  \param[out] total_face_nodes Total degrees of freedom per face.
  *  \param[out] local_num_cells Number of cells DTK will allocate memory for.
  *  \param[out] total_cell_faces Total number of faces per cell.
- *  \param[out] has_ghosts Whether some of the cells that will be passed are
- *              ghosted (i.e. belong to another process)
  */
 typedef void ( *DTK_PolyhedronListSizeFunction )(
     void *user_data, unsigned *space_dim, size_t *local_num_nodes,
     size_t *local_num_faces, size_t *total_face_nodes,
-    size_t *local_num_cells, size_t *total_cell_faces, bool *has_ghosts );
+    size_t *local_num_cells, size_t *total_cell_faces );
 
 /** \brief Prototype function to get the data for a polyhedron list.
  *
@@ -300,12 +298,11 @@ typedef void ( *DTK_PolyhedronListSizeFunction )(
  *  \param[out] cells Connectivity list of polyhedrons.
  *  \param[out] faces_per_cell Number of faces per cell.
  *  \param[out] face_orientation Orientation of the faces.
- *  \param[out] is_ghost_cell Indicates whether a given cell is ghosted.
  */
 typedef void ( *DTK_PolyhedronListDataFunction )(
     void *user_data, Coordinate *coordinates, LocalOrdinal *faces,
     unsigned *nodes_per_face, LocalOrdinal *cells, unsigned *faces_per_cell,
-    int *face_orientation, bool *is_ghost_cell );
+    int *face_orientation );
 
 /** \brief Prototype function to get the size parameters for building a cell
  *  list.
@@ -318,12 +315,10 @@ typedef void ( *DTK_PolyhedronListDataFunction )(
  *  \param[out] local_num_nodes Number of nodes DTK will allocate memory for.
  *  \param[out] local_num_cells Number of cells DTK will allocate memory for.
  *  \param[out] total_cell_nodes Total number of nodes per cell.
- *  \param[out] has_ghosts Whether some of the cells that will be passed are
- *              ghosted (i.e. belong to another process)
  */
 typedef void ( *DTK_CellListSizeFunction )(
     void *user_data, unsigned *space_dim, size_t *local_num_nodes,
-    size_t *local_num_cells, size_t *total_cell_nodes, bool *has_ghosts );
+    size_t *local_num_cells, size_t *total_cell_nodes );
 
 /** \brief Prototype function to get the data for a mixed topology cell list.
  *
@@ -334,11 +329,10 @@ typedef void ( *DTK_CellListSizeFunction )(
  *  \param[out] coordinates Node coordinates.
  *  \param[out] cells List of cells.
  *  \param[out] cell_topologies Topologies of the cells.
- *  \param[out] is_ghost_cell Indicates whether a given cell is ghosted.
  */
 typedef void ( *DTK_CellListDataFunction )(
     void *user_data, Coordinate *coordinates, LocalOrdinal *cells,
-    DTK_CellTopology *cell_topologies, bool *is_ghost_cell );
+    DTK_CellTopology *cell_topologies );
 
 /** \brief Prototype function to get the size parameters for a boundary
  *

--- a/packages/Interface/src/DTK_C_API.h
+++ b/packages/Interface/src/DTK_C_API.h
@@ -16,6 +16,7 @@
 #include <DataTransferKit_config.hpp>
 
 #include <DTK_Types.h>
+#include "DTK_CellTypes.h"
 
 #ifndef __cplusplus
 #include <stdbool.h> // for bool
@@ -181,8 +182,6 @@ typedef enum {
     DTK_POLYHEDRON_LIST_DATA_FUNCTION /** See DTK_PolyhedronListDataFunction() */,
     DTK_CELL_LIST_SIZE_FUNCTION /** See DTK_CellListSizeFunction() */,
     DTK_CELL_LIST_DATA_FUNCTION /** See DTK_CellListDataFunction() */,
-    DTK_MIXED_TOPOLOGY_CELL_LIST_SIZE_FUNCTION /** See DTK_MixedTopologyCellListSizeFunction() */,
-    DTK_MIXED_TOPOLOGY_CELL_LIST_DATA_FUNCTION /** See DTK_MixedTopologyCellListDataFunction() */,
     DTK_BOUNDARY_SIZE_FUNCTION /** See DTK_BoundarySizeFunction() */,
     DTK_BOUNDARY_DATA_FUNCTION /** See DTK_BoundaryDataFunction() */,
     DTK_DOF_MAP_SIZE_FUNCTION /** See DTK_DOFMapSizeFunction() */,
@@ -318,7 +317,7 @@ typedef void ( *DTK_PolyhedronListDataFunction )(
     int *face_orientation, bool *is_ghost_cell );
 
 /** \brief Prototype function to get the size parameters for building a cell
- *  list with a single topology.
+ *  list.
  *
  *  Register with a user application using DTK_set_function() by passing
  *  DTK_CELL_LIST_SIZE_FUNCTION as the \p type argument.
@@ -327,15 +326,15 @@ typedef void ( *DTK_PolyhedronListDataFunction )(
  *  \param[out] space_dim Spatial dimension.
  *  \param[out] local_num_nodes Number of nodes DTK will allocate memory for.
  *  \param[out] local_num_cells Number of cells DTK will allocate memory for.
- *  \param[out] nodes_per_cell Number of nodes per cell.
+ *  \param[out] total_cell_nodes Total number of nodes per cell.
  *  \param[out] has_ghosts Whether some of the cells that will be passed are
  *              ghosted (i.e. belong to another process)
  */
 typedef void ( *DTK_CellListSizeFunction )(
     void *user_data, unsigned *space_dim, size_t *local_num_nodes,
-    size_t *local_num_cells, unsigned *nodes_per_cell, bool *has_ghosts );
+    size_t *local_num_cells, size_t *total_cell_nodes, bool *has_ghosts );
 
-/** \brief Prototype function to get the data for a single topology cell list.
+/** \brief Prototype function to get the data for a mixed topology cell list.
  *
  *  Register with a user application using DTK_set_function() by passing
  *  DTK_CELL_LIST_DATA_FUNCTION as the \p type argument.
@@ -343,48 +342,12 @@ typedef void ( *DTK_CellListSizeFunction )(
  *  \param[in] user_data Pointer to custom user data.
  *  \param[out] coordinates Node coordinates.
  *  \param[out] cells List of cells.
- *  \param[out] is_ghost_cell Indicates whether a given cell is ghosted.
- *  \param[out] cell_topology Topology of the cells.
- */
-typedef void ( *DTK_CellListDataFunction )( void *user_data,
-                                            Coordinate *coordinates,
-                                            LocalOrdinal *cells,
-                                            bool *is_ghost_cell,
-                                            char *cell_topology );
-
-/** \brief Prototype function to get the size parameters for building a cell
- *  list with a mixed topology.
- *
- *  Register with a user application using DTK_set_function() by passing
- *  DTK_MIXED_TOPOLOGY_CELL_LIST_SIZE_FUNCTION as the \p type argument.
- *
- *  \param[in] user_data Pointer to custom user data.
- *  \param[out] space_dim Spatial dimension.
- *  \param[out] local_num_nodes Number of nodes DTK will allocate memory for.
- *  \param[out] local_num_cells Number of cells DTK will allocate memory for.
- *  \param[out] total_nodes_per_cell Total number of nodes per cell.
- *  \param[out] has_ghosts Whether some of the cells that will be passed are
- *              ghosted (i.e. belong to another process)
- */
-typedef void ( *DTK_MixedTopologyCellListSizeFunction )(
-    void *user_data, unsigned *space_dim, size_t *local_num_nodes,
-    size_t *local_num_cells, size_t *total_nodes_per_cell, bool *has_ghosts );
-
-/** \brief Prototype function to get the data for a mixed topology cell list.
- *
- *  Register with a user application using DTK_set_function() by passing
- *  DTK_MIXED_TOPOLOGY_CELL_LIST_DATA_FUNCTION as the \p type argument.
- *
- *  \param[in] user_data Pointer to custom user data.
- *  \param[out] coordinates Node coordinates.
- *  \param[out] cells List of cells.
- *  \param[out] cell_topology_ids Topology id for each cell.
- *  \param[out] is_ghost_cell Indicates whether a given cell is ghosted.
  *  \param[out] cell_topologies Topologies of the cells.
+ *  \param[out] is_ghost_cell Indicates whether a given cell is ghosted.
  */
-typedef void ( *DTK_MixedTopologyCellListDataFunction )(
+typedef void ( *DTK_CellListDataFunction )(
     void *user_data, Coordinate *coordinates, LocalOrdinal *cells,
-    unsigned *cell_topology_ids, bool *is_ghost_cell, char **cell_topologies );
+    DTK_CellTopology *cell_topologies, bool *is_ghost_cell );
 
 /** \brief Prototype function to get the size parameters for a boundary
  *

--- a/packages/Interface/src/DTK_C_API.h
+++ b/packages/Interface/src/DTK_C_API.h
@@ -184,6 +184,8 @@ typedef enum {
     DTK_CELL_LIST_DATA_FUNCTION /** See DTK_CellListDataFunction() */,
     DTK_BOUNDARY_SIZE_FUNCTION /** See DTK_BoundarySizeFunction() */,
     DTK_BOUNDARY_DATA_FUNCTION /** See DTK_BoundaryDataFunction() */,
+    DTK_ADJACENCY_LIST_SIZE_FUNCTION /** See DTK_AdjacencyListSizeFunction() */,
+    DTK_ADJACENCY_LIST_DATA_FUNCTION /** See DTK_AdjacencyListDataFunction() */,
     DTK_DOF_MAP_SIZE_FUNCTION /** See DTK_DOFMapSizeFunction() */,
     DTK_DOF_MAP_DATA_FUNCTION /** See DTK_DOFMapDataFunction() */,
     DTK_MIXED_TOPOLOGY_DOF_MAP_SIZE_FUNCTION /** See DTK_MixedTopologyDofMapSizeFunction() */,
@@ -362,6 +364,36 @@ typedef void ( *DTK_BoundaryDataFunction )( void *user_data,
                                             const char *boundary_name,
                                             LocalOrdinal *boundary_cells,
                                             unsigned *cell_faces_on_boundary );
+
+/** \brief Prototype function to get the size parameters for building an
+ *  adjacency list.
+ *
+ *  Register with a user application using DTK_set_function() by passing
+ *  DTK_ADJACENCY_LIST_SIZE_FUNCTION as the \p type argument.
+ *
+ *  \param[in] user_data Pointer to custom user data.
+ *  \param[out] total_adjacencies Total number of adjacencies in the list.
+ */
+typedef void ( *DTK_AdjacencyListSizeFunction )(
+    void *user_data, size_t *total_adjacencies );
+
+/** \brief Prototype function to get the data for an adjacency list.
+ *
+ *  Register with a user application using DTK_set_function() by passing
+ *  DTK_ADJACENCY_LIST_DATA_FUNCTION as the \p type argument.
+ *
+ *  \param[in] user_data Pointer to custom user data.
+ *  \param[out] global_cell_ids The global ids of the local cells in the
+ *  list.
+ *  \param[out] adjacent_global_cell_ids The global ids of the cells adjacent
+ *  to the local cells in the list. These may live on another process.
+ *  \param[out] adjacencies_per_cell The number of adjacencies each local cell
+ *  has. These serve as offsets into the adjacent_global_cell_ids array.
+ */
+typedef void ( *DTK_AdjacencyListDataFunction )(
+    void *user_data, GlobalOrdinal* global_cell_ids,
+    GlobalOrdinal* adjacent_global_cell_ids,
+    unsigned* adjacencies_per_cell );
 
 /** \brief Prototype function to get the size parameters for a
  *  degree-of-freedom id map with a single number of dofs per object.

--- a/packages/Interface/src/DTK_C_API.h
+++ b/packages/Interface/src/DTK_C_API.h
@@ -277,16 +277,16 @@ typedef void ( *DTK_BoundingVolumeListDataFunction )(
  *  \param[out] space_dim Spatial dimension.
  *  \param[out] local_num_nodes Number of nodes DTK will allocate memory for.
  *  \param[out] local_num_faces Number of faces DTK will allocate memory for.
- *  \param[out] total_nodes_per_face Total degrees of freedom per face.
+ *  \param[out] total_face_nodes Total degrees of freedom per face.
  *  \param[out] local_num_cells Number of cells DTK will allocate memory for.
- *  \param[out] total_faces_per_cell Total number of faces per cell.
+ *  \param[out] total_cell_faces Total number of faces per cell.
  *  \param[out] has_ghosts Whether some of the cells that will be passed are
  *              ghosted (i.e. belong to another process)
  */
 typedef void ( *DTK_PolyhedronListSizeFunction )(
     void *user_data, unsigned *space_dim, size_t *local_num_nodes,
-    size_t *local_num_faces, size_t *total_nodes_per_face,
-    size_t *local_num_cells, size_t *total_faces_per_cell, bool *has_ghosts );
+    size_t *local_num_faces, size_t *total_face_nodes,
+    size_t *local_num_cells, size_t *total_cell_faces, bool *has_ghosts );
 
 /** \brief Prototype function to get the data for a polyhedron list.
  *

--- a/packages/Interface/src/DTK_C_API.h
+++ b/packages/Interface/src/DTK_C_API.h
@@ -342,11 +342,9 @@ typedef void ( *DTK_CellListDataFunction )(
  *  DTK_BOUNDARY_SIZE_FUNCTION as the \p type argument.
  *
  *  \param[in] user_data Pointer to custom user data.
- *  \param[in] boundary_name Name of the boundary.
  *  \param[out] local_num_faces Number of faces owned by this process.
  */
 typedef void ( *DTK_BoundarySizeFunction )( void *user_data,
-                                            const char *boundary_name,
                                             size_t *local_num_faces );
 
 /** \brief Prototype function to get the data for a boundary
@@ -355,13 +353,11 @@ typedef void ( *DTK_BoundarySizeFunction )( void *user_data,
  *  DTK_BOUNDARY_DATA_FUNCTION as the \p type argument.
  *
  *  \param[in] user_data Pointer to custom user data.
- *  \param[in] boundary_name Name of the boundary.
  *  \param[out] boundary_cells Indices of the cells on the boundary.
  *  \param[out] cell_faces_on_boundary Indices of the faces within a given cell
  *  that is on the boundary.
  */
 typedef void ( *DTK_BoundaryDataFunction )( void *user_data,
-                                            const char *boundary_name,
                                             LocalOrdinal *boundary_cells,
                                             unsigned *cell_faces_on_boundary );
 

--- a/packages/Interface/src/DTK_C_API.h
+++ b/packages/Interface/src/DTK_C_API.h
@@ -279,9 +279,9 @@ typedef void ( *DTK_BoundingVolumeListDataFunction )(
  *  \param[out] space_dim Spatial dimension.
  *  \param[out] local_num_nodes Number of nodes DTK will allocate memory for.
  *  \param[out] local_num_faces Number of faces DTK will allocate memory for.
- *  \param[out] total_face_nodes Total degrees of freedom per face.
+ *  \param[out] total_face_nodes Total number of nodes for all faces.
  *  \param[out] local_num_cells Number of cells DTK will allocate memory for.
- *  \param[out] total_cell_faces Total number of faces per cell.
+ *  \param[out] total_cell_faces Total number of faces for all cells.
  */
 typedef void ( *DTK_PolyhedronListSizeFunction )(
     void *user_data, unsigned *space_dim, size_t *local_num_nodes,
@@ -316,7 +316,7 @@ typedef void ( *DTK_PolyhedronListDataFunction )(
  *  \param[out] space_dim Spatial dimension.
  *  \param[out] local_num_nodes Number of nodes DTK will allocate memory for.
  *  \param[out] local_num_cells Number of cells DTK will allocate memory for.
- *  \param[out] total_cell_nodes Total number of nodes per cell.
+ *  \param[out] total_cell_nodes Total number of nodes for all cells.
  */
 typedef void ( *DTK_CellListSizeFunction )(
     void *user_data, unsigned *space_dim, size_t *local_num_nodes,

--- a/packages/Interface/src/DTK_C_API.h
+++ b/packages/Interface/src/DTK_C_API.h
@@ -225,13 +225,10 @@ extern void DTK_set_function( DTK_UserApplicationHandle handle,
  *  \param[in] user_data Pointer to custom user data.
  *  \param[out] space_dim Spatial dimension.
  *  \param[out] local_num_nodes Number of nodes DTK will allocate memory for.
- *  \param[out] has_ghosts Whether some of the nodes that will be passed are
- *              ghosted (i.e. belong to another process)
  */
 typedef void ( *DTK_NodeListSizeFunction )( void *user_data,
                                             unsigned *space_dim,
-                                            size_t *local_num_nodes,
-                                            bool *has_ghosts );
+                                            size_t *local_num_nodes );
 
 /** \brief Prototype function to get the data for a node list.
  *
@@ -240,11 +237,9 @@ typedef void ( *DTK_NodeListSizeFunction )( void *user_data,
  *
  *  \param[in] user_data Pointer to custom user data.
  *  \param[out] coordinates Node coordinates.
- *  \param[out] is_ghost_node Indicates whether a given node is ghosted.
  */
 typedef void ( *DTK_NodeListDataFunction )( void *user_data,
-                                            Coordinate *coordinates,
-                                            bool *is_ghost_node );
+                                            Coordinate *coordinates );
 
 /** \brief Prototype function to get the size parameters for building a bounding
  *  volume list.
@@ -256,13 +251,10 @@ typedef void ( *DTK_NodeListDataFunction )( void *user_data,
  *  \param[out] space_dim Spatial dimension.
  *  \param[out] local_num_volumes Number of volumes DTK will allocate memory
  *  for.
- *  \param[out] has_ghosts Whether some of the bounding volumes that will be
- *              passed are ghosted (i.e. belong to another process)
  */
 typedef void ( *DTK_BoundingVolumeListSizeFunction )( void *user_data,
                                                       unsigned *space_dim,
-                                                      size_t *local_num_volumes,
-                                                      bool *has_ghosts );
+                                                      size_t *local_num_volumes );
 
 /** \brief Prototype function to get the data for a bounding volume list.
  *
@@ -271,10 +263,9 @@ typedef void ( *DTK_BoundingVolumeListSizeFunction )( void *user_data,
  *
  *  \param[in] user_data Pointer to custom user data.
  *  \param[out] bounding_volumes Bounding volumes.
- *  \param[out] is_ghost_node Indicates whether a given volume is ghosted.
  */
 typedef void ( *DTK_BoundingVolumeListDataFunction )(
-    void *user_data, Coordinate *bounding_volumes, bool *is_ghost_volume );
+    void *user_data, Coordinate *bounding_volumes );
 
 /** \brief Prototype function to get the size parameters for building a
  *  polyhedron list.

--- a/packages/Interface/src/DTK_CellList.hpp
+++ b/packages/Interface/src/DTK_CellList.hpp
@@ -15,8 +15,11 @@
 #ifndef DTK_CELLLIST_HPP
 #define DTK_CELLLIST_HPP
 
+#include "DTK_CellTypes.h"
+
 #include <Kokkos_Core.hpp>
-#include <Kokkos_DynRankView.hpp>
+
+#include <vector>
 
 namespace DataTransferKit
 {
@@ -44,34 +47,23 @@ class CellList
     //! be sized as (number of nodes, spatial dimension).
     Kokkos::View<Coordinate **, ViewProperties...> coordinates;
 
-    //! Connectivity list of cells. The view rank is defined dynamically and
-    //! can be either rank-1 or rank-2.
+    //! Connectivity list of cells. The view rank is rank-1.
     //!
-    //! If rank-1, it represents an unordered lists of cells with different
-    //! topologies. It should be sized as (total sum of the number of nodes
-    //! composing each cell). The input should be arranged as follows. Consider
-    //! the \f$n^th\f$ node of cell \f$i\f$ to be \f$c^i_n\f$ which is equal to
-    //! the local
-    //! index of the corresponding node in the nodes view. Two cells, the first
-    //! with 5 nodes and the second with 4 would then be defined via this view
-    //! as: \f$(c^1_1, c^1_2, c^1_3, c^1_4, c^1_5, c^2_1, c^2_2, c^2_3, c^2_4
-    //! )\f$
-    //! with the nodes_per_cell view reading \f$(5, 4)\f$. The number of nodes
-    //! per
-    //! cell is defined by the topology of the cell given by the associated
-    //! entry in topology_keys.
-    //!
-    //! If rank-2, it represents a list of cells all with the same
-    //! topologies. It should be dimensioned as (cells, nodes per cell). The
-    //! nodes for each cell should be given in the same canonical order as the
-    //! rank-1 input case.
-    Kokkos::DynRankView<LocalOrdinal, ViewProperties...> cells;
+    //! It represents a lists of cells with different topologies ordered in
+    //! blocks. It should be sized as (total sum of the number of nodes
+    //! composing each cell). The input should be arranged as
+    //! follows. Consider the \f$n^th\f$ node of cell \f$i\f$ to be
+    //! \f$c^i_n\f$ which is equal to the local index of the corresponding
+    //! node in the nodes view. Two cells, the first with 5 nodes and the
+    //! second with 4 would then be defined via this view as: \f$(c^1_1,
+    //! c^1_2, c^1_3, c^1_4, c^1_5, c^2_1, c^2_2, c^2_3, c^2_4 )\f$ with the
+    //! nodes_per_cell view reading \f$(5, 4)\f$. The number of nodes per cell
+    //! is defined by the topology of the cell block given by the associated
+    //! entry in block_topologies.
+    Kokkos::View<LocalOrdinal *, ViewProperties...> cells;
 
-    //! The local topology id for each cell in the cells view. This view is of
-    //! rank-1 and of the length of the number of cells in the list. This
-    //! should only be filled by the user if the cells view is of rank-1,
-    //! indicated potentially a different topology for every cell in the list.
-    Kokkos::View<unsigned *, ViewProperties...> cell_topology_ids;
+    //! The topologies of the cells.
+    Kokkos::View<DTK_CellTopology *, ViewProperties...> cell_topologies;
 
     //! View indicating if the given cell is owned by the local process or is a
     //! ghost. This information is not necessary for all algorithms and

--- a/packages/Interface/src/DTK_CellList.hpp
+++ b/packages/Interface/src/DTK_CellList.hpp
@@ -65,14 +65,6 @@ class CellList
     //! The topologies of the cells.
     Kokkos::View<DTK_CellTopology *, ViewProperties...> cell_topologies;
 
-    //! View indicating if the given cell is owned by the local process or is a
-    //! ghost. This information is not necessary for all algorithms and
-    //! therefore this view can optionally be of size 0 or NULL to indicate
-    //! that no ghost information is available thereby indicating that all
-    //! cells provided are locally-owned by this MPI rank. This view is of
-    //! rank-1 and of the length of the number of cells in the list.
-    Kokkos::View<bool *, ViewProperties...> is_ghost_cell;
-
     //! For every face on the boundary give the local id of the cell to which
     //! the face belongs. This view is of rank-1 and of length equal to the
     //! number of faces on the boundary. If the list does not have a boundary

--- a/packages/Interface/src/DTK_CellList.hpp
+++ b/packages/Interface/src/DTK_CellList.hpp
@@ -77,6 +77,16 @@ class CellList
     //! length equal to the number of faces on the boundary. If the list does
     //! not have a boundary this view will be empty. Dimensions: (face)
     Kokkos::View<unsigned *, ViewProperties...> cell_faces_on_boundary;
+
+    //! The global ids of the cells in the list.
+    Kokkos::View<GlobalOrdinal *, ViewProperties...> cell_global_ids;
+
+    //! The global ids of the cells that are adjacent to the cells in the
+    //! list.
+    Kokkos::View<GlobalOrdinal *, ViewProperties...> adjacent_cells;
+
+    //! The number of cells which are adjacent to each cell in the list.
+    Kokkos::View<unsigned *, ViewProperties...> adjacencies_per_cell;
 };
 
 //---------------------------------------------------------------------------//

--- a/packages/Interface/src/DTK_CellList.hpp
+++ b/packages/Interface/src/DTK_CellList.hpp
@@ -50,8 +50,8 @@ class CellList
     //! Connectivity list of cells. The view rank is rank-1.
     //!
     //! It represents a lists of cells with different topologies ordered in
-    //! blocks. It should be sized as (total sum of the number of nodes
-    //! composing each cell). The input should be arranged as
+    //! blocks. It should be sized as total sum of the number of nodes
+    //! composing each cell. The input should be arranged as
     //! follows. Consider the \f$n^th\f$ node of cell \f$i\f$ to be
     //! \f$c^i_n\f$ which is equal to the local index of the corresponding
     //! node in the nodes view. Two cells, the first with 5 nodes and the

--- a/packages/Interface/src/DTK_CellTypes.h
+++ b/packages/Interface/src/DTK_CellTypes.h
@@ -1,0 +1,40 @@
+/****************************************************************************
+ * Copyright (c) 2012-2017 by the DataTransferKit authors                   *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the DataTransferKit library. DataTransferKit is     *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ ****************************************************************************/
+/*!
+ * \file
+ * \brief DTK supported cell topology types.
+ */
+#ifndef DTK_CELLTYPES_H
+#define DTK_CELLTYPES_H
+
+/*!
+ * \brief Cell topology enumeration.
+ *
+ * The following standard cell topology types are supported by DTK.
+ */
+typedef enum
+{
+    DTK_TRI_3,
+    DTK_TRI_6,
+    DTK_QUAD_4,
+    DTK_QUAD_9,
+    DTK_TET_4,
+    DTK_TET_10,
+    DTK_TET_11,
+    DTK_HEX_8,
+    DTK_HEX_20,
+    DTK_HEX_27,
+    DTK_PYRAMID_5,
+    DTK_PYRAMID_13,
+    DTK_WEDGE_6,
+    DTK_WEDGE_15,
+    DTK_WEDGE_18
+} DTK_CellTopology;
+
+#endif // DTK_CELLTYPES_H

--- a/packages/Interface/src/DTK_DOFMap.hpp
+++ b/packages/Interface/src/DTK_DOFMap.hpp
@@ -36,10 +36,10 @@ class DOFMap
     using ViewTraits = typename Kokkos::ViewTraits<int, ViewProperties...>;
 
     //! Globally-unique ids for dofs represented on this process. These may or
-    //! may not be equally owned but every dof for every object defined on this
-    //! process (ghosted or not) must be available in this list. This list is
-    //! of rank-1 and of length equal to the number of degrees of freedom on
-    //! the local MPI rank. Dimensions: (dof)
+    //! may not be equally owned but every dof for every object defined on
+    //! this process must be available in this list. This list is of rank-1
+    //! and of length equal to the number of degrees of freedom on the local
+    //! MPI rank. Dimensions: (dof)
     Kokkos::View<GlobalOrdinal *, ViewProperties...> global_dof_ids;
 
     //! For every object of the given type in the object list give the local

--- a/packages/Interface/src/DTK_InputAllocators.hpp
+++ b/packages/Interface/src/DTK_InputAllocators.hpp
@@ -48,14 +48,13 @@ class InputAllocators
     static PolyhedronList<ViewProperties...> allocatePolyhedronList(
         const unsigned space_dim, const size_t local_num_nodes,
         const size_t local_num_faces, const size_t total_face_nodes,
-        const size_t local_num_cells, const size_t total_cell_faces,
-        const bool has_ghosts );
+        const size_t local_num_cells, const size_t total_cell_faces );
 
     // Allocate a cell list.
     static CellList<ViewProperties...>
     allocateCellList( const unsigned space_dim, const size_t local_num_nodes,
                       const size_t local_num_cells,
-                      const size_t total_cell_nodes, const bool has_ghosts );
+                      const size_t total_cell_nodes );
 
     // Allocate a boundary.
     template <class ListType>

--- a/packages/Interface/src/DTK_InputAllocators.hpp
+++ b/packages/Interface/src/DTK_InputAllocators.hpp
@@ -61,6 +61,11 @@ class InputAllocators
     static void allocateBoundary( const size_t local_num_faces,
                                   ListType &list );
 
+    // Allocate an adjacency list.
+    template <class ListType>
+    static void allocateAdjacencyList( const size_t total_adjacencies,
+                                       ListType &list );
+
     // Allocate a degree-of-freedom id Map for objects that all have the same
     // number of degrees of freedom.
     static DOFMap<ViewProperties...>
@@ -83,6 +88,13 @@ class InputAllocators
     static EvaluationSet<ViewProperties...>
     allocateEvaluationSet( const size_t local_num_evals,
                            const unsigned space_dim );
+
+  private:
+    // Get the number of cells in a polyhedron list.
+    static size_t listNumCells( const PolyhedronList<ViewProperties...> &list );
+
+    // Get the number of cells in a cell list.
+    static size_t listNumCells( const CellList<ViewProperties...> &list );
 };
 
 } // end namespace DataTransferKit

--- a/packages/Interface/src/DTK_InputAllocators.hpp
+++ b/packages/Interface/src/DTK_InputAllocators.hpp
@@ -47,8 +47,8 @@ class InputAllocators
     // Allocate a polyhedron list.
     static PolyhedronList<ViewProperties...> allocatePolyhedronList(
         const unsigned space_dim, const size_t local_num_nodes,
-        const size_t local_num_faces, const size_t total_nodes_per_face,
-        const size_t local_num_cells, const size_t total_faces_per_cell,
+        const size_t local_num_faces, const size_t total_face_nodes,
+        const size_t local_num_cells, const size_t total_cell_faces,
         const bool has_ghosts );
 
     // Allocate a cell list.

--- a/packages/Interface/src/DTK_InputAllocators.hpp
+++ b/packages/Interface/src/DTK_InputAllocators.hpp
@@ -53,17 +53,11 @@ class InputAllocators
         const size_t local_num_cells, const size_t total_faces_per_cell,
         const bool has_ghosts );
 
-    // Allocate a cell list of cells with the same topology.
+    // Allocate a cell list.
     static CellList<ViewProperties...>
     allocateCellList( const unsigned space_dim, const size_t local_num_nodes,
                       const size_t local_num_cells,
-                      const unsigned nodes_per_cell, const bool has_ghosts );
-
-    // Allocate a cell list from cells with different topologies.
-    static CellList<ViewProperties...> allocateMixedTopologyCellList(
-        const unsigned space_dim, const size_t local_num_nodes,
-        const size_t local_num_cells, const size_t total_nodes_per_cell,
-        const bool has_ghosts );
+                      const size_t total_cell_nodes, const bool has_ghosts );
 
     // Allocate a boundary.
     template <class ListType>

--- a/packages/Interface/src/DTK_InputAllocators.hpp
+++ b/packages/Interface/src/DTK_InputAllocators.hpp
@@ -37,14 +37,12 @@ class InputAllocators
   public:
     // Allocate a node list.
     static NodeList<ViewProperties...>
-    allocateNodeList( const unsigned space_dim, const size_t local_num_nodes,
-                      const bool has_ghosts );
+    allocateNodeList( const unsigned space_dim, const size_t local_num_nodes );
 
     // Allocate a bounding volume list.
     static BoundingVolumeList<ViewProperties...>
     allocateBoundingVolumeList( const unsigned space_dim,
-                                const size_t local_num_volumes,
-                                const bool has_ghosts );
+                                const size_t local_num_volumes );
 
     // Allocate a polyhedron list.
     static PolyhedronList<ViewProperties...> allocatePolyhedronList(

--- a/packages/Interface/src/DTK_InputAllocators_def.hpp
+++ b/packages/Interface/src/DTK_InputAllocators_def.hpp
@@ -59,8 +59,7 @@ PolyhedronList<ViewProperties...>
 InputAllocators<ViewProperties...>::allocatePolyhedronList(
     const unsigned space_dim, const size_t local_num_nodes,
     const size_t local_num_faces, const size_t total_face_nodes,
-    const size_t local_num_cells, const size_t total_cell_faces,
-    const bool has_ghosts )
+    const size_t local_num_cells, const size_t total_cell_faces )
 {
     PolyhedronList<ViewProperties...> poly_list;
 
@@ -82,12 +81,6 @@ InputAllocators<ViewProperties...>::allocatePolyhedronList(
     poly_list.face_orientation = Kokkos::View<int *, ViewProperties...>(
         "face_orientation", total_cell_faces );
 
-    if ( has_ghosts )
-    {
-        poly_list.is_ghost_cell = Kokkos::View<bool *, ViewProperties...>(
-            "is_ghost_cell", local_num_cells );
-    }
-
     return poly_list;
 }
 
@@ -97,8 +90,7 @@ template <class... ViewProperties>
 CellList<ViewProperties...>
 InputAllocators<ViewProperties...>::allocateCellList(
     const unsigned space_dim, const size_t local_num_nodes,
-    const size_t local_num_cells, const size_t total_cell_nodes,
-    const bool has_ghosts )
+    const size_t local_num_cells, const size_t total_cell_nodes )
 {
     CellList<ViewProperties...> cell_list;
 
@@ -111,12 +103,6 @@ InputAllocators<ViewProperties...>::allocateCellList(
     cell_list.cell_topologies =
         Kokkos::View<DTK_CellTopology *, ViewProperties...>( "cell_topologies",
                                                              local_num_cells );
-
-    if ( has_ghosts )
-    {
-        cell_list.is_ghost_cell = Kokkos::View<bool *, ViewProperties...>(
-            "is_ghost_cell", local_num_cells );
-    }
 
     return cell_list;
 }

--- a/packages/Interface/src/DTK_InputAllocators_def.hpp
+++ b/packages/Interface/src/DTK_InputAllocators_def.hpp
@@ -15,6 +15,8 @@
 #ifndef DTK_INPUTALLOCATORS_DEF_HPP
 #define DTK_INPUTALLOCATORS_DEF_HPP
 
+#include <DTK_CellTypes.h>
+
 #include <Kokkos_Core.hpp>
 
 namespace DataTransferKit
@@ -104,38 +106,12 @@ InputAllocators<ViewProperties...>::allocatePolyhedronList(
 }
 
 //---------------------------------------------------------------------------//
-// Allocate a cell list of cells with the same topology.
+// Allocate a cell list.
 template <class... ViewProperties>
 CellList<ViewProperties...>
 InputAllocators<ViewProperties...>::allocateCellList(
     const unsigned space_dim, const size_t local_num_nodes,
-    const size_t local_num_cells, const unsigned nodes_per_cell,
-    const bool has_ghosts )
-{
-    CellList<ViewProperties...> cell_list;
-
-    cell_list.coordinates = Kokkos::View<Coordinate **, ViewProperties...>(
-        "coordinates", local_num_nodes, space_dim );
-
-    cell_list.cells = Kokkos::View<LocalOrdinal **, ViewProperties...>(
-        "cells", local_num_cells, nodes_per_cell );
-
-    if ( has_ghosts )
-    {
-        cell_list.is_ghost_cell = Kokkos::View<bool *, ViewProperties...>(
-            "is_ghost_cell", local_num_cells );
-    }
-
-    return cell_list;
-}
-
-//---------------------------------------------------------------------------//
-// Allocate a cell list from cells with different topologies.
-template <class... ViewProperties>
-CellList<ViewProperties...>
-InputAllocators<ViewProperties...>::allocateMixedTopologyCellList(
-    const unsigned space_dim, const size_t local_num_nodes,
-    const size_t local_num_cells, const size_t total_nodes_per_cell,
+    const size_t local_num_cells, const size_t total_cell_nodes,
     const bool has_ghosts )
 {
     CellList<ViewProperties...> cell_list;
@@ -144,10 +120,11 @@ InputAllocators<ViewProperties...>::allocateMixedTopologyCellList(
         "coordinates", local_num_nodes, space_dim );
 
     cell_list.cells = Kokkos::View<LocalOrdinal *, ViewProperties...>(
-        "cells", total_nodes_per_cell );
+        "cells", total_cell_nodes );
 
-    cell_list.cell_topology_ids = Kokkos::View<unsigned *, ViewProperties...>(
-        "cell_topology_ids", local_num_cells );
+    cell_list.cell_topologies =
+        Kokkos::View<DTK_CellTopology *, ViewProperties...>( "cell_topologies",
+                                                             local_num_cells );
 
     if ( has_ghosts )
     {

--- a/packages/Interface/src/DTK_InputAllocators_def.hpp
+++ b/packages/Interface/src/DTK_InputAllocators_def.hpp
@@ -26,19 +26,12 @@ namespace DataTransferKit
 template <class... ViewProperties>
 NodeList<ViewProperties...>
 InputAllocators<ViewProperties...>::allocateNodeList(
-    const unsigned space_dim, const size_t local_num_nodes,
-    const bool has_ghosts )
+    const unsigned space_dim, const size_t local_num_nodes )
 {
     NodeList<ViewProperties...> node_list;
 
     node_list.coordinates = Kokkos::View<Coordinate **, ViewProperties...>(
         "coordinates", local_num_nodes, space_dim );
-
-    if ( has_ghosts )
-    {
-        node_list.is_ghost_node = Kokkos::View<bool *, ViewProperties...>(
-            "is_ghost_node", local_num_nodes );
-    }
 
     return node_list;
 }
@@ -48,20 +41,13 @@ InputAllocators<ViewProperties...>::allocateNodeList(
 template <class... ViewProperties>
 BoundingVolumeList<ViewProperties...>
 InputAllocators<ViewProperties...>::allocateBoundingVolumeList(
-    const unsigned space_dim, const size_t local_num_volumes,
-    const bool has_ghosts )
+    const unsigned space_dim, const size_t local_num_volumes )
 {
     BoundingVolumeList<ViewProperties...> bv_list;
 
     bv_list.bounding_volumes =
         Kokkos::View<Coordinate * * [2], ViewProperties...>(
             "bounding_volumes", local_num_volumes, space_dim, 2 );
-
-    if ( has_ghosts )
-    {
-        bv_list.is_ghost_volume = Kokkos::View<bool *, ViewProperties...>(
-            "is_ghost_volume", local_num_volumes );
-    }
 
     return bv_list;
 }

--- a/packages/Interface/src/DTK_InputAllocators_def.hpp
+++ b/packages/Interface/src/DTK_InputAllocators_def.hpp
@@ -58,8 +58,8 @@ template <class... ViewProperties>
 PolyhedronList<ViewProperties...>
 InputAllocators<ViewProperties...>::allocatePolyhedronList(
     const unsigned space_dim, const size_t local_num_nodes,
-    const size_t local_num_faces, const size_t total_nodes_per_face,
-    const size_t local_num_cells, const size_t total_faces_per_cell,
+    const size_t local_num_faces, const size_t total_face_nodes,
+    const size_t local_num_cells, const size_t total_cell_faces,
     const bool has_ghosts )
 {
     PolyhedronList<ViewProperties...> poly_list;
@@ -68,19 +68,19 @@ InputAllocators<ViewProperties...>::allocatePolyhedronList(
         "coordinates", local_num_nodes, space_dim );
 
     poly_list.faces = Kokkos::View<LocalOrdinal *, ViewProperties...>(
-        "faces", total_nodes_per_face );
+        "faces", total_face_nodes );
 
     poly_list.nodes_per_face = Kokkos::View<unsigned *, ViewProperties...>(
         "nodes_per_face", local_num_faces );
 
     poly_list.cells = Kokkos::View<LocalOrdinal *, ViewProperties...>(
-        "cells", total_faces_per_cell );
+        "cells", total_cell_faces );
 
     poly_list.faces_per_cell = Kokkos::View<unsigned *, ViewProperties...>(
         "faces_per_cell", local_num_cells );
 
     poly_list.face_orientation = Kokkos::View<int *, ViewProperties...>(
-        "face_orientation", total_faces_per_cell );
+        "face_orientation", total_cell_faces );
 
     if ( has_ghosts )
     {

--- a/packages/Interface/src/DTK_InputAllocators_def.hpp
+++ b/packages/Interface/src/DTK_InputAllocators_def.hpp
@@ -15,7 +15,9 @@
 #ifndef DTK_INPUTALLOCATORS_DEF_HPP
 #define DTK_INPUTALLOCATORS_DEF_HPP
 
+#include <DTK_CellList.hpp>
 #include <DTK_CellTypes.h>
+#include <DTK_PolyhedronList.hpp>
 
 #include <Kokkos_Core.hpp>
 
@@ -122,6 +124,25 @@ void InputAllocators<ViewProperties...>::allocateBoundary(
 }
 
 //---------------------------------------------------------------------------//
+// Allocate an adjacency list.
+template <class... ViewProperties>
+template <class ListType>
+void InputAllocators<ViewProperties...>::allocateAdjacencyList(
+    const size_t total_adjacencies, ListType &list )
+{
+    auto num_cells = listNumCells( list );
+
+    list.cell_global_ids = Kokkos::View<GlobalOrdinal *, ViewProperties...>(
+        "cell_global_ids", num_cells );
+
+    list.adjacent_cells = Kokkos::View<GlobalOrdinal *, ViewProperties...>(
+        "adjacent_cells", total_adjacencies );
+
+    list.adjacencies_per_cell = Kokkos::View<unsigned *, ViewProperties...>(
+        "adjacencies_per_cell", total_adjacencies );
+}
+
+//---------------------------------------------------------------------------//
 // Allocate a degree-of-freedom id Map for objects that all have the same
 // number of degrees of freedom.
 template <class... ViewProperties>
@@ -198,6 +219,24 @@ InputAllocators<ViewProperties...>::allocateEvaluationSet(
         "object_ids", local_num_evals );
 
     return eval_set;
+}
+
+//---------------------------------------------------------------------------//
+// Get the number of cells in a list (PolyhedronList specialization).
+template <class... ViewProperties>
+size_t InputAllocators<ViewProperties...>::listNumCells(
+    const PolyhedronList<ViewProperties...> &list )
+{
+    return list.faces_per_cell.extent( 0 );
+}
+
+//---------------------------------------------------------------------------//
+// Get the number of cells in a list list (CellList specialization).
+template <class... ViewProperties>
+size_t InputAllocators<ViewProperties...>::listNumCells(
+    const CellList<ViewProperties...> &list )
+{
+    return list.cell_topologies.extent( 0 );
 }
 
 //---------------------------------------------------------------------------//

--- a/packages/Interface/src/DTK_InputAllocators_def.hpp
+++ b/packages/Interface/src/DTK_InputAllocators_def.hpp
@@ -139,7 +139,7 @@ void InputAllocators<ViewProperties...>::allocateAdjacencyList(
         "adjacent_cells", total_adjacencies );
 
     list.adjacencies_per_cell = Kokkos::View<unsigned *, ViewProperties...>(
-        "adjacencies_per_cell", total_adjacencies );
+        "adjacencies_per_cell", num_cells );
 }
 
 //---------------------------------------------------------------------------//
@@ -227,7 +227,7 @@ template <class... ViewProperties>
 size_t InputAllocators<ViewProperties...>::listNumCells(
     const PolyhedronList<ViewProperties...> &list )
 {
-    return list.faces_per_cell.extent( 0 );
+    return list.faces_per_cell.size();
 }
 
 //---------------------------------------------------------------------------//
@@ -236,7 +236,7 @@ template <class... ViewProperties>
 size_t InputAllocators<ViewProperties...>::listNumCells(
     const CellList<ViewProperties...> &list )
 {
-    return list.cell_topologies.extent( 0 );
+    return list.cell_topologies.size();
 }
 
 //---------------------------------------------------------------------------//

--- a/packages/Interface/src/DTK_NodeList.hpp
+++ b/packages/Interface/src/DTK_NodeList.hpp
@@ -38,14 +38,6 @@ class NodeList
     //! rank. This view is rank-2 and should be sized as (number of nodes,
     //! spatial dimension)
     Kokkos::View<Coordinate **, ViewProperties...> coordinates;
-
-    //! View indicating if the given node is owned by the local process or is
-    //! a ghost. This information is not necessary for all algorithms and
-    //! therefore this view can optionally be of size 0 or NULL to indicate
-    //! that no ghost information is available thereby indicating that all
-    //! nodes provided are locally-owned by this MPI rank. This view is rank-1
-    //! and of length of the number of nodes in the list.
-    Kokkos::View<bool *, ViewProperties...> is_ghost_node;
 };
 
 //---------------------------------------------------------------------------//

--- a/packages/Interface/src/DTK_PolyhedronList.hpp
+++ b/packages/Interface/src/DTK_PolyhedronList.hpp
@@ -106,6 +106,16 @@ class PolyhedronList
     //! faces on the boundary. If the list does not have a boundary this view
     //! will be empty. Dimensions: (face)
     Kokkos::View<unsigned *, ViewProperties...> cell_faces_on_boundary;
+
+    //! The global ids of the cells in the list.
+    Kokkos::View<GlobalOrdinal *, ViewProperties...> cell_global_ids;
+
+    //! The global ids of the cells that are adjacent to the cells in the
+    //! list.
+    Kokkos::View<GlobalOrdinal *, ViewProperties...> adjacent_cells;
+
+    //! The number of cells which are adjacent to each cell in the list.
+    Kokkos::View<unsigned *, ViewProperties...> adjacencies_per_cell;
 };
 
 //---------------------------------------------------------------------------//

--- a/packages/Interface/src/DTK_PolyhedronList.hpp
+++ b/packages/Interface/src/DTK_PolyhedronList.hpp
@@ -93,14 +93,6 @@ class PolyhedronList
     //! +1 should be input.
     Kokkos::View<int *, ViewProperties...> face_orientation;
 
-    //! View indicating if the given cell is owned by the local process or is a
-    //! ghost. This information is not necessary for all algorithms and
-    //! therefore this view can optionally be of size 0 or NULL to indicate
-    //! that no ghost information is available thereby indicating that all
-    //! cells provided are locally-owned by this MPI rank. This view is rank-1
-    //! and of length of the number of cell in the list.
-    Kokkos::View<bool *, ViewProperties...> is_ghost_cell;
-
     //! For every face on the boundary give the local id of the cell to which
     //! the face belongs. This view is of rank-1 and of length equal to the
     //! number of faces on the boundary. If the list does not have a boundary

--- a/packages/Interface/src/DTK_UserApplication.hpp
+++ b/packages/Interface/src/DTK_UserApplication.hpp
@@ -83,6 +83,10 @@ class UserApplication
     template <class ListType>
     void getBoundary( const std::string &boundary_name, ListType &list );
 
+    //! Get adjacencies from the application and put it in the given list.
+    template <class ListType>
+    void getAdjacencyList( ListType &list );
+
     //! Get a dof id map from the application.
     DOFMap<Kokkos::LayoutLeft, ExecutionSpace>
     getDOFMap( std::string &discretization_type );

--- a/packages/Interface/src/DTK_UserApplication.hpp
+++ b/packages/Interface/src/DTK_UserApplication.hpp
@@ -81,7 +81,7 @@ class UserApplication
 
     //! Get a boundary from the application and put it in the given list.
     template <class ListType>
-    void getBoundary( const std::string &boundary_name, ListType &list );
+    void getBoundary( ListType &list );
 
     //! Get adjacencies from the application and put it in the given list.
     template <class ListType>

--- a/packages/Interface/src/DTK_UserApplication.hpp
+++ b/packages/Interface/src/DTK_UserApplication.hpp
@@ -77,8 +77,7 @@ class UserApplication
     PolyhedronList<Kokkos::LayoutLeft, ExecutionSpace> getPolyhedronList();
 
     //! Get a cell list from the application.
-    CellList<Kokkos::LayoutLeft, ExecutionSpace>
-    getCellList( std::vector<std::string> &cell_topologies );
+    CellList<Kokkos::LayoutLeft, ExecutionSpace> getCellList();
 
     //! Get a boundary from the application and put it in the given list.
     template <class ListType>

--- a/packages/Interface/src/DTK_UserApplication_def.hpp
+++ b/packages/Interface/src/DTK_UserApplication_def.hpp
@@ -38,20 +38,17 @@ auto UserApplication<Scalar, ParallelModel>::getNodeList()
     // Get the size of the node list.
     unsigned space_dim;
     size_t local_num_nodes;
-    bool has_ghosts;
     callUserFunction( _user_functions->_node_list_size_func, space_dim,
-                      local_num_nodes, has_ghosts );
+                      local_num_nodes );
 
     // Allocate the node list.
     auto node_list =
         InputAllocators<Kokkos::LayoutLeft, ExecutionSpace>::allocateNodeList(
-            space_dim, local_num_nodes, has_ghosts );
+            space_dim, local_num_nodes );
 
     // Fill the list with user data.
     View<Coordinate> coordinates( node_list.coordinates );
-    View<bool> is_ghost_node( node_list.is_ghost_node );
-    callUserFunction( _user_functions->_node_list_data_func, coordinates,
-                      is_ghost_node );
+    callUserFunction( _user_functions->_node_list_data_func, coordinates );
 
     return node_list;
 }
@@ -65,19 +62,16 @@ auto UserApplication<Scalar, ParallelModel>::getBoundingVolumeList()
     // Get the size of the bounding volume list.
     unsigned space_dim;
     size_t local_num_volumes;
-    bool has_ghosts;
     callUserFunction( _user_functions->_bv_list_size_func, space_dim,
-                      local_num_volumes, has_ghosts );
+                      local_num_volumes );
 
     // Allocate the bounding volume list.
     auto bv_list = InputAllocators<Kokkos::LayoutLeft, ExecutionSpace>::
-        allocateBoundingVolumeList( space_dim, local_num_volumes, has_ghosts );
+        allocateBoundingVolumeList( space_dim, local_num_volumes );
 
     // Fill the list with user data.
     View<Coordinate> bounding_volumes( bv_list.bounding_volumes );
-    View<bool> is_ghost_volume( bv_list.is_ghost_volume );
-    callUserFunction( _user_functions->_bv_list_data_func, bounding_volumes,
-                      is_ghost_volume );
+    callUserFunction( _user_functions->_bv_list_data_func, bounding_volumes );
 
     return bv_list;
 }

--- a/packages/Interface/src/DTK_UserApplication_def.hpp
+++ b/packages/Interface/src/DTK_UserApplication_def.hpp
@@ -145,13 +145,11 @@ auto UserApplication<Scalar, ParallelModel>::getCellList()
 // Get a boundary from the application.
 template <class Scalar, class ParallelModel>
 template <class ListType>
-void UserApplication<Scalar, ParallelModel>::getBoundary(
-    const std::string &boundary_name, ListType &list )
+void UserApplication<Scalar, ParallelModel>::getBoundary( ListType &list )
 {
     // Get the size of the boundary.
     size_t local_num_faces;
-    callUserFunction( _user_functions->_boundary_size_func, boundary_name,
-                      local_num_faces );
+    callUserFunction( _user_functions->_boundary_size_func, local_num_faces );
 
     // Allocate the boundary.
     InputAllocators<Kokkos::LayoutLeft, ExecutionSpace>::allocateBoundary(
@@ -160,8 +158,8 @@ void UserApplication<Scalar, ParallelModel>::getBoundary(
     // Fill the boundary with user data.
     View<LocalOrdinal> boundary_cells( list.boundary_cells );
     View<unsigned> cell_faces_on_boundary( list.cell_faces_on_boundary );
-    callUserFunction( _user_functions->_boundary_data_func, boundary_name,
-                      boundary_cells, cell_faces_on_boundary );
+    callUserFunction( _user_functions->_boundary_data_func, boundary_cells,
+                      cell_faces_on_boundary );
 }
 
 //---------------------------------------------------------------------------//

--- a/packages/Interface/src/DTK_UserApplication_def.hpp
+++ b/packages/Interface/src/DTK_UserApplication_def.hpp
@@ -89,16 +89,15 @@ auto UserApplication<Scalar, ParallelModel>::getPolyhedronList()
     size_t total_face_nodes;
     size_t local_num_cells;
     size_t total_cell_faces;
-    bool has_ghosts;
     callUserFunction( _user_functions->_poly_list_size_func, space_dim,
                       local_num_nodes, local_num_faces, total_face_nodes,
-                      local_num_cells, total_cell_faces, has_ghosts );
+                      local_num_cells, total_cell_faces );
 
     // Allocate the polyhedron list.
     auto poly_list = InputAllocators<Kokkos::LayoutLeft, ExecutionSpace>::
         allocatePolyhedronList( space_dim, local_num_nodes, local_num_faces,
                                 total_face_nodes, local_num_cells,
-                                total_cell_faces, has_ghosts );
+                                total_cell_faces );
 
     // Fill the list with user data.
     View<Coordinate> coordinates( poly_list.coordinates );
@@ -107,10 +106,8 @@ auto UserApplication<Scalar, ParallelModel>::getPolyhedronList()
     View<LocalOrdinal> cells( poly_list.cells );
     View<unsigned> faces_per_cell( poly_list.faces_per_cell );
     View<int> face_orientation( poly_list.face_orientation );
-    View<bool> is_ghost_cell( poly_list.is_ghost_cell );
     callUserFunction( _user_functions->_poly_list_data_func, coordinates, faces,
-                      nodes_per_face, cells, faces_per_cell, face_orientation,
-                      is_ghost_cell );
+                      nodes_per_face, cells, faces_per_cell, face_orientation );
 
     return poly_list;
 }
@@ -126,24 +123,20 @@ auto UserApplication<Scalar, ParallelModel>::getCellList()
     size_t local_num_nodes;
     size_t local_num_cells;
     size_t total_cell_nodes;
-    bool has_ghosts;
     callUserFunction( _user_functions->_cell_list_size_func, space_dim,
-                      local_num_nodes, local_num_cells, total_cell_nodes,
-                      has_ghosts );
+                      local_num_nodes, local_num_cells, total_cell_nodes );
 
     // Allocate the cell list.
     auto cell_list =
         InputAllocators<Kokkos::LayoutLeft, ExecutionSpace>::allocateCellList(
-            space_dim, local_num_nodes, local_num_cells, total_cell_nodes,
-            has_ghosts );
+            space_dim, local_num_nodes, local_num_cells, total_cell_nodes );
 
     // Fill the list with user data.
     View<Coordinate> coordinates( cell_list.coordinates );
     View<LocalOrdinal> cells( cell_list.cells );
     View<DTK_CellTopology> cell_topologies( cell_list.cell_topologies );
-    View<bool> is_ghost_cell( cell_list.is_ghost_cell );
     callUserFunction( _user_functions->_cell_list_data_func, coordinates, cells,
-                      cell_topologies, is_ghost_cell );
+                      cell_topologies );
 
     return cell_list;
 }

--- a/packages/Interface/src/DTK_UserApplication_def.hpp
+++ b/packages/Interface/src/DTK_UserApplication_def.hpp
@@ -165,6 +165,30 @@ void UserApplication<Scalar, ParallelModel>::getBoundary(
 }
 
 //---------------------------------------------------------------------------//
+// Get an adjacency list from the application.
+template <class Scalar, class ParallelModel>
+template <class ListType>
+void UserApplication<Scalar, ParallelModel>::getAdjacencyList( ListType &list )
+{
+    // Get the size of the adjacency list.
+    size_t total_adjacencies;
+    callUserFunction( _user_functions->_adjacencyList_size_func,
+                      total_adjacencies );
+
+    // Allocate the adjacency list.
+    InputAllocators<Kokkos::LayoutLeft, ExecutionSpace>::allocateAdjacencyList(
+        total_adjacencies, list );
+
+    // Fill the adjacency list with user data.
+    View<GlobalOrdinal> global_cell_ids( list.global_cell_ids );
+    View<GlobalOrdinal> adjacent_global_cell_ids( list.adjacent_cells );
+    View<unsigned> adjacencies_per_cell( list.adjacencies_per_cell );
+    callUserFunction( _user_functions->_adjacencyList_data_func,
+                      global_cell_ids, adjacent_global_cell_ids,
+                      adjacencies_per_cell );
+}
+
+//---------------------------------------------------------------------------//
 // Get a dof map from the application.
 template <class Scalar, class ParallelModel>
 auto UserApplication<Scalar, ParallelModel>::getDOFMap(

--- a/packages/Interface/src/DTK_UserApplication_def.hpp
+++ b/packages/Interface/src/DTK_UserApplication_def.hpp
@@ -86,19 +86,19 @@ auto UserApplication<Scalar, ParallelModel>::getPolyhedronList()
     unsigned space_dim;
     size_t local_num_nodes;
     size_t local_num_faces;
-    size_t total_nodes_per_face;
+    size_t total_face_nodes;
     size_t local_num_cells;
-    size_t total_faces_per_cell;
+    size_t total_cell_faces;
     bool has_ghosts;
     callUserFunction( _user_functions->_poly_list_size_func, space_dim,
-                      local_num_nodes, local_num_faces, total_nodes_per_face,
-                      local_num_cells, total_faces_per_cell, has_ghosts );
+                      local_num_nodes, local_num_faces, total_face_nodes,
+                      local_num_cells, total_cell_faces, has_ghosts );
 
     // Allocate the polyhedron list.
     auto poly_list = InputAllocators<Kokkos::LayoutLeft, ExecutionSpace>::
         allocatePolyhedronList( space_dim, local_num_nodes, local_num_faces,
-                                total_nodes_per_face, local_num_cells,
-                                total_faces_per_cell, has_ghosts );
+                                total_face_nodes, local_num_cells,
+                                total_cell_faces, has_ghosts );
 
     // Fill the list with user data.
     View<Coordinate> coordinates( poly_list.coordinates );

--- a/packages/Interface/src/DTK_UserApplication_def.hpp
+++ b/packages/Interface/src/DTK_UserApplication_def.hpp
@@ -170,7 +170,7 @@ void UserApplication<Scalar, ParallelModel>::getAdjacencyList( ListType &list )
 {
     // Get the size of the adjacency list.
     size_t total_adjacencies;
-    callUserFunction( _user_functions->_adjacencyList_size_func,
+    callUserFunction( _user_functions->_adjacency_list_size_func,
                       total_adjacencies );
 
     // Allocate the adjacency list.
@@ -178,11 +178,11 @@ void UserApplication<Scalar, ParallelModel>::getAdjacencyList( ListType &list )
         total_adjacencies, list );
 
     // Fill the adjacency list with user data.
-    View<GlobalOrdinal> global_cell_ids( list.global_cell_ids );
-    View<GlobalOrdinal> adjacent_global_cell_ids( list.adjacent_cells );
+    View<GlobalOrdinal> cell_global_ids( list.cell_global_ids );
+    View<GlobalOrdinal> adjacent_cell_global_ids( list.adjacent_cells );
     View<unsigned> adjacencies_per_cell( list.adjacencies_per_cell );
-    callUserFunction( _user_functions->_adjacencyList_data_func,
-                      global_cell_ids, adjacent_global_cell_ids,
+    callUserFunction( _user_functions->_adjacency_list_data_func,
+                      cell_global_ids, adjacent_cell_global_ids,
                       adjacencies_per_cell );
 }
 
@@ -259,6 +259,7 @@ auto UserApplication<Scalar, ParallelModel>::getField(
     // Get the size of the field.
     unsigned field_dim;
     size_t local_num_dofs;
+
     callUserFunction( _user_functions->_field_size_func, field_name, field_dim,
                       local_num_dofs );
 

--- a/packages/Interface/src/DTK_UserDataInterface.hpp
+++ b/packages/Interface/src/DTK_UserDataInterface.hpp
@@ -87,11 +87,10 @@ using BoundingVolumeListDataFunction = std::function<void(
 /*!
  * \brief Get the size parameters for building a polyhedron list.
  */
-using PolyhedronListSizeFunction =
-    std::function<void( std::shared_ptr<void> user_data, unsigned &space_dim,
-                        size_t &local_num_nodes, size_t &local_num_faces,
-                        size_t &total_nodes_per_face, size_t &local_num_cells,
-                        size_t &total_faces_per_cell, bool &has_ghosts )>;
+using PolyhedronListSizeFunction = std::function<void(
+    std::shared_ptr<void> user_data, unsigned &space_dim,
+    size_t &local_num_nodes, size_t &local_num_faces, size_t &total_face_nodes,
+    size_t &local_num_cells, size_t &total_cell_faces, bool &has_ghosts )>;
 
 //---------------------------------------------------------------------------//
 /*!

--- a/packages/Interface/src/DTK_UserDataInterface.hpp
+++ b/packages/Interface/src/DTK_UserDataInterface.hpp
@@ -126,16 +126,15 @@ using CellListDataFunction = std::function<void(
  * \brief Get the size parameters for a boundary.
  */
 using BoundarySizeFunction = std::function<void(
-    std::shared_ptr<void> user_data, const std::string &boundary_name,
-    size_t &local_num_faces )>;
+    std::shared_ptr<void> user_data, size_t &local_num_faces )>;
 
 //---------------------------------------------------------------------------//
 /*!
  * \brief Get the data for a boundary.
  */
 using BoundaryDataFunction = std::function<void(
-    std::shared_ptr<void> user_data, const std::string &boundary_name,
-    View<LocalOrdinal> boundary_cells, View<unsigned> cell_faces_on_boundary )>;
+    std::shared_ptr<void> user_data, View<LocalOrdinal> boundary_cells,
+    View<unsigned> cell_faces_on_boundary )>;
 
 //---------------------------------------------------------------------------//
 /*!

--- a/packages/Interface/src/DTK_UserDataInterface.hpp
+++ b/packages/Interface/src/DTK_UserDataInterface.hpp
@@ -15,6 +15,7 @@
 #ifndef DTK_USERDATAINTERFACE_HPP
 #define DTK_USERDATAINTERFACE_HPP
 
+#include "DTK_CellTypes.h"
 #include "DTK_Types.h"
 #include "DTK_View.hpp"
 
@@ -106,41 +107,21 @@ using PolyhedronListDataFunction = std::function<void(
 
 //---------------------------------------------------------------------------//
 /*!
- * \brief Get the size parameters for building a cell list with a single
- * topology.
+ * \brief Get the size parameters for building a cell list.
  */
 using CellListSizeFunction =
     std::function<void( std::shared_ptr<void> user_data, unsigned &space_dim,
                         size_t &local_num_nodes, size_t &local_num_cells,
-                        unsigned &nodes_per_cell, bool &has_ghosts )>;
+                        size_t &total_cell_nodes, bool &has_ghosts )>;
 
 //---------------------------------------------------------------------------//
 /*!
- * \brief Get the data for a single topology cell list.
+ * \brief Get the data for a cell list.
  */
-using CellListDataFunction =
-    std::function<void( std::shared_ptr<void> user_data,
-                        View<Coordinate> coordinates, View<LocalOrdinal> cells,
-                        View<bool> is_ghost_cell, std::string &cell_topology )>;
-
-//---------------------------------------------------------------------------//
-/*!
- * \brief Get the size parameters for building a cell list with mixed
- * topologies.
- */
-using MixedTopologyCellListSizeFunction =
-    std::function<void( std::shared_ptr<void> user_data, unsigned &space_dim,
-                        size_t &local_num_nodes, size_t &local_num_cells,
-                        size_t &total_nodes_per_cell, bool &has_ghosts )>;
-
-//---------------------------------------------------------------------------//
-/*!
- * \brief Get the data for a mixed topology cell list.
- */
-using MixedTopologyCellListDataFunction = std::function<void(
+using CellListDataFunction = std::function<void(
     std::shared_ptr<void> user_data, View<Coordinate> coordinates,
-    View<LocalOrdinal> cells, View<unsigned> cell_topology_ids,
-    View<bool> is_ghost_cell, std::vector<std::string> &cell_topologies )>;
+    View<LocalOrdinal> cells, View<DTK_CellTopology> cell_topologies,
+    View<bool> is_ghost_cell )>;
 
 //---------------------------------------------------------------------------//
 /*!

--- a/packages/Interface/src/DTK_UserDataInterface.hpp
+++ b/packages/Interface/src/DTK_UserDataInterface.hpp
@@ -90,7 +90,7 @@ using BoundingVolumeListDataFunction = std::function<void(
 using PolyhedronListSizeFunction = std::function<void(
     std::shared_ptr<void> user_data, unsigned &space_dim,
     size_t &local_num_nodes, size_t &local_num_faces, size_t &total_face_nodes,
-    size_t &local_num_cells, size_t &total_cell_faces, bool &has_ghosts )>;
+    size_t &local_num_cells, size_t &total_cell_faces )>;
 
 //---------------------------------------------------------------------------//
 /*!
@@ -100,7 +100,7 @@ using PolyhedronListDataFunction = std::function<void(
     std::shared_ptr<void> user_data, View<Coordinate> coordinates,
     View<LocalOrdinal> faces, View<unsigned> nodes_per_face,
     View<LocalOrdinal> cells, View<unsigned> faces_per_cell,
-    View<int> face_orientation, View<bool> is_ghost_cell )>;
+    View<int> face_orientation )>;
 
 //---------------------------------------------------------------------------//
 /*!
@@ -109,7 +109,7 @@ using PolyhedronListDataFunction = std::function<void(
 using CellListSizeFunction =
     std::function<void( std::shared_ptr<void> user_data, unsigned &space_dim,
                         size_t &local_num_nodes, size_t &local_num_cells,
-                        size_t &total_cell_nodes, bool &has_ghosts )>;
+                        size_t &total_cell_nodes )>;
 
 //---------------------------------------------------------------------------//
 /*!
@@ -117,8 +117,7 @@ using CellListSizeFunction =
  */
 using CellListDataFunction = std::function<void(
     std::shared_ptr<void> user_data, View<Coordinate> coordinates,
-    View<LocalOrdinal> cells, View<DTK_CellTopology> cell_topologies,
-    View<bool> is_ghost_cell )>;
+    View<LocalOrdinal> cells, View<DTK_CellTopology> cell_topologies )>;
 
 //---------------------------------------------------------------------------//
 /*!

--- a/packages/Interface/src/DTK_UserDataInterface.hpp
+++ b/packages/Interface/src/DTK_UserDataInterface.hpp
@@ -59,15 +59,14 @@ namespace UserDataInterface
  */
 using NodeListSizeFunction =
     std::function<void( std::shared_ptr<void> user_data, unsigned &space_dim,
-                        size_t &local_num_nodes, bool &has_ghosts )>;
+                        size_t &local_num_nodes )>;
 
 //---------------------------------------------------------------------------//
 /*!
  * \brief Get the data for a node list.
  */
 using NodeListDataFunction = std::function<void(
-    std::shared_ptr<void> user_data, View<Coordinate> coordinates,
-    View<bool> is_ghost_node )>;
+    std::shared_ptr<void> user_data, View<Coordinate> coordinates )>;
 
 //---------------------------------------------------------------------------//
 /*!
@@ -75,15 +74,14 @@ using NodeListDataFunction = std::function<void(
  */
 using BoundingVolumeListSizeFunction =
     std::function<void( std::shared_ptr<void> user_data, unsigned &space_dim,
-                        size_t &local_num_volumes, bool &has_ghosts )>;
+                        size_t &local_num_volumes )>;
 
 //---------------------------------------------------------------------------//
 /*
  * \brief Get the data for a bounding volume list.
  */
 using BoundingVolumeListDataFunction = std::function<void(
-    std::shared_ptr<void> user_data, View<Coordinate> bounding_volumes,
-    View<bool> is_ghost_volume )>;
+    std::shared_ptr<void> user_data, View<Coordinate> bounding_volumes )>;
 
 //---------------------------------------------------------------------------//
 /*!

--- a/packages/Interface/src/DTK_UserDataInterface.hpp
+++ b/packages/Interface/src/DTK_UserDataInterface.hpp
@@ -52,7 +52,7 @@ namespace DataTransferKit
 namespace UserDataInterface
 {
 //---------------------------------------------------------------------------//
-// Geometry interface.
+// Basic Geometry Interface
 //---------------------------------------------------------------------------//
 /*!
  * \brief Get the size parameters for building a node list.
@@ -120,6 +120,8 @@ using CellListDataFunction = std::function<void(
     View<LocalOrdinal> cells, View<DTK_CellTopology> cell_topologies )>;
 
 //---------------------------------------------------------------------------//
+// Extended Geometry Interface
+//---------------------------------------------------------------------------//
 /*!
  * \brief Get the size parameters for a boundary.
  */
@@ -134,6 +136,22 @@ using BoundarySizeFunction = std::function<void(
 using BoundaryDataFunction = std::function<void(
     std::shared_ptr<void> user_data, const std::string &boundary_name,
     View<LocalOrdinal> boundary_cells, View<unsigned> cell_faces_on_boundary )>;
+
+//---------------------------------------------------------------------------//
+/*!
+ * \brief Get the size parameters for building a cell adjacency list.
+ */
+using AdjacencyListSizeFunction = std::function<void(
+    std::shared_ptr<void> user_data, size_t &total_adjacencies )>;
+
+//---------------------------------------------------------------------------//
+/*!
+ * \brief Get the data for an adjacency list.
+ */
+using AdjacencyListDataFunction = std::function<void(
+    std::shared_ptr<void> user_data, View<GlobalOrdinal> global_cell_ids,
+    View<GlobalOrdinal> adjacent_global_cell_ids,
+    View<unsigned> adjacencies_per_cell )>;
 
 //---------------------------------------------------------------------------//
 // Degree-of-freedom interface.

--- a/packages/Interface/src/DTK_UserFunctionRegistry.hpp
+++ b/packages/Interface/src/DTK_UserFunctionRegistry.hpp
@@ -106,16 +106,6 @@ class UserFunctionRegistry
     void setCellListDataFunction( CellListDataFunction &&func,
                                   std::shared_ptr<void> user_data = nullptr );
 
-    //! Mixed topology cell list size function.
-    void setMixedTopologyCellListSizeFunction(
-        MixedTopologyCellListSizeFunction &&func,
-        std::shared_ptr<void> user_data = nullptr );
-
-    //! Mixed topology cell list data function.
-    void setMixedTopologyCellListDataFunction(
-        MixedTopologyCellListDataFunction &&func,
-        std::shared_ptr<void> user_data = nullptr );
-
     //! Boundary data function.
     void setBoundarySizeFunction( BoundarySizeFunction &&func,
                                   std::shared_ptr<void> user_data = nullptr );
@@ -194,12 +184,6 @@ class UserFunctionRegistry
 
     //! Single topology cell list data function.
     UserImpl<CellListDataFunction> _cell_list_data_func;
-
-    //! Mixed topology cell list data function.
-    UserImpl<MixedTopologyCellListSizeFunction> _mt_cell_list_size_func;
-
-    //! Mixed topology cell list data function.
-    UserImpl<MixedTopologyCellListDataFunction> _mt_cell_list_data_func;
 
     //! Boundary size function.
     UserImpl<BoundarySizeFunction> _boundary_size_func;

--- a/packages/Interface/src/DTK_UserFunctionRegistry.hpp
+++ b/packages/Interface/src/DTK_UserFunctionRegistry.hpp
@@ -113,6 +113,16 @@ class UserFunctionRegistry
     //! Boundary data function.
     void setBoundaryDataFunction( BoundaryDataFunction &&func,
                                   std::shared_ptr<void> user_data = nullptr );
+
+    //! Adjacency list size function.
+    void
+    setAdjacencyListSizeFunction( AdjacencyListSizeFunction &&func,
+                                  std::shared_ptr<void> user_data = nullptr );
+
+    //! Adjacency list data function.
+    void
+    setAdjacencyListDataFunction( AdjacencyListDataFunction &&func,
+                                  std::shared_ptr<void> user_data = nullptr );
     //@}
 
     //! @name Set Degree-of-freedom Maps
@@ -190,6 +200,12 @@ class UserFunctionRegistry
 
     //! Boundary data function.
     UserImpl<BoundaryDataFunction> _boundary_data_func;
+
+    //! Single topology adjacency list size function.
+    UserImpl<AdjacencyListSizeFunction> _adjacency_list_size_func;
+
+    //! Single topology adjacency list data function.
+    UserImpl<AdjacencyListDataFunction> _adjacency_list_data_func;
     //@}
 
     //@{

--- a/packages/Interface/src/DTK_UserFunctionRegistry_def.hpp
+++ b/packages/Interface/src/DTK_UserFunctionRegistry_def.hpp
@@ -108,6 +108,24 @@ void UserFunctionRegistry<Scalar>::setBoundaryDataFunction(
 }
 
 //---------------------------------------------------------------------------//
+// Adjacency list size function.
+template <class Scalar>
+void UserFunctionRegistry<Scalar>::setAdjacencyListSizeFunction(
+    AdjacencyListSizeFunction &&func, std::shared_ptr<void> user_data )
+{
+    _adjacency_list_size_func = std::make_pair( func, user_data );
+}
+
+//---------------------------------------------------------------------------//
+// Adjacency list data function.
+template <class Scalar>
+void UserFunctionRegistry<Scalar>::setAdjacencyListDataFunction(
+    AdjacencyListDataFunction &&func, std::shared_ptr<void> user_data )
+{
+    _adjacency_list_data_func = std::make_pair( func, user_data );
+}
+
+//---------------------------------------------------------------------------//
 // Single dofs per object dof map size.
 template <class Scalar>
 void UserFunctionRegistry<Scalar>::setDOFMapSizeFunction(

--- a/packages/Interface/src/DTK_UserFunctionRegistry_def.hpp
+++ b/packages/Interface/src/DTK_UserFunctionRegistry_def.hpp
@@ -90,24 +90,6 @@ void UserFunctionRegistry<Scalar>::setCellListDataFunction(
 }
 
 //---------------------------------------------------------------------------//
-// Mixed topology cell list size function.
-template <class Scalar>
-void UserFunctionRegistry<Scalar>::setMixedTopologyCellListSizeFunction(
-    MixedTopologyCellListSizeFunction &&func, std::shared_ptr<void> user_data )
-{
-    _mt_cell_list_size_func = std::make_pair( func, user_data );
-}
-
-//---------------------------------------------------------------------------//
-// Mixed topology cell list data function.
-template <class Scalar>
-void UserFunctionRegistry<Scalar>::setMixedTopologyCellListDataFunction(
-    MixedTopologyCellListDataFunction &&func, std::shared_ptr<void> user_data )
-{
-    _mt_cell_list_data_func = std::make_pair( func, user_data );
-}
-
-//---------------------------------------------------------------------------//
 // Boundary size function.
 template <class Scalar>
 void UserFunctionRegistry<Scalar>::setBoundarySizeFunction(

--- a/packages/Interface/test/DTK_TestApplicationHelpers.hpp
+++ b/packages/Interface/test/DTK_TestApplicationHelpers.hpp
@@ -23,14 +23,10 @@ void test_node_list( UserApplication &user_app, UserTestClass &u,
     // Check the node list.
     auto host_coordinates = Kokkos::create_mirror_view( node_list.coordinates );
     Kokkos::deep_copy( host_coordinates, node_list.coordinates );
-    auto host_is_ghost_node =
-        Kokkos::create_mirror_view( node_list.is_ghost_node );
-    Kokkos::deep_copy( host_is_ghost_node, node_list.is_ghost_node );
     for ( unsigned i = 0; i < u._size_1; ++i )
     {
         for ( unsigned d = 0; d < u._space_dim; ++d )
             TEST_EQUALITY( host_coordinates( i, d ), i + d + u._offset );
-        TEST_ASSERT( host_is_ghost_node( i ) );
     }
 }
 
@@ -45,16 +41,12 @@ void test_bounding_volume_list( UserApplication &user_app, UserTestClass &u,
     auto host_bounding_volumes =
         Kokkos::create_mirror_view( bv_list.bounding_volumes );
     Kokkos::deep_copy( host_bounding_volumes, bv_list.bounding_volumes );
-    auto host_is_ghost_volume =
-        Kokkos::create_mirror_view( bv_list.is_ghost_volume );
-    Kokkos::deep_copy( host_is_ghost_volume, bv_list.is_ghost_volume );
     for ( unsigned i = 0; i < u._size_1; ++i )
     {
         for ( unsigned d = 0; d < u._space_dim; ++d )
             for ( unsigned b = 0; b < 2; ++b )
                 TEST_EQUALITY( host_bounding_volumes( i, d, b ),
                                i + d + b + u._offset );
-        TEST_ASSERT( host_is_ghost_volume( i ) );
     }
 }
 

--- a/packages/Interface/test/DTK_TestApplicationHelpers.hpp
+++ b/packages/Interface/test/DTK_TestApplicationHelpers.hpp
@@ -173,21 +173,20 @@ void test_adjacency_list( UserApplication &user_app, UserTestClass &u,
         user_app.getAdjacencyList( cell_list );
 
         // Check the adjacency list.
-        auto host_global_cell_ids =
-            Kokkos::create_mirror_view( cell_list.global_cell_ids );
-        Kokkos::deep_copy( host_global_cell_ids, cell_list.global_cell_ids );
-        auto host_adjacent_global_cell_ids =
-            Kokkos::create_mirror_view( cell_list.adjacent_global_cell_ids );
-        Kokkos::deep_copy( host_adjacent_global_cell_ids,
-                           cell_list.adjacent_global_cell_ids );
+        auto host_cell_global_ids =
+            Kokkos::create_mirror_view( cell_list.cell_global_ids );
+        Kokkos::deep_copy( host_cell_global_ids, cell_list.cell_global_ids );
+        auto host_adjacent_cells =
+            Kokkos::create_mirror_view( cell_list.adjacent_cells );
+        Kokkos::deep_copy( host_adjacent_cells, cell_list.adjacent_cells );
         auto host_adjacencies_per_cell =
             Kokkos::create_mirror_view( cell_list.adjacencies_per_cell );
         Kokkos::deep_copy( host_adjacencies_per_cell,
                            cell_list.adjacencies_per_cell );
         for ( unsigned i = 0; i < u._size_1; ++i )
         {
-            TEST_EQUALITY( host_global_cell_ids( i ), i + u._offset );
-            TEST_EQUALITY( host_adjacent_global_cell_ids( i ), i );
+            TEST_EQUALITY( host_cell_global_ids( i ), i + u._offset );
+            TEST_EQUALITY( host_adjacent_cells( i ), i );
             TEST_EQUALITY( host_adjacencies_per_cell( i ), 1 );
         }
     }
@@ -201,21 +200,20 @@ void test_adjacency_list( UserApplication &user_app, UserTestClass &u,
         user_app.getAdjacencyList( poly_list );
 
         // Check the adjacency list.
-        auto host_global_cell_ids =
-            Kokkos::create_mirror_view( poly_list.global_cell_ids );
-        Kokkos::deep_copy( host_global_cell_ids, poly_list.global_cell_ids );
-        auto host_adjacent_global_cell_ids =
-            Kokkos::create_mirror_view( poly_list.adjacent_global_cell_ids );
-        Kokkos::deep_copy( host_adjacent_global_cell_ids,
-                           poly_list.adjacent_global_cell_ids );
+        auto host_cell_global_ids =
+            Kokkos::create_mirror_view( poly_list.cell_global_ids );
+        Kokkos::deep_copy( host_cell_global_ids, poly_list.cell_global_ids );
+        auto host_adjacent_cells =
+            Kokkos::create_mirror_view( poly_list.adjacent_cells );
+        Kokkos::deep_copy( host_adjacent_cells, poly_list.adjacent_cells );
         auto host_adjacencies_per_cell =
             Kokkos::create_mirror_view( poly_list.adjacencies_per_cell );
         Kokkos::deep_copy( host_adjacencies_per_cell,
                            poly_list.adjacencies_per_cell );
         for ( unsigned i = 0; i < u._size_1; ++i )
         {
-            TEST_EQUALITY( host_global_cell_ids( i ), i + u._offset );
-            TEST_EQUALITY( host_adjacent_global_cell_ids( i ), i );
+            TEST_EQUALITY( host_cell_global_ids( i ), i + u._offset );
+            TEST_EQUALITY( host_adjacent_cells( i ), i );
             TEST_EQUALITY( host_adjacencies_per_cell( i ), 1 );
         }
     }
@@ -239,9 +237,9 @@ void test_single_topology_dof( UserApplication &user_app, UserTestClass &u,
     Kokkos::deep_copy( host_object_dof_ids, dof_map.object_dof_ids );
     for ( unsigned i = 0; i < u._size_1; ++i )
     {
-        host_global_dof_ids( i ) = i + u._offset;
+        TEST_EQUALITY( host_global_dof_ids( i ), i + u._offset );
         for ( unsigned d = 0; d < u._size_2; ++d )
-            host_object_dof_ids( i, d ) = i + d + u._offset;
+            TEST_EQUALITY( host_object_dof_ids( i, d ), i + d + u._offset );
     }
     TEST_EQUALITY( discretization_type, "unit_test_discretization" );
 }
@@ -267,9 +265,9 @@ void test_multiple_topology_dof( UserApplication &user_app, UserTestClass &u,
     Kokkos::deep_copy( host_dofs_per_object, dof_map.dofs_per_object );
     for ( unsigned i = 0; i < u._size_1; ++i )
     {
-        host_global_dof_ids( i ) = i + u._offset;
-        host_object_dof_ids( i ) = i + u._offset;
-        host_dofs_per_object( i ) = u._size_2;
+        TEST_EQUALITY( host_global_dof_ids( i ), i + u._offset );
+        TEST_EQUALITY( host_object_dof_ids( i ), i + u._offset );
+        TEST_EQUALITY( host_dofs_per_object( i ), u._size_2 );
     }
     TEST_EQUALITY( discretization_type, "unit_test_discretization" );
 }

--- a/packages/Interface/test/DTK_TestApplicationHelpers.hpp
+++ b/packages/Interface/test/DTK_TestApplicationHelpers.hpp
@@ -161,6 +161,67 @@ void test_boundary( UserApplication &user_app, UserTestClass &u,
 }
 
 template <class UserApplication, class UserTestClass>
+void test_adjacency_list( UserApplication &user_app, UserTestClass &u,
+                          Teuchos::FancyOStream &out, bool &success )
+{
+    // Test with a cell list.
+    {
+        // Create a cell list.
+        auto cell_list = user_app.getCellList();
+
+        // Get the adjacency of the list.
+        user_app.getAdjacencyList( u._boundary_name, cell_list );
+
+        // Check the adjacency list.
+        auto host_global_cell_ids =
+            Kokkos::create_mirror_view( cell_list.global_cell_ids );
+        Kokkos::deep_copy( host_global_cell_ids, cell_list.global_cell_ids );
+        auto host_adjacent_global_cell_ids =
+            Kokkos::create_mirror_view( cell_list.adjacent_global_cell_ids );
+        Kokkos::deep_copy( host_adjacent_global_cell_ids,
+                           cell_list.adjacent_global_cell_ids );
+        auto host_adjacencies_per_cell =
+            Kokkos::create_mirror_view( cell_list.adjacencies_per_cell );
+        Kokkos::deep_copy( host_adjacencies_per_cell,
+                           cell_list.adjacencies_per_cell );
+        for ( unsigned i = 0; i < u._size_1; ++i )
+        {
+            TEST_EQUALITY( host_global_cell_ids( i ), i + u._offset );
+            TEST_EQUALITY( host_adjacent_global_cell_ids( i ), i );
+            TEST_EQUALITY( host_adjacencies_per_cell( i ), 1 );
+        }
+    }
+
+    // Test with a polyhedron list.
+    {
+        // Create a polyhedron list.
+        auto poly_list = user_app.getPolyhedronList();
+
+        // Get the adjacency of the list.
+        user_app.getAdjacencyList( u._boundary_name, poly_list );
+
+        // Check the adjacency list.
+        auto host_global_cell_ids =
+            Kokkos::create_mirror_view( poly_list.global_cell_ids );
+        Kokkos::deep_copy( host_global_cell_ids, poly_list.global_cell_ids );
+        auto host_adjacent_global_cell_ids =
+            Kokkos::create_mirror_view( poly_list.adjacent_global_cell_ids );
+        Kokkos::deep_copy( host_adjacent_global_cell_ids,
+                           poly_list.adjacent_global_cell_ids );
+        auto host_adjacencies_per_cell =
+            Kokkos::create_mirror_view( poly_list.adjacencies_per_cell );
+        Kokkos::deep_copy( host_adjacencies_per_cell,
+                           poly_list.adjacencies_per_cell );
+        for ( unsigned i = 0; i < u._size_1; ++i )
+        {
+            TEST_EQUALITY( host_global_cell_ids( i ), i + u._offset );
+            TEST_EQUALITY( host_adjacent_global_cell_ids( i ), i );
+            TEST_EQUALITY( host_adjacencies_per_cell( i ), 1 );
+        }
+    }
+}
+
+template <class UserApplication, class UserTestClass>
 void test_single_topology_dof( UserApplication &user_app, UserTestClass &u,
                                Teuchos::FancyOStream &out, bool &success )
 {

--- a/packages/Interface/test/DTK_TestApplicationHelpers.hpp
+++ b/packages/Interface/test/DTK_TestApplicationHelpers.hpp
@@ -73,9 +73,6 @@ void test_polyhedron_list( UserApplication &user_app, UserTestClass &u,
     auto host_face_orientation =
         Kokkos::create_mirror_view( poly_list.face_orientation );
     Kokkos::deep_copy( host_face_orientation, poly_list.face_orientation );
-    auto host_is_ghost_cell =
-        Kokkos::create_mirror_view( poly_list.is_ghost_cell );
-    Kokkos::deep_copy( host_is_ghost_cell, poly_list.is_ghost_cell );
     for ( unsigned i = 0; i < u._size_1; ++i )
     {
         for ( unsigned d = 0; d < u._space_dim; ++d )
@@ -85,7 +82,6 @@ void test_polyhedron_list( UserApplication &user_app, UserTestClass &u,
         TEST_EQUALITY( host_cells( i ), i + u._offset );
         TEST_EQUALITY( host_faces_per_cell( i ), i + u._offset );
         TEST_EQUALITY( host_face_orientation( i ), 1 );
-        TEST_ASSERT( host_is_ghost_cell( i ) );
     }
 }
 
@@ -104,16 +100,12 @@ void test_multiple_topology_cell( UserApplication &user_app, UserTestClass &u,
     auto host_cell_topologies =
         Kokkos::create_mirror_view( cell_list.cell_topologies );
     Kokkos::deep_copy( host_cell_topologies, cell_list.cell_topologies );
-    auto host_is_ghost_cell =
-        Kokkos::create_mirror_view( cell_list.is_ghost_cell );
-    Kokkos::deep_copy( host_is_ghost_cell, cell_list.is_ghost_cell );
     for ( unsigned i = 0; i < u._size_1; ++i )
     {
         for ( unsigned d = 0; d < u._space_dim; ++d )
             TEST_EQUALITY( host_coordinates( i, d ), i + d + u._offset );
         TEST_EQUALITY( host_cells( i ), i + u._offset );
         TEST_EQUALITY( host_cell_topologies( i ), DTK_TET_4 );
-        TEST_ASSERT( host_is_ghost_cell( i ) );
     }
 }
 

--- a/packages/Interface/test/DTK_TestApplicationHelpers.hpp
+++ b/packages/Interface/test/DTK_TestApplicationHelpers.hpp
@@ -119,7 +119,7 @@ void test_boundary( UserApplication &user_app, UserTestClass &u,
         auto cell_list = user_app.getCellList();
 
         // Get the boundary of the list.
-        user_app.getBoundary( u._boundary_name, cell_list );
+        user_app.getBoundary( cell_list );
 
         // Check the boundary.
         auto host_boundary_cells =
@@ -142,7 +142,7 @@ void test_boundary( UserApplication &user_app, UserTestClass &u,
         auto poly_list = user_app.getPolyhedronList();
 
         // Get the boundary of the list.
-        user_app.getBoundary( u._boundary_name, poly_list );
+        user_app.getBoundary( poly_list );
 
         // Check the boundary.
         auto host_boundary_cells =
@@ -170,7 +170,7 @@ void test_adjacency_list( UserApplication &user_app, UserTestClass &u,
         auto cell_list = user_app.getCellList();
 
         // Get the adjacency of the list.
-        user_app.getAdjacencyList( u._boundary_name, cell_list );
+        user_app.getAdjacencyList( cell_list );
 
         // Check the adjacency list.
         auto host_global_cell_ids =
@@ -198,7 +198,7 @@ void test_adjacency_list( UserApplication &user_app, UserTestClass &u,
         auto poly_list = user_app.getPolyhedronList();
 
         // Get the adjacency of the list.
-        user_app.getAdjacencyList( u._boundary_name, poly_list );
+        user_app.getAdjacencyList( poly_list );
 
         // Check the adjacency list.
         auto host_global_cell_ids =

--- a/packages/Interface/test/tstC_API.c
+++ b/packages/Interface/test/tstC_API.c
@@ -543,7 +543,7 @@ int main( int argc, char *argv[] )
     u._size_2 = 5;
     u._offset = 8;
     u._field_name = "test_field";
-    u._data = (double *)malloc( u._size_1 * u._space_dim * sizeof( double ) );
+    u._data = (double *) calloc( u._size_1 * u._space_dim, sizeof( double ) );
 
     int rv = 0;
 
@@ -609,6 +609,11 @@ int main( int argc, char *argv[] )
     {
         DTK_UserApplicationHandle dtk_handle = DTK_create( exec_space );
         rv |= test_boundary( dtk_handle, u );
+        DTK_destroy( dtk_handle );
+    }
+    {
+        DTK_UserApplicationHandle dtk_handle = DTK_create( exec_space );
+        rv |= test_adjacency_list( dtk_handle, u );
         DTK_destroy( dtk_handle );
     }
     {

--- a/packages/Interface/test/tstC_API.c
+++ b/packages/Interface/test/tstC_API.c
@@ -20,7 +20,6 @@ typedef struct UserTestClass
     unsigned _size_1;
     unsigned _size_2;
     unsigned _offset;
-    const char *_boundary_name;
     const char *_field_name;
     double *_data;
 } UserTestClass;
@@ -157,28 +156,21 @@ void cell_list_data( void *user_data, Coordinate *coordinates,
 
 //---------------------------------------------------------------------------//
 // Get the size parameters for a boundary.
-void boundary_size( void *user_data, const char *boundary_name,
+void boundary_size( void *user_data,
                     size_t *local_num_faces )
 {
     UserTestClass *u = (UserTestClass *)user_data;
 
-    // Here one could do actions depening on the name, but in the tests we
-    // simply ignore it
-    (void)boundary_name;
     *local_num_faces = u->_size_1;
 }
 
 //---------------------------------------------------------------------------//
 // Get the data for a boundary.
-void boundary_data( void *user_data, const char *boundary_name,
+void boundary_data( void *user_data,
                     LocalOrdinal *boundary_cells,
                     unsigned *cell_faces_on_boundary )
 {
     UserTestClass *u = (UserTestClass *)user_data;
-
-    // Here one could do actions depening on the name, but in the tests we
-    // simply ignore it
-    (void)boundary_name;
 
     for ( size_t n = 0; n < u->_size_1; n++ )
     {
@@ -550,7 +542,6 @@ int main( int argc, char *argv[] )
     u._size_1 = 100;
     u._size_2 = 5;
     u._offset = 8;
-    u._boundary_name = "unit_test_boundary";
     u._field_name = "test_field";
     u._data = (double *)malloc( u._size_1 * u._space_dim * sizeof( double ) );
 

--- a/packages/Interface/test/tstC_API.c
+++ b/packages/Interface/test/tstC_API.c
@@ -30,19 +30,17 @@ typedef struct UserTestClass
 //---------------------------------------------------------------------------//
 // Get the size parameters for building a node list.
 void node_list_size( void *user_data, unsigned *space_dim,
-                     size_t *local_num_nodes, bool *has_ghosts )
+                     size_t *local_num_nodes )
 {
     UserTestClass *u = (UserTestClass *)user_data;
 
     *space_dim = u->_space_dim;
     *local_num_nodes = u->_size_1;
-    *has_ghosts = true;
 }
 
 //---------------------------------------------------------------------------//
 // Get the data for a node list.
-void node_list_data( void *user_data, Coordinate *coordinates,
-                     bool *is_ghost_node )
+void node_list_data( void *user_data, Coordinate *coordinates )
 {
     UserTestClass *u = (UserTestClass *)user_data;
 
@@ -50,26 +48,23 @@ void node_list_data( void *user_data, Coordinate *coordinates,
     {
         for ( int j = 0; j < u->_space_dim; j++ )
             coordinates[j * u->_size_1 + i] = i + j + u->_offset;
-        is_ghost_node[i] = true;
     }
 }
 
 //---------------------------------------------------------------------------//
 // Get the size parameters for building a bounding volume list.
 void bounding_volume_list_size( void *user_data, unsigned *space_dim,
-                                size_t *local_num_volumes, bool *has_ghosts )
+                                size_t *local_num_volumes )
 {
     UserTestClass *u = (UserTestClass *)user_data;
 
     *space_dim = u->_space_dim;
     *local_num_volumes = u->_size_1;
-    *has_ghosts = true;
 }
 
 //---------------------------------------------------------------------------//
 // Get the data for a bounding volume list.
-void bounding_volume_list_data( void *user_data, Coordinate *bounding_volumes,
-                                bool *is_ghost_volume )
+void bounding_volume_list_data( void *user_data, Coordinate *bounding_volumes )
 {
     UserTestClass *u = (UserTestClass *)user_data;
 
@@ -84,7 +79,6 @@ void bounding_volume_list_data( void *user_data, Coordinate *bounding_volumes,
                 bounding_volumes[index] = v + d + h + u->_offset;
             }
         }
-        is_ghost_volume[v] = true;
     }
 }
 

--- a/packages/Interface/test/tstC_API.c
+++ b/packages/Interface/test/tstC_API.c
@@ -88,7 +88,7 @@ void polyhedron_list_size( void *user_data, unsigned *space_dim,
                            size_t *local_num_nodes, size_t *local_num_faces,
                            size_t *total_face_nodes,
                            size_t *local_num_cells,
-                           size_t *total_cell_faces, bool *has_ghosts )
+                           size_t *total_cell_faces )
 {
     UserTestClass *u = (UserTestClass *)user_data;
 
@@ -98,7 +98,6 @@ void polyhedron_list_size( void *user_data, unsigned *space_dim,
     *total_face_nodes = u->_size_1;
     *local_num_cells = u->_size_1;
     *total_cell_faces = u->_size_1;
-    *has_ghosts = true;
 }
 
 //---------------------------------------------------------------------------//
@@ -106,7 +105,7 @@ void polyhedron_list_size( void *user_data, unsigned *space_dim,
 void polyhedron_list_data( void *user_data, Coordinate *coordinates,
                            LocalOrdinal *faces, unsigned *nodes_per_face,
                            LocalOrdinal *cells, unsigned *faces_per_cell,
-                           int *face_orientation, bool *is_ghost_cell )
+                           int *face_orientation )
 {
     UserTestClass *u = (UserTestClass *)user_data;
 
@@ -121,7 +120,6 @@ void polyhedron_list_data( void *user_data, Coordinate *coordinates,
         cells[n] = n + u->_offset;
         faces_per_cell[n] = n + u->_offset;
         face_orientation[n] = 1;
-        is_ghost_cell[n] = true;
     }
 }
 
@@ -130,8 +128,7 @@ void polyhedron_list_data( void *user_data, Coordinate *coordinates,
 void cell_list_size( void *user_data, unsigned *space_dim,
                      size_t *local_num_nodes,
                      size_t *local_num_cells,
-                     size_t *total_cell_nodes,
-                     bool *has_ghosts )
+                     size_t *total_cell_nodes )
 {
     UserTestClass *u = (UserTestClass *)user_data;
 
@@ -139,15 +136,13 @@ void cell_list_size( void *user_data, unsigned *space_dim,
     *local_num_nodes = u->_size_1;
     *local_num_cells = u->_size_1;
     *total_cell_nodes = u->_size_1;
-    *has_ghosts = true;
 }
 
 //---------------------------------------------------------------------------//
 // Get the data for a cell list.
 void cell_list_data( void *user_data, Coordinate *coordinates,
                      LocalOrdinal *cells,
-                     DTK_CellTopology *cell_topologies,
-                     bool *is_ghost_cell )
+                     DTK_CellTopology *cell_topologies )
 {
     UserTestClass *u = (UserTestClass *)user_data;
 
@@ -157,7 +152,6 @@ void cell_list_data( void *user_data, Coordinate *coordinates,
             coordinates[u->_size_1 * d + n] = n + d + u->_offset;
         cells[n] = n + u->_offset;
         cell_topologies[n] = DTK_TET_4;
-        is_ghost_cell[n] = true;
     }
 }
 

--- a/packages/Interface/test/tstC_API.c
+++ b/packages/Interface/test/tstC_API.c
@@ -188,6 +188,33 @@ void boundary_data( void *user_data, const char *boundary_name,
 }
 
 //---------------------------------------------------------------------------//
+// Get the size parameters for building a cell list.
+void adjacency_list_size( void *user_data,
+                          size_t *total_adjacencies )
+{
+    UserTestClass *u = (UserTestClass *)user_data;
+
+    *total_adjacencies = u->_size_1;
+}
+
+//---------------------------------------------------------------------------//
+// Get the data for a adjacency list.
+void adjacency_list_data( void *user_data,
+                          GlobalOrdinal* global_cell_ids,
+                          GlobalOrdinal* adjacent_global_cell_ids,
+                          unsigned* adjacencies_per_cell )
+{
+    UserTestClass *u = (UserTestClass *)user_data;
+
+    for ( size_t n = 0; n < u->_size_1; n++ )
+    {
+        global_cell_ids[n] = n + u->_offset;
+        adjacent_global_cell_ids[n] = n;
+        adjacencies_per_cell[n] = 1;
+    }
+}
+
+//---------------------------------------------------------------------------//
 // Get the size parameters for a degree-of-freedom id map with a single
 // number of dofs per object.
 void dof_map_size( void *user_data, size_t *local_num_dofs,
@@ -393,6 +420,24 @@ int test_boundary( DTK_UserApplicationHandle dtk_handle, UserTestClass u )
                       polyhedron_list_data, &u );
 
     return check_registry( "test_boundary", dtk_handle, u );
+}
+
+int test_adjacency_list( DTK_UserApplicationHandle dtk_handle, UserTestClass u )
+{
+    DTK_set_function( dtk_handle, DTK_ADJACENCY_LIST_SIZE_FUNCTION, adjacency_list_size,
+                      &u );
+    DTK_set_function( dtk_handle, DTK_ADJACENCY_LIST_DATA_FUNCTION, adjacency_list_data,
+                      &u );
+    DTK_set_function( dtk_handle, DTK_CELL_LIST_SIZE_FUNCTION, cell_list_size,
+                      &u );
+    DTK_set_function( dtk_handle, DTK_CELL_LIST_DATA_FUNCTION, cell_list_data,
+                      &u );
+    DTK_set_function( dtk_handle, DTK_POLYHEDRON_LIST_SIZE_FUNCTION,
+                      polyhedron_list_size, &u );
+    DTK_set_function( dtk_handle, DTK_POLYHEDRON_LIST_DATA_FUNCTION,
+                      polyhedron_list_data, &u );
+
+    return check_registry( "test_adjacency_list", dtk_handle, u );
 }
 
 int test_single_topology_dof( DTK_UserApplicationHandle dtk_handle,

--- a/packages/Interface/test/tstC_API.c
+++ b/packages/Interface/test/tstC_API.c
@@ -86,18 +86,18 @@ void bounding_volume_list_data( void *user_data, Coordinate *bounding_volumes )
 // Get the size parameters for building a polyhedron list.
 void polyhedron_list_size( void *user_data, unsigned *space_dim,
                            size_t *local_num_nodes, size_t *local_num_faces,
-                           size_t *total_nodes_per_face,
+                           size_t *total_face_nodes,
                            size_t *local_num_cells,
-                           size_t *total_faces_per_cell, bool *has_ghosts )
+                           size_t *total_cell_faces, bool *has_ghosts )
 {
     UserTestClass *u = (UserTestClass *)user_data;
 
     *space_dim = u->_space_dim;
     *local_num_nodes = u->_size_1;
     *local_num_faces = u->_size_1;
-    *total_nodes_per_face = u->_size_1;
+    *total_face_nodes = u->_size_1;
     *local_num_cells = u->_size_1;
-    *total_faces_per_cell = u->_size_1;
+    *total_cell_faces = u->_size_1;
     *has_ghosts = true;
 }
 

--- a/packages/Interface/test/tstC_API.cpp
+++ b/packages/Interface/test/tstC_API.cpp
@@ -35,8 +35,6 @@ int test( const std::string &test_name, UserApplication &user_app,
             test_bounding_volume_list( user_app, u, out, success );
         else if ( test_name == "test_polyhedron_list" )
             test_polyhedron_list( user_app, u, out, success );
-        else if ( test_name == "test_single_topology_cell" )
-            test_single_topology_cell( user_app, u, out, success );
         else if ( test_name == "test_multiple_topology_cell" )
             test_multiple_topology_cell( user_app, u, out, success );
         else if ( test_name == "test_boundary" )

--- a/packages/Interface/test/tstC_API.cpp
+++ b/packages/Interface/test/tstC_API.cpp
@@ -39,6 +39,8 @@ int test( const std::string &test_name, UserApplication &user_app,
             test_multiple_topology_cell( user_app, u, out, success );
         else if ( test_name == "test_boundary" )
             test_boundary( user_app, u, out, success );
+        else if ( test_name == "test_adjacency_list" )
+            test_adjacency_list( user_app, u, out, success );
         else if ( test_name == "test_single_topology_dof" )
             test_single_topology_dof( user_app, u, out, success );
         else if ( test_name == "test_multiple_topology_dof" )

--- a/packages/Interface/test/tstUserApplication.cpp
+++ b/packages/Interface/test/tstUserApplication.cpp
@@ -145,8 +145,8 @@ void boundingVolumeListData(
 template <class Scalar, class ExecutionSpace>
 void polyhedronListSize( std::shared_ptr<void> user_data, unsigned &space_dim,
                          size_t &local_num_nodes, size_t &local_num_faces,
-                         size_t &total_nodes_per_face, size_t &local_num_cells,
-                         size_t &total_faces_per_cell, bool &has_ghosts )
+                         size_t &total_face_nodes, size_t &local_num_cells,
+                         size_t &total_cell_faces, bool &has_ghosts )
 {
     auto u = std::static_pointer_cast<UserTestClass<Scalar, ExecutionSpace>>(
         user_data );
@@ -154,9 +154,9 @@ void polyhedronListSize( std::shared_ptr<void> user_data, unsigned &space_dim,
     space_dim = u->_space_dim;
     local_num_nodes = u->_size_1;
     local_num_faces = u->_size_1;
-    total_nodes_per_face = u->_size_1;
+    total_face_nodes = u->_size_1;
     local_num_cells = u->_size_1;
-    total_faces_per_cell = u->_size_1;
+    total_cell_faces = u->_size_1;
     has_ghosts = true;
 }
 

--- a/packages/Interface/test/tstUserApplication.cpp
+++ b/packages/Interface/test/tstUserApplication.cpp
@@ -146,7 +146,7 @@ template <class Scalar, class ExecutionSpace>
 void polyhedronListSize( std::shared_ptr<void> user_data, unsigned &space_dim,
                          size_t &local_num_nodes, size_t &local_num_faces,
                          size_t &total_face_nodes, size_t &local_num_cells,
-                         size_t &total_cell_faces, bool &has_ghosts )
+                         size_t &total_cell_faces )
 {
     auto u = std::static_pointer_cast<UserTestClass<Scalar, ExecutionSpace>>(
         user_data );
@@ -157,7 +157,6 @@ void polyhedronListSize( std::shared_ptr<void> user_data, unsigned &space_dim,
     total_face_nodes = u->_size_1;
     local_num_cells = u->_size_1;
     total_cell_faces = u->_size_1;
-    has_ghosts = true;
 }
 
 //---------------------------------------------------------------------------//
@@ -170,8 +169,7 @@ void polyhedronListData(
     DataTransferKit::View<unsigned> nodes_per_face,
     DataTransferKit::View<DataTransferKit::LocalOrdinal> cells,
     DataTransferKit::View<unsigned> faces_per_cell,
-    DataTransferKit::View<int> face_orientation,
-    DataTransferKit::View<bool> is_ghost_cell )
+    DataTransferKit::View<int> face_orientation )
 {
     auto u = std::static_pointer_cast<UserTestClass<Scalar, ExecutionSpace>>(
         user_data );
@@ -192,7 +190,6 @@ void polyhedronListData(
         cells[n] = n + offset;
         faces_per_cell[n] = n + offset;
         face_orientation[n] = 1;
-        is_ghost_cell[n] = true;
     };
     Kokkos::parallel_for( Kokkos::RangePolicy<ExecutionSpace>( 0, size_1 ),
                           fill );
@@ -204,7 +201,7 @@ void polyhedronListData(
 template <class Scalar, class ExecutionSpace>
 void cellListSize( std::shared_ptr<void> user_data, unsigned &space_dim,
                    size_t &local_num_nodes, size_t &local_num_cells,
-                   size_t &total_cell_nodes, bool &has_ghosts )
+                   size_t &total_cell_nodes )
 {
     auto u = std::static_pointer_cast<UserTestClass<Scalar, ExecutionSpace>>(
         user_data );
@@ -213,7 +210,6 @@ void cellListSize( std::shared_ptr<void> user_data, unsigned &space_dim,
     local_num_nodes = u->_size_1;
     local_num_cells = u->_size_1;
     total_cell_nodes = u->_size_1;
-    has_ghosts = true;
 }
 
 //---------------------------------------------------------------------------//
@@ -223,8 +219,7 @@ void cellListData(
     std::shared_ptr<void> user_data,
     DataTransferKit::View<DataTransferKit::Coordinate> coordinates,
     DataTransferKit::View<DataTransferKit::LocalOrdinal> cells,
-    DataTransferKit::View<DTK_CellTopology> cell_topologies,
-    DataTransferKit::View<bool> is_ghost_cell )
+    DataTransferKit::View<DTK_CellTopology> cell_topologies )
 {
     auto u = std::static_pointer_cast<UserTestClass<Scalar, ExecutionSpace>>(
         user_data );
@@ -239,7 +234,6 @@ void cellListData(
         for ( unsigned d = 0; d < space_dim; ++d )
             coordinates[size_1 * d + n] = n + d + offset;
         cells[n] = n + offset;
-        is_ghost_cell[n] = true;
         cell_topologies[n] = DTK_TET_4;
     };
     Kokkos::parallel_for( Kokkos::RangePolicy<ExecutionSpace>( 0, size_1 ),

--- a/packages/Interface/test/tstUserApplication.cpp
+++ b/packages/Interface/test/tstUserApplication.cpp
@@ -887,6 +887,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_2_DECL( UserApplication, too_many_functions, SC,
         UserApplication, multiple_topology_cell, SCALAR, DeviceType##NODE )    \
     TEUCHOS_UNIT_TEST_TEMPLATE_2_INSTANT( UserApplication, boundary, SCALAR,   \
                                           DeviceType##NODE )                   \
+    TEUCHOS_UNIT_TEST_TEMPLATE_2_INSTANT( UserApplication, adjacency_list,     \
+                                          SCALAR, DeviceType##NODE )           \
     TEUCHOS_UNIT_TEST_TEMPLATE_2_INSTANT(                                      \
         UserApplication, single_topology_dof, SCALAR, DeviceType##NODE )       \
     TEUCHOS_UNIT_TEST_TEMPLATE_2_INSTANT(                                      \

--- a/packages/Interface/test/tstUserApplication.cpp
+++ b/packages/Interface/test/tstUserApplication.cpp
@@ -59,14 +59,13 @@ struct UserTestClass
 // Get the size parameters for building a node list.
 template <class Scalar, class ExecutionSpace>
 void nodeListSize( std::shared_ptr<void> user_data, unsigned &space_dim,
-                   size_t &local_num_nodes, bool &has_ghosts )
+                   size_t &local_num_nodes )
 {
     auto u = std::static_pointer_cast<UserTestClass<Scalar, ExecutionSpace>>(
         user_data );
 
     space_dim = u->_space_dim;
     local_num_nodes = u->_size_1;
-    has_ghosts = true;
 }
 
 //---------------------------------------------------------------------------//
@@ -74,8 +73,7 @@ void nodeListSize( std::shared_ptr<void> user_data, unsigned &space_dim,
 template <class Scalar, class ExecutionSpace>
 void nodeListData(
     std::shared_ptr<void> user_data,
-    DataTransferKit::View<DataTransferKit::Coordinate> coordinates,
-    DataTransferKit::View<bool> is_ghost_node )
+    DataTransferKit::View<DataTransferKit::Coordinate> coordinates )
 {
     auto u = std::static_pointer_cast<UserTestClass<Scalar, ExecutionSpace>>(
         user_data );
@@ -91,7 +89,6 @@ void nodeListData(
         {
             coordinates[size_1 * d + n] = n + d + offset;
         }
-        is_ghost_node[n] = true;
     };
 
     Kokkos::parallel_for( Kokkos::RangePolicy<ExecutionSpace>( 0, size_1 ),
@@ -103,15 +100,13 @@ void nodeListData(
 // Get the size parameters for building a bounding volume list.
 template <class Scalar, class ExecutionSpace>
 void boundingVolumeListSize( std::shared_ptr<void> user_data,
-                             unsigned &space_dim, size_t &local_num_volumes,
-                             bool &has_ghosts )
+                             unsigned &space_dim, size_t &local_num_volumes )
 {
     auto u = std::static_pointer_cast<UserTestClass<Scalar, ExecutionSpace>>(
         user_data );
 
     space_dim = u->_space_dim;
     local_num_volumes = u->_size_1;
-    has_ghosts = true;
 }
 
 //---------------------------------------------------------------------------//
@@ -119,8 +114,7 @@ void boundingVolumeListSize( std::shared_ptr<void> user_data,
 template <class Scalar, class ExecutionSpace>
 void boundingVolumeListData(
     std::shared_ptr<void> user_data,
-    DataTransferKit::View<DataTransferKit::Coordinate> bounding_volumes,
-    DataTransferKit::View<bool> is_ghost_volume )
+    DataTransferKit::View<DataTransferKit::Coordinate> bounding_volumes )
 {
     auto u = std::static_pointer_cast<UserTestClass<Scalar, ExecutionSpace>>(
         user_data );
@@ -140,7 +134,6 @@ void boundingVolumeListData(
                 bounding_volumes[index] = v + d + h + offset;
             }
         }
-        is_ghost_volume[v] = true;
     };
     Kokkos::parallel_for( Kokkos::RangePolicy<ExecutionSpace>( 0, size_1 ),
                           fill );

--- a/packages/Interface/test/tstUserApplication.cpp
+++ b/packages/Interface/test/tstUserApplication.cpp
@@ -48,7 +48,6 @@ struct UserTestClass
     const size_t _size_1 = 100;
     const size_t _size_2 = 5;
     const unsigned _offset = 8;
-    const std::string _boundary_name = "unit_test_boundary";
     const std::string _field_name = "test_field";
     Kokkos::View<Scalar **> _data;
 };
@@ -244,15 +243,11 @@ void cellListData(
 //---------------------------------------------------------------------------//
 // Get the size parameters for a boundary.
 template <class Scalar, class ExecutionSpace>
-void boundarySize( std::shared_ptr<void> user_data,
-                   const std::string &boundary_name, size_t &local_num_faces )
+void boundarySize( std::shared_ptr<void> user_data, size_t &local_num_faces )
 {
     auto u = std::static_pointer_cast<UserTestClass<Scalar, ExecutionSpace>>(
         user_data );
 
-    // Here one could do actions depening on the name, but in the tests we
-    // simply ignore it
-    (void)boundary_name;
     local_num_faces = u->_size_1;
 }
 
@@ -260,16 +255,12 @@ void boundarySize( std::shared_ptr<void> user_data,
 // Get the data for a boundary.
 template <class Scalar, class ExecutionSpace>
 void boundaryData(
-    std::shared_ptr<void> user_data, const std::string &boundary_name,
+    std::shared_ptr<void> user_data,
     DataTransferKit::View<DataTransferKit::LocalOrdinal> boundary_cells,
     DataTransferKit::View<unsigned> cell_faces_on_boundary )
 {
     auto u = std::static_pointer_cast<UserTestClass<Scalar, ExecutionSpace>>(
         user_data );
-
-    // Here one could do actions depening on the name, but in the tests we
-    // simply ignore it
-    (void)boundary_name;
 
     // The lambda does not properly capture class data so extract it.
     unsigned size_1 = u->_size_1;


### PR DESCRIPTION
Cleaning up the user data interface based on lessons learned. This includes:

- [x] Cell topology enumeration
Adding a cell topology enumeration allows for a cleaner multi-topology input into the code for the topologies that we support. It also allows us to encode the number of nodes for the topology into the enum. Finally, with an enum we can immediately use this information on the device for algorithms.

- [x] Single cell list interface
A single cell list interface makes input easier for users and covers all use cases for cell lists with a simple interface. The view of enums can be used as a filter/stencil over which to launch kernels over cells of the same topology. For single topology cases the code is just as easy to write as it was before. For multiple topology cases, the input is even easier with a little less information required and no need to relate cell topologies to a vector of strings.

- [x] Global ids for adjacency computations instead of ghosts.
Ghosting was removed as it was still not sufficient for computing adjacencies - we needed some input from the user that would tell us what the owning process is. By forcing users to give us only locally-owned cells, we automatically know which cells belong to which processors. Furthermore, this greatly simplifies user input in the field interface. We now will only require field data for degrees-of-freedom on locally-owned entities. This removes a lot of confusion in parallel I/O through the interface. It also removes optional arguments from the interface (i.e. `has_ghosts`). Instead of optional arguments, I would advocate adding extra functions, such as the `adjacencyList` functions, that give us extra information when we need it.

- [x] Remove string names from boundary
A map will only work for a single boundary. This fixes that problem and also doesn't force the user to identify boundaries with a string. Whichever boundary the user wants to give to the map they can specify in whichever way they want with the user data they register with the function.

Future work for discretization PR:

- Discretization enumeration
- Remove string names from field functions
- Separate cell topology from discretization
- Single field layout interface
- User-provided shape function/interpolation

Future work for a user-defined discretization PR:

- Point-in-geometry functionality
- Shape function interface
- Integration rule interface
- Interpolation interface