### PR TITLE
Add unit tests for calling `query()` with empty predicate view on search trees

### DIFF
--- a/packages/Search/src/details/DTK_DetailsDistributedSearchTreeImpl.hpp
+++ b/packages/Search/src/details/DTK_DetailsDistributedSearchTreeImpl.hpp
@@ -34,6 +34,12 @@ class SerializationTraits<Ordinal, DataTransferKit::Details::Nearest>
                                        DataTransferKit::Details::Nearest>
 {
 };
+template <typename Ordinal>
+class SerializationTraits<Ordinal, DataTransferKit::Details::Overlap>
+    : public DirectSerializationTraits<Ordinal,
+                                       DataTransferKit::Details::Overlap>
+{
+};
 
 } // end namespace Teuchos
 

--- a/packages/Search/test/tstLinearBVH.cpp
+++ b/packages/Search/test/tstLinearBVH.cpp
@@ -275,6 +275,28 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( LinearBVH, empty, DeviceType )
 
     TEST_ASSERT( details::TreeTraversal<DeviceType>::getRoot( bvh ) );
     TEST_ASSERT( !details::TreeTraversal<DeviceType>::getRoot( empty_bvh ) );
+
+    // query for nothing is also valid
+    // We test it for both kind of predicates, spatial and nearest, on an empty
+    // and on an non-empty tree.
+    check_results(
+        bvh, Kokkos::View<DataTransferKit::Details::Overlap *, DeviceType>(
+                 "nothing", 0 ),
+        {}, {0}, success, out );
+    check_results(
+        bvh, Kokkos::View<DataTransferKit::Details::Nearest *, DeviceType>(
+                 "nothing", 0 ),
+        {}, {0}, success, out );
+    check_results(
+        empty_bvh,
+        Kokkos::View<DataTransferKit::Details::Overlap *, DeviceType>(
+            "nothing", 0 ),
+        {}, {0}, success, out );
+    check_results(
+        empty_bvh,
+        Kokkos::View<DataTransferKit::Details::Nearest *, DeviceType>(
+            "nothing", 0 ),
+        {}, {0}, success, out );
 }
 
 TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( LinearBVH, structured_grid, DeviceType )

--- a/packages/Search/test/tstLinearBVH.cpp
+++ b/packages/Search/test/tstLinearBVH.cpp
@@ -19,6 +19,28 @@
 #include <random>
 #include <tuple>
 
+// The `out` and `success` parameters come from the Teuchos unit testing macros
+// expansion.
+template <typename Query, typename DeviceType>
+void check_results( DataTransferKit::BVH<DeviceType> &bvh,
+                    Kokkos::View<Query *, DeviceType> const &queries,
+                    std::vector<int> const &indices_ref,
+                    std::vector<int> const &offset_ref, bool &success,
+                    Teuchos::FancyOStream &out )
+{
+    Kokkos::View<int *, DeviceType> indices( "indices" );
+    Kokkos::View<int *, DeviceType> offset( "offset" );
+    bvh.query( queries, indices, offset );
+
+    auto indices_host = Kokkos::create_mirror_view( indices );
+    deep_copy( indices_host, indices );
+    auto offset_host = Kokkos::create_mirror_view( offset );
+    deep_copy( offset_host, offset );
+
+    TEST_COMPARE_ARRAYS( indices_host, indices_ref );
+    TEST_COMPARE_ARRAYS( offset_host, offset_ref );
+}
+
 namespace details = DataTransferKit::Details;
 
 template <typename DeviceType>
@@ -92,12 +114,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( LinearBVH, queries, DeviceType )
     Kokkos::deep_copy( boxes, boxes_host );
     DataTransferKit::BVH<DeviceType> bvh( boxes );
 
-    // `out` and `successs` need to be captured by reference  They come from the
-    // test assertion macros expansion.
-    auto check_results = [&bvh, &out, &success](
-        std::vector<DataTransferKit::Box> const &overlap_boxes,
-        std::vector<int> const &indices_ref,
-        std::vector<int> const &offset_ref ) {
+    auto make_overlap_queries = [](
+        std::vector<DataTransferKit::Box> const &overlap_boxes ) {
         Kokkos::View<DataTransferKit::Details::Overlap *, DeviceType> queries(
             "queries", overlap_boxes.size() );
         auto queries_host = Kokkos::create_mirror_view( queries );
@@ -105,42 +123,37 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( LinearBVH, queries, DeviceType )
             queries_host( i ) =
                 DataTransferKit::Details::Overlap( overlap_boxes[i] );
         Kokkos::deep_copy( queries, queries_host );
-
-        Kokkos::View<int *, DeviceType> indices( "indices" );
-        Kokkos::View<int *, DeviceType> offset( "offset" );
-        bvh.query( queries, indices, offset );
-
-        auto indices_host = Kokkos::create_mirror_view( indices );
-        deep_copy( indices_host, indices );
-        auto offset_host = Kokkos::create_mirror_view( offset );
-        deep_copy( offset_host, offset );
-
-        TEST_COMPARE_ARRAYS( indices_host, indices_ref );
-        TEST_COMPARE_ARRAYS( offset_host, offset_ref );
+        return queries;
     };
 
     // single query overlap with nothing
-    check_results( {DataTransferKit::Box()}, {}, {0, 0} );
+    check_results( bvh, make_overlap_queries( {DataTransferKit::Box()} ), {},
+                   {0, 0}, success, out );
 
     // single query overlap with both
-    check_results( {DataTransferKit::Box( {0., 1., 0., 1., 0., 1.} )}, {1, 0},
-                   {0, 2} );
+    check_results( bvh, make_overlap_queries( {DataTransferKit::Box(
+                            {0., 1., 0., 1., 0., 1.} )} ),
+                   {1, 0}, {0, 2}, success, out );
 
     // single query overlap with only one
-    check_results( {DataTransferKit::Box( {0.5, 1.5, 0.5, 1.5, 0.5, 1.5} )},
-                   {1}, {0, 1} );
+    check_results( bvh, make_overlap_queries( {DataTransferKit::Box(
+                            {0.5, 1.5, 0.5, 1.5, 0.5, 1.5} )} ),
+                   {1}, {0, 1}, success, out );
 
     // a couple queries both overlap with nothing
-    check_results( {DataTransferKit::Box(), DataTransferKit::Box()}, {},
-                   {0, 0, 0} );
+    check_results( bvh, make_overlap_queries(
+                            {DataTransferKit::Box(), DataTransferKit::Box()} ),
+                   {}, {0, 0, 0}, success, out );
 
     // a couple queries first overlap with nothing second with only one
-    check_results( {DataTransferKit::Box(),
-                    DataTransferKit::Box( {0., 0., 0., 0., 0., 0.} )},
-                   {0}, {0, 0, 1} );
+    check_results( bvh,
+                   make_overlap_queries(
+                       {DataTransferKit::Box(),
+                        DataTransferKit::Box( {0., 0., 0., 0., 0., 0.} )} ),
+                   {0}, {0, 0, 1}, success, out );
 
     // no query
-    check_results( {}, {}, {0} );
+    check_results( bvh, make_overlap_queries( {} ), {}, {0}, success, out );
     // QUESTION: does it make sense to have len( offset ) = 1 ???
 }
 
@@ -202,26 +215,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( LinearBVH, nearest_queries, DeviceType )
     TEST_EQUALITY( distances.extent( 0 ), 1 );
     TEST_EQUALITY( indices.extent( 0 ), 1 );
     TEST_EQUALITY( offset.extent( 0 ), 2 );
-}
-
-template <typename Query, typename DeviceType>
-void check_results( DataTransferKit::BVH<DeviceType> &bvh,
-                    Kokkos::View<Query *, DeviceType> queries,
-                    std::vector<int> const &indices_ref,
-                    std::vector<int> const &offset_ref, bool &success,
-                    Teuchos::FancyOStream &out )
-{
-    Kokkos::View<int *, DeviceType> indices( "indices" );
-    Kokkos::View<int *, DeviceType> offset( "offset" );
-    bvh.query( queries, indices, offset );
-
-    auto indices_host = Kokkos::create_mirror_view( indices );
-    deep_copy( indices_host, indices );
-    auto offset_host = Kokkos::create_mirror_view( offset );
-    deep_copy( offset_host, offset );
-
-    TEST_COMPARE_ARRAYS( indices_host, indices_ref );
-    TEST_COMPARE_ARRAYS( offset_host, offset_ref );
 }
 
 TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( LinearBVH, empty, DeviceType )


### PR DESCRIPTION
```C++
search_tree.query( queries, indices, offset, ranks );
```
In #303, Bruno was checking whether `offset.extent( 0 )` is greater than zero which by design should always be true.
Say `queries` has size `n_queries` then:
* `offset` will be of size `n_queries + 1`
* `indices` and `ranks` have size `offset( n_queries )`

This is true even when`n_queries` is zero in which case `indices` and `ranks` are empty and `offset` contains a single `0` element.

Hence, it is always valid to write something like this to iterate through the results of the search for all queries:
```C++
for (int q = 0; q < n_queries; ++q )
  for (int i = offset( q ); i < offset( q + 1 ); ++i)
    // etc.
```

When reviewing the interpolation PR, I realized we were not actually testing for that, so here it is :)