### PR TITLE
Specify CUDA version when working with containers

### DIFF
--- a/docker/jenkins/Makefile
+++ b/docker/jenkins/Makefile
@@ -2,13 +2,22 @@ BASE_FILE=docker-compose.yml
 OVERRIDE_FILE=docker-compose.override.yml
 SERVICE=ci
 SETUP_SCRIPT=../nvidia/setup_nvidia_docker_compose.py
+ENV_VARIABLES=CUDA_VERSION GPU_ARCH
 
 all: setup_nvidia_docker
 
 setup_nvidia_docker: ${OVERRIDE_FILE}
 
-${OVERRIDE_FILE}: ${BASE_FILE} ${SETUP_SCRIPT} Makefile
+${OVERRIDE_FILE}: ${BASE_FILE} ${SETUP_SCRIPT} Makefile ${ENV_VARIABLES}
 	${SETUP_SCRIPT} --extended-file ${BASE_FILE} --extend-services ${SERVICE} --override-file ${OVERRIDE_FILE}
 
 clean:
-	rm -vf *_generated ${OVERRIDE_FILE}
+	rm -vf *_generated ${OVERRIDE_FILE} ${ENV_VARIABLES}
+
+.PHONY: always-rebuild
+
+.SILENT: ${ENV_VARIABLES}
+${ENV_VARIABLES}: always-rebuild
+	echo $@=$$$@ > $@.tmp
+	diff $@ $@.tmp &>/dev/null || cp $@.tmp $@
+	rm -f $@.tmp

--- a/docker/nvidia/setup_nvidia_docker_compose.py
+++ b/docker/nvidia/setup_nvidia_docker_compose.py
@@ -56,6 +56,7 @@ if args.cuda_pkg_version is not None:
 else:
     # from NVIDIA public hub repository https://hub.docker.com/r/nvidia/cuda/
     cuda_pkg_versions = {
+        '9.0': '9-0=9.0.176-1',
         '8.0': '8-0=8.0.61-1',
         '7.5': '7-5=7.5-18',
         '7.0': '7-0=7.0-28',

--- a/docker/nvidia/setup_nvidia_docker_compose.py
+++ b/docker/nvidia/setup_nvidia_docker_compose.py
@@ -14,7 +14,7 @@ with open(dockerfile_template, 'r') as fin:
 parser = argparse.ArgumentParser(description='Enable GPU-aware dev container.')
 parser.add_argument('--nvidia-docker-plugin-url', dest='nvidia_docker_plugin_url', type=str, default='http://localhost:3476',
                     help='nvidia-docker-plugin REST API URL (default: http://localhost:3476)')
-parser.add_argument('--gpu-arch', dest='gpu_arch', type=str,
+parser.add_argument('--gpu-arch', dest='gpu_arch', type=str, default=os.getenv('GPU_ARCH'),
                     help='specify what GPU architecture (default: sm_30)')
 parser.add_argument('--cuda-version', dest='cuda_version', type=str, default=os.getenv('CUDA_VERSION'),
                     help='specify the CUDA version')

--- a/docker/nvidia/setup_nvidia_docker_compose.py
+++ b/docker/nvidia/setup_nvidia_docker_compose.py
@@ -16,7 +16,7 @@ parser.add_argument('--nvidia-docker-plugin-url', dest='nvidia_docker_plugin_url
                     help='nvidia-docker-plugin REST API URL (default: http://localhost:3476)')
 parser.add_argument('--gpu-arch', dest='gpu_arch', type=str,
                     help='specify what GPU architecture (default: sm_30)')
-parser.add_argument('--cuda-version', dest='cuda_version', type=str,
+parser.add_argument('--cuda-version', dest='cuda_version', type=str, default=os.getenv('CUDA_VERSION'),
                     help='specify the CUDA version')
 parser.add_argument('--cuda-pkg-version', dest='cuda_pkg_version', type=str,
                     help='specify what CUDA package version to install in the extended image')


### PR DESCRIPTION
Take, respectively, `CUDA_VERSION` and `GPU_ARCH` env variables as default for the `--cuda-version` and `--gpu-arch` arguments in docker/nvidia/setup_nvidia_docker_compose.py

If the args are not passed and the env variables are not here, the script interrogates the nvidia-docker-plugin.

This would let us define these env variables in the Jenkins configuration.

NOTE: Currently we set `CUDA_VERSION=8.0` and `GPU_ARCH=sm_35` for the slave machine (fetnat01)