### PR TITLE
Use llvm-symbolizer with Sanitizer

### DIFF
--- a/scripts/docker_clang_env.sh
+++ b/scripts/docker_clang_env.sh
@@ -12,6 +12,10 @@ if [ "$SANITIZER" == "undefined_sanitizer" ]
   then FLAGS="-fsanitize=address -fsanitize=undefined -fsanitize-blacklist=/scratch/source/trilinos/release/DataTransferKit/scripts/undefined_blacklist.txt"
   # Suppress leak sanitizer on functions we have no control of.
   export LSAN_OPTIONS=suppressions=/scratch/source/trilinos/release/DataTransferKit/scripts/leak_blacklist.txt
+  # Set the ASAN_SYMBOLIZER_PATH environment variable to point to the
+  # llvm-symbolizer to make AddressSanitizer symbolize its output.  This makes
+  # the reports more human-readable.
+  export ASAN_SYMBOLIZER_PATH=/usr/lib/llvm-4.0/bin/llvm-symbolizer
 elif [ "$SANITIZER" == "thread_sanitizer" ]
   then FLAGS="-fsanitize=thread"
 fi


### PR DESCRIPTION
Sanitizer errors are impossible to debug without line and file info. Setting ASAN_SYMBOLIZER_PATH to the llvm-symbolizer path enables this as shown [here](https://stackoverflow.com/questions/24566416/how-do-i-get-line-numbers-in-the-debug-output-with-clangs-fsanitize-address)

I did this recently with an error and it worked great. This will always enable it with docker and clang sanitizer builds so we should also see it in our output logs in the CI system