### PR TITLE
Update clang-format to version 5.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,7 @@ TRIBITS_PACKAGE_DEF()
 TRIBITS_PACKAGE_POSTPROCESS()
 
 ##---------------------------------------------------------------------------##
-## Check C++ code style using clang-format version 4.0
+## Check C++ code style using clang-format
 ##---------------------------------------------------------------------------##
 
 IF(DataTransferKit_ENABLE_ClangFormat)

--- a/cmake/CodeFormat.cmake
+++ b/cmake/CodeFormat.cmake
@@ -1,8 +1,8 @@
 if(NOT CLANG_FORMAT_EXECUTABLE)
     find_program(CLANG_FORMAT_EXECUTABLE
         NAMES
-        clang-format-4.0
-        clang-format-mp-4.0
+        clang-format-5.0
+        clang-format-mp-5.0
         clang-format
     )
     if(CLANG_FORMAT_EXECUTABLE)
@@ -17,13 +17,13 @@ else()
     endif()
 endif()
 
-# Check that the vesion of clang-format is 4.0
+# Check that the version of clang-format is the correct one
 execute_process(
     COMMAND ${CLANG_FORMAT_EXECUTABLE} -version
     OUTPUT_VARIABLE CLANG_FORMAT_VERSION
 )
-if(NOT CLANG_FORMAT_VERSION MATCHES "4.0")
-    message(FATAL_ERROR "You must use clang-format version 4.0")
+if(NOT CLANG_FORMAT_VERSION MATCHES "5.0")
+    message(FATAL_ERROR "You must use clang-format version 5.0")
 endif()
 # Download diff-clang-format.py from ORNL-CEES/Cap
 file(DOWNLOAD

--- a/docker/.vimrc
+++ b/docker/.vimrc
@@ -42,5 +42,5 @@ highlight ExtraWhitespace ctermbg=red guibg=red
 autocmd BufWinEnter * match ExtraWhitespace /\s\+$/
 
 " Configure clang-format
-let g:clang_format#command = "clang-format-4.0"
+let g:clang_format#command = "clang-format-5.0"
 let g:clang_format#detect_style_file = 1

--- a/docker/Dockerfile_stack
+++ b/docker/Dockerfile_stack
@@ -239,10 +239,10 @@ RUN export TRILINOS_HASH=89b8c7f016c247568f7c9c1f32d250c8d2683de0 && \
 ENV TRILINOS_DIR=/scratch/source/trilinos/release
 
 
-# download Kokkos-Tools
+# download Kokkos Profiling and Debugging Tools
 # sh does not support arrays so we need to use bash
-ENV KOKKOS_TOOLS_SHORT_HASH=7ee5bcb
-RUN ["/bin/bash","-c","export KOKKOS_TOOLS_HASH=7ee5bcb80a8329c8493da735bc7bad5a859dfb1f && \
+ENV KOKKOS_TOOLS_SHORT_HASH=2d75b69
+RUN ["/bin/bash","-c","export KOKKOS_TOOLS_HASH=2d75b699f1529444e19a495bb48e5300a9d8f680 && \
     export KOKKOS_TOOLS_ARRAY=(\"kernel-filter\" \
                                \"kernel-logger\" \
                                \"memory-events\" \

--- a/docker/Dockerfile_stack
+++ b/docker/Dockerfile_stack
@@ -31,12 +31,12 @@ RUN apt-get update && apt-get install -y \
         python-pip \
         doxygen \
         && \
-    echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-4.0 main" > /etc/apt/sources.list.d/llvm.list && \
+    echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-5.0 main" > /etc/apt/sources.list.d/llvm.list && \
     wget -q -O - http://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
     apt-get update && apt-get install -y \
-        clang-4.0 \
-        clang-format-4.0 \
-        clang-tidy-4.0 \
+        clang-5.0 \
+        clang-format-5.0 \
+        clang-tidy-5.0 \
         && \
     apt-get install -y software-properties-common && \
     add-apt-repository -y ppa:ubuntu-toolchain-r/test && \
@@ -58,7 +58,7 @@ RUN mkdir -p ${PREFIX} && \
     mkdir install
 
 # Install OpenMP runtime library
-RUN export OPENMP_VERSION=4.0.0 && \
+RUN export OPENMP_VERSION=5.0.0 && \
     export OPENMP_URL=http://releases.llvm.org/${OPENMP_VERSION}/openmp-${OPENMP_VERSION}.src.tar.xz && \
     export OPENMP_ARCHIVE=${PREFIX}/archive/openmp-${OPENMP_VERSION}.src.tar.xz && \
     export OPENMP_SOURCE_DIR=${PREFIX}/source/openmp/${OPENMP_VERSION} && \
@@ -69,8 +69,8 @@ RUN export OPENMP_VERSION=4.0.0 && \
     mkdir -p ${OPENMP_BUILD_DIR} && \
     cd ${OPENMP_BUILD_DIR} && \
     cmake \
-        -D CMAKE_C_COMPILER=clang-4.0 \
-        -D CMAKE_CXX_COMPILER=clang++-4.0 \
+        -D CMAKE_C_COMPILER=clang-5.0 \
+        -D CMAKE_CXX_COMPILER=clang++-5.0 \
         ${OPENMP_SOURCE_DIR} \
         && \
     make -j${NPROC} install && \

--- a/docker/Dockerfile_stack
+++ b/docker/Dockerfile_stack
@@ -221,8 +221,9 @@ ENV LIBMESH_DIR=/opt/libmesh/1.2.0
 
 # download Trilinos
 # git clone --depth 1 only works for the last commit -> use a tarball instead
-RUN export TRILINOS_HASH=4c8adc92fcbad83b827f9f1b91a5060a4a9cdd65 && \
-    export TRILINOS_SHORT_HASH=4c8adc9 && \
+# Note: the commit hash provided below has been tagged `trilinos-release-12-12-1` on GitHub
+RUN export TRILINOS_HASH=89b8c7f016c247568f7c9c1f32d250c8d2683de0 && \
+    export TRILINOS_SHORT_HASH=89b8c7f && \
     export TRILINOS_URL=https://github.com/trilinos/Trilinos/archive/${TRILINOS_HASH}.tar.gz && \
     export TRILINOS_ARCHIVE=${PREFIX}/archive/trilinos-${TRILINOS_HASH}.tar.xz && \
     export TRILINOS_SOURCE_DIR=${PREFIX}/source/trilinos/${TRILINOS_SHORT_HASH} && \

--- a/docker/Dockerfile_stack
+++ b/docker/Dockerfile_stack
@@ -225,7 +225,7 @@ ENV LIBMESH_DIR=/opt/libmesh/1.2.0
 RUN export TRILINOS_HASH=89b8c7f016c247568f7c9c1f32d250c8d2683de0 && \
     export TRILINOS_SHORT_HASH=89b8c7f && \
     export TRILINOS_URL=https://github.com/trilinos/Trilinos/archive/${TRILINOS_HASH}.tar.gz && \
-    export TRILINOS_ARCHIVE=${PREFIX}/archive/trilinos-${TRILINOS_HASH}.tar.xz && \
+    export TRILINOS_ARCHIVE=${PREFIX}/archive/trilinos-${TRILINOS_HASH}.tar.gz && \
     export TRILINOS_SOURCE_DIR=${PREFIX}/source/trilinos/${TRILINOS_SHORT_HASH} && \
     export TRILINOS_BUILD_DIR=${PREFIX}/build/trilinos/${TRILINOS_SHORT_HASH} && \
     export TRILINOS_INSTALL_DIR=${PREFIX}/install/trilinos/${TRILINOS_SHORT_HASH} && \
@@ -254,7 +254,7 @@ RUN ["/bin/bash","-c","export KOKKOS_TOOLS_HASH=2d75b699f1529444e19a495bb48e5300
                                \"space-time-stack\" \
                               ) && \
     export KOKKOS_TOOLS_URL=https://github.com/kokkos/kokkos-tools/archive/${KOKKOS_TOOLS_HASH}.tar.gz && \
-    export KOKKOS_TOOLS_ARCHIVE=${PREFIX}/archive/kokkos-tools-${KOKKOS_TOOLS_HASH}.tar.xz && \
+    export KOKKOS_TOOLS_ARCHIVE=${PREFIX}/archive/kokkos-tools-${KOKKOS_TOOLS_HASH}.tar.gz && \
     export KOKKOS_TOOLS_SOURCE_DIR=${PREFIX}/source/kokkos-tools/${KOKKOS_TOOLS_SHORT_HASH} && \
     wget --quiet ${KOKKOS_TOOLS_URL} --output-document=${KOKKOS_TOOLS_ARCHIVE} && \
     mkdir -p ${KOKKOS_TOOLS_SOURCE_DIR} && \

--- a/docker/Dockerfile_stack
+++ b/docker/Dockerfile_stack
@@ -83,13 +83,13 @@ RUN export OPENMP_VERSION=4.0.0 && \
     rm -rf ${OPENMP_BUILD_DIR} && \
     rm -rf ${OPENMP_SOURCE_DIR}
 
-# install boost
-RUN export BOOST_URL=http://sourceforge.net/projects/boost/files/boost/1.63.0/boost_1_63_0.tar.bz2 && \
-    export BOOST_SHA256=beae2529f759f6b3bf3f4969a19c2e9d6f0c503edcb2de4a61d1428519fcb3b0 && \
-    export BOOST_ARCHIVE=${PREFIX}/archive/boost_1_63_0.tar.bz2 && \
-    export BOOST_SOURCE_DIR=${PREFIX}/source/boost/1.63.0 && \
-    export BOOST_BUILD_DIR=${PREFIX}/build/boost/1.63.0 && \
-    export BOOST_INSTALL_DIR=/opt/boost/1.63.0 && \
+# install Boost
+RUN export BOOST_URL=https://dl.bintray.com/boostorg/release/1.65.1/source/boost_1_65_1.tar.bz2 && \
+    export BOOST_SHA256=9807a5d16566c57fd74fb522764e0b134a8bbe6b6e8967b83afefd30dcd3be81 && \
+    export BOOST_ARCHIVE=${PREFIX}/archive/boost_1_65_1.tar.bz2 && \
+    export BOOST_SOURCE_DIR=${PREFIX}/source/boost/1.65.1 && \
+    export BOOST_BUILD_DIR=${PREFIX}/build/boost/1.65.1 && \
+    export BOOST_INSTALL_DIR=/opt/boost/1.65.1 && \
     wget --quiet ${BOOST_URL} --output-document=${BOOST_ARCHIVE} && \
     echo "${BOOST_SHA256} ${BOOST_ARCHIVE}" | sha256sum -c && \
     mkdir -p ${BOOST_SOURCE_DIR} && \
@@ -108,7 +108,7 @@ RUN export BOOST_URL=http://sourceforge.net/projects/boost/files/boost/1.63.0/bo
     rm -rf ${BOOST_BUILD_DIR} && \
     rm -rf ${BOOST_SOURCE_DIR}
 
-ENV BOOST_DIR=/opt/boost/1.63.0
+ENV BOOST_DIR=/opt/boost/1.65.1
 
 # install HDF5
 RUN export HDF5_VERSION=1.10.1 && \

--- a/docker/Dockerfile_stack
+++ b/docker/Dockerfile_stack
@@ -47,12 +47,7 @@ RUN apt-get update && apt-get install -y \
     rm -rf /var/lib/apt/lists/*
 
 RUN pip install --upgrade --no-cache-dir pip && \
-    pip install --no-cache-dir sphinx==1.4 sphinx_rtd_theme breathe==4.6 && \
-    echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-4.0 main" > /etc/apt/sources.list.d/llvm.list && \
-    wget -q -O - http://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
-    apt-get update && apt-get install -y clang-format-4.0 clang-tidy-4.0 && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+    pip install --no-cache-dir sphinx==1.4 sphinx_rtd_theme breathe==4.6
 
 ENV PREFIX=/scratch
 RUN mkdir -p ${PREFIX} && \

--- a/docker/Dockerfile_stack
+++ b/docker/Dockerfile_stack
@@ -161,7 +161,7 @@ RUN export NETCDF_VERSION=4.4.1.1 && \
 ENV NETCDF_DIR=/opt/netcdf/4.4.1.1
 
 # install PETSc
-RUN export PETSC_VERSION=3.6.4 && \
+RUN export PETSC_VERSION=3.7.5 && \
     export PETSC_URL=http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-${PETSC_VERSION}.tar.gz && \
     export PETSC_ARCHIVE=${PREFIX}/archive/petsc-${PETSC_VERSION}.tar.gz && \
     export PETSC_SOURCE_DIR=${PREFIX}/source/petsc/${PETSC_VERSION} && \
@@ -186,10 +186,11 @@ RUN export PETSC_VERSION=3.6.4 && \
     rm -rf ${PETSC_BUILD_DIR} && \
     rm -rf ${PETSC_SOURCE_DIR}
 
-ENV PETSC_DIR=/opt/petsc/3.6.4
+ENV PETSC_DIR=/opt/petsc/3.7.5
+
 
 # install libMesh
-RUN export LIBMESH_VERSION=1.2.0 && \
+RUN export LIBMESH_VERSION=1.2.1 && \
     export LIBMESH_URL=https://github.com/libMesh/libmesh/releases/download/v${LIBMESH_VERSION}/libmesh-${LIBMESH_VERSION}.tar.bz2 && \
     export LIBMESH_ARCHIVE=${PREFIX}/archive/libmesh-${LIBMESH_VERSION}.tar.bz2 && \
     export LIBMESH_SOURCE_DIR=${PREFIX}/source/libmesh/${LIBMESH_VERSION} && \
@@ -211,8 +212,8 @@ RUN export LIBMESH_VERSION=1.2.0 && \
     rm -rf ${LIBMESH_BUILD_DIR} && \
     rm -rf ${LIBMESH_SOURCE_DIR}
 
+ENV LIBMESH_DIR=/opt/libmesh/1.2.1
 
-ENV LIBMESH_DIR=/opt/libmesh/1.2.0
 
 # download Trilinos
 # git clone --depth 1 only works for the last commit -> use a tarball instead

--- a/docker/travis/Dockerfile_clang-format
+++ b/docker/travis/Dockerfile_clang-format
@@ -3,9 +3,9 @@ from ubuntu:16.04
 RUN apt-get update && apt-get install -y wget git python-pip doxygen && \
     pip install --upgrade --no-cache-dir pip && \
     pip install --no-cache-dir sphinx==1.4 sphinx_rtd_theme breathe==4.6 && \
-    echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-4.0 main" > /etc/apt/sources.list.d/llvm.list && \
+    echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-5.0 main" > /etc/apt/sources.list.d/llvm.list && \
     wget -q -O - http://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
-    apt-get update && apt-get install -y clang-format-4.0 clang-tidy-4.0 && \
+    apt-get update && apt-get install -y clang-format-5.0 clang-tidy-5.0 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/docker/travis/check_format_cpp.sh
+++ b/docker/travis/check_format_cpp.sh
@@ -5,7 +5,7 @@ for file in $(git ls-files packages | grep "\(.hpp\|.cpp\)"); do
     diff -u \
         <(cat $file) \
         --label a/$file \
-        <(clang-format-4.0 $file) \
+        <(clang-format-5.0 $file) \
         --label b/$file
     if [ $? -eq 1 ]; then
         let "unformatted_files++"

--- a/docs/source/coding_guidelines.rst
+++ b/docs/source/coding_guidelines.rst
@@ -8,7 +8,7 @@ the repository.
 ClangFormat
 -----------
 
-ClangFormat (version 4.0) is used to check the C++ code formatting style in
+ClangFormat (version 5.0) is used to check the C++ code formatting style in
 DTK.  A pull request that does not comply will be rejected. Configure with
 ``-D DataTransferKit_ENABLE_ClangFormat=ON`` and do ``make format-cpp`` to
 apply the formatting style before your commit.  Alternatively, run

--- a/packages/Interface/src/DTK_CellList.hpp
+++ b/packages/Interface/src/DTK_CellList.hpp
@@ -34,7 +34,7 @@ namespace DataTransferKit
  * CellList describes cells for various discretizations (FEM, FD, FV, etc.)
  * using a standard set of cell topologies indicated via a unique cell
  * topology key.
-*/
+ */
 template <class... ViewProperties>
 class CellList
 {

--- a/packages/Interface/src/DTK_PolyhedronList.hpp
+++ b/packages/Interface/src/DTK_PolyhedronList.hpp
@@ -30,7 +30,7 @@ namespace DataTransferKit
  *
  * PolyhedronList describes arbitrary linear polyhedra accessible from the
  * calling MPI rank.
-*/
+ */
 template <class... ViewProperties>
 class PolyhedronList
 {

--- a/packages/Search/examples/bvh_driver/bvh_driver.cpp
+++ b/packages/Search/examples/bvh_driver/bvh_driver.cpp
@@ -25,8 +25,10 @@ std::vector<std::array<double, 3>>
 make_stuctured_cloud( double Lx, double Ly, double Lz, int nx, int ny, int nz )
 {
     std::vector<std::array<double, 3>> cloud( nx * ny * nz );
-    std::function<int( int, int, int )> ind = [nx, ny, nz](
-        int i, int j, int k ) { return i + j * nx + k * ( nx * ny ); };
+    std::function<int( int, int, int )> ind = [nx, ny, nz]( int i, int j,
+                                                            int k ) {
+        return i + j * nx + k * ( nx * ny );
+    };
     double x, y, z;
     for ( int i = 0; i < nx; ++i )
         for ( int j = 0; j < ny; ++j )

--- a/packages/Search/src/DTK_LinearBVH_decl.hpp
+++ b/packages/Search/src/DTK_LinearBVH_decl.hpp
@@ -115,8 +115,9 @@ void queryDispatch(
             KOKKOS_LAMBDA( int i ) {
                 int count = 0;
                 Details::TreeTraversal<DeviceType>::query(
-                    bvh, queries( i ), [indices, offset, distances, i,
-                                        &count]( int index, double distance ) {
+                    bvh, queries( i ),
+                    [indices, offset, distances, i, &count]( int index,
+                                                             double distance ) {
                         indices( offset( i ) + count ) = index;
                         distances( offset( i ) + count ) = distance;
                         count++;

--- a/packages/Search/src/DTK_LinearBVH_def.hpp
+++ b/packages/Search/src/DTK_LinearBVH_def.hpp
@@ -51,9 +51,9 @@ class SetBoundingBoxesFunctor
 template <typename DeviceType>
 BVH<DeviceType>::BVH( Kokkos::View<Box const *, DeviceType> bounding_boxes )
     : _leaf_nodes( "leaf_nodes", bounding_boxes.extent( 0 ) )
-    , _internal_nodes(
-          "internal_nodes",
-          bounding_boxes.extent( 0 ) > 0 ? bounding_boxes.extent( 0 ) - 1 : 0 )
+    , _internal_nodes( "internal_nodes", bounding_boxes.extent( 0 ) > 0
+                                             ? bounding_boxes.extent( 0 ) - 1
+                                             : 0 )
     , _indices( "sorted_indices", bounding_boxes.extent( 0 ) )
 {
     using ExecutionSpace = typename DeviceType::execution_space;

--- a/packages/Search/src/details/DTK_DetailsDistributedSearchTreeImpl.hpp
+++ b/packages/Search/src/details/DTK_DetailsDistributedSearchTreeImpl.hpp
@@ -149,8 +149,9 @@ void DistributedSearchTreeImpl<DeviceType>::sendAcrossNetwork(
     distributor.doPostsAndWaits(
         Teuchos::ArrayView<T const>( exports_host.data(),
                                      exports_host.extent( 0 ) ),
-        1, Teuchos::ArrayView<T>( imports_host.data(),
-                                  imports_host.extent( 0 ) ) );
+        1,
+        Teuchos::ArrayView<T>( imports_host.data(),
+                               imports_host.extent( 0 ) ) );
     Kokkos::deep_copy( imports, imports_host );
 }
 
@@ -170,9 +171,12 @@ void DistributedSearchTreeImpl<DeviceType>::deviseStrategy(
                           KOKKOS_LAMBDA( int q ) {
                               Point point = queries( q )._query_point;
                               Box box( {
-                                  point[0] - epsilon[0], point[0] + epsilon[0],
-                                  point[1] - epsilon[1], point[1] + epsilon[1],
-                                  point[2] - epsilon[2], point[2] + epsilon[2],
+                                  point[0] - epsilon[0],
+                                  point[0] + epsilon[0],
+                                  point[1] - epsilon[1],
+                                  point[1] + epsilon[1],
+                                  point[2] - epsilon[2],
+                                  point[2] + epsilon[2],
                               } );
                               overlap_queries( q ) = Details::Overlap( box );
                           } );

--- a/packages/Search/test/tstDetailsDistributedSearchTreeImpl.cpp
+++ b/packages/Search/test/tstDetailsDistributedSearchTreeImpl.cpp
@@ -84,11 +84,17 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DetailsDistributedSearchTreeImpl,
     TEST_EQUALITY( offset.size(), m + 1 );
     std::vector<int> results_ = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
     std::vector<std::set<int>> sorted_results = {
-        {3}, {6, 2}, {8, 5, 1}, {9, 7, 4, 0},
+        {3},
+        {6, 2},
+        {8, 5, 1},
+        {9, 7, 4, 0},
     };
     std::vector<int> ranks_ = {10, 11, 12, 13, 14, 15, 16, 17, 18, 19};
     std::vector<std::set<int>> sorted_ranks = {
-        {13}, {16, 12}, {18, 15, 11}, {19, 17, 14, 10},
+        {13},
+        {16, 12},
+        {18, 15, 11},
+        {19, 17, 14, 10},
     };
     TEST_EQUALITY( results_.size(), n );
     TEST_EQUALITY( ranks_.size(), n );

--- a/packages/Search/test/tstDetailsTreeConstruction.cpp
+++ b/packages/Search/test/tstDetailsTreeConstruction.cpp
@@ -296,7 +296,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DetailsBVH, example_tree_construction,
     std::function<void( DataTransferKit::Node *, std::ostream & )>
         traverseRecursive;
     traverseRecursive = [&leaf_nodes, &internal_nodes, &traverseRecursive](
-        DataTransferKit::Node *node, std::ostream &os ) {
+                            DataTransferKit::Node *node, std::ostream &os ) {
         if ( std::any_of( leaf_nodes.data(), leaf_nodes.data() + n,
                           [node]( DataTransferKit::Node const &leaf_node ) {
                               return std::addressof( leaf_node ) == node;

--- a/packages/Search/test/tstDistributedSearchTree.cpp
+++ b/packages/Search/test/tstDistributedSearchTree.cpp
@@ -219,12 +219,14 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DistributedSearchTree, empty_tree_no_queries,
         {}, {0}, {}, success, out );
 
     check_results(
-        tree, Kokkos::View<DataTransferKit::Details::Nearest *, DeviceType>(
-                  "nothing", 0 ),
+        tree,
+        Kokkos::View<DataTransferKit::Details::Nearest *, DeviceType>(
+            "nothing", 0 ),
         {}, {0}, {}, success, out );
     check_results(
-        tree, Kokkos::View<DataTransferKit::Details::Overlap *, DeviceType>(
-                  "nothing", 0 ),
+        tree,
+        Kokkos::View<DataTransferKit::Details::Overlap *, DeviceType>(
+            "nothing", 0 ),
         {}, {0}, {}, success, out );
 }
 
@@ -342,12 +344,12 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DistributedSearchTree, boost_comparison,
             point_coords_host( j, 2 ) = z;
 
             // use the R-tree to obtain a reference solution
-            rtree.query( bgi::satisfies( [centroid, radius](
-                             std::pair<BPoint, int> const &val ) {
-                             return bg::distance( centroid, val.first ) <=
-                                    radius;
-                         } ),
-                         std::back_inserter( returned_values_within[j] ) );
+            rtree.query(
+                bgi::satisfies(
+                    [centroid, radius]( std::pair<BPoint, int> const &val ) {
+                        return bg::distance( centroid, val.first ) <= radius;
+                    } ),
+                std::back_inserter( returned_values_within[j] ) );
         }
     }
 

--- a/packages/Search/test/tstDistributedSearchTree.cpp
+++ b/packages/Search/test/tstDistributedSearchTree.cpp
@@ -12,7 +12,7 @@
 #include <Teuchos_DefaultComm.hpp>
 #include <Teuchos_UnitTestHarness.hpp>
 
-#include <boost/geometry/index/rtree.hpp>
+#include <boost/geometry.hpp>
 
 #include <algorithm>
 #include <bitset>

--- a/packages/Search/test/tstLinearBVH.cpp
+++ b/packages/Search/test/tstLinearBVH.cpp
@@ -114,35 +114,38 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( LinearBVH, queries, DeviceType )
     Kokkos::deep_copy( boxes, boxes_host );
     DataTransferKit::BVH<DeviceType> bvh( boxes );
 
-    auto make_overlap_queries = [](
-        std::vector<DataTransferKit::Box> const &overlap_boxes ) {
-        Kokkos::View<DataTransferKit::Details::Overlap *, DeviceType> queries(
-            "queries", overlap_boxes.size() );
-        auto queries_host = Kokkos::create_mirror_view( queries );
-        for ( int i = 0; i < queries.extent_int( 0 ); ++i )
-            queries_host( i ) =
-                DataTransferKit::Details::Overlap( overlap_boxes[i] );
-        Kokkos::deep_copy( queries, queries_host );
-        return queries;
-    };
+    auto make_overlap_queries =
+        []( std::vector<DataTransferKit::Box> const &overlap_boxes ) {
+            Kokkos::View<DataTransferKit::Details::Overlap *, DeviceType>
+                queries( "queries", overlap_boxes.size() );
+            auto queries_host = Kokkos::create_mirror_view( queries );
+            for ( int i = 0; i < queries.extent_int( 0 ); ++i )
+                queries_host( i ) =
+                    DataTransferKit::Details::Overlap( overlap_boxes[i] );
+            Kokkos::deep_copy( queries, queries_host );
+            return queries;
+        };
 
     // single query overlap with nothing
     check_results( bvh, make_overlap_queries( {DataTransferKit::Box()} ), {},
                    {0, 0}, success, out );
 
     // single query overlap with both
-    check_results( bvh, make_overlap_queries( {DataTransferKit::Box(
-                            {0., 1., 0., 1., 0., 1.} )} ),
+    check_results( bvh,
+                   make_overlap_queries(
+                       {DataTransferKit::Box( {0., 1., 0., 1., 0., 1.} )} ),
                    {1, 0}, {0, 2}, success, out );
 
     // single query overlap with only one
-    check_results( bvh, make_overlap_queries( {DataTransferKit::Box(
-                            {0.5, 1.5, 0.5, 1.5, 0.5, 1.5} )} ),
+    check_results( bvh,
+                   make_overlap_queries( {DataTransferKit::Box(
+                       {0.5, 1.5, 0.5, 1.5, 0.5, 1.5} )} ),
                    {1}, {0, 1}, success, out );
 
     // a couple queries both overlap with nothing
-    check_results( bvh, make_overlap_queries(
-                            {DataTransferKit::Box(), DataTransferKit::Box()} ),
+    check_results( bvh,
+                   make_overlap_queries(
+                       {DataTransferKit::Box(), DataTransferKit::Box()} ),
                    {}, {0, 0, 0}, success, out );
 
     // a couple queries first overlap with nothing second with only one
@@ -167,7 +170,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( LinearBVH, nearest_queries, DeviceType )
     DataTransferKit::BVH<DeviceType> bvh( boxes );
 
     std::vector<std::pair<DataTransferKit::Point, int>> points = {
-        {{{0., 0., 0.}}, 2}, {{{1., 0., 0.}}, 4},
+        {{{0., 0., 0.}}, 2},
+        {{{1., 0., 0.}}, 4},
     };
     std::vector<int> indices_ref = {0, 1, 0, 1, -1, -1};
     std::vector<int> offset_ref = {0, 2, 6};
@@ -273,12 +277,14 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( LinearBVH, empty, DeviceType )
     // We test it for both kind of predicates, spatial and nearest, on an empty
     // and on an non-empty tree.
     check_results(
-        bvh, Kokkos::View<DataTransferKit::Details::Overlap *, DeviceType>(
-                 "nothing", 0 ),
+        bvh,
+        Kokkos::View<DataTransferKit::Details::Overlap *, DeviceType>(
+            "nothing", 0 ),
         {}, {0}, success, out );
     check_results(
-        bvh, Kokkos::View<DataTransferKit::Details::Nearest *, DeviceType>(
-                 "nothing", 0 ),
+        bvh,
+        Kokkos::View<DataTransferKit::Details::Nearest *, DeviceType>(
+            "nothing", 0 ),
         {}, {0}, success, out );
     check_results(
         empty_bvh,
@@ -377,8 +383,10 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( LinearBVH, structured_grid, DeviceType )
     //
 
     auto bounding_boxes_host = Kokkos::create_mirror_view( bounding_boxes );
-    std::function<int( int, int, int )> ind = [nx, ny, nz](
-        int i, int j, int k ) { return i + j * nx + k * ( nx * ny ); };
+    std::function<int( int, int, int )> ind = [nx, ny, nz]( int i, int j,
+                                                            int k ) {
+        return i + j * nx + k * ( nx * ny );
+    };
     std::vector<std::set<int>> ref( n );
     for ( int i = 0; i < nx; ++i )
         for ( int j = 0; j < ny; ++j )
@@ -532,8 +540,10 @@ std::vector<std::array<double, 3>>
 make_stuctured_cloud( double Lx, double Ly, double Lz, int nx, int ny, int nz )
 {
     std::vector<std::array<double, 3>> cloud( nx * ny * nz );
-    std::function<int( int, int, int )> ind = [nx, ny, nz](
-        int i, int j, int k ) { return i + j * nx + k * ( nx * ny ); };
+    std::function<int( int, int, int )> ind = [nx, ny, nz]( int i, int j,
+                                                            int k ) {
+        return i + j * nx + k * ( nx * ny );
+    };
     double x, y, z;
     for ( int i = 0; i < nx; ++i )
         for ( int j = 0; j < ny; ++j )
@@ -660,7 +670,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( LinearBVH, rtree, DeviceType )
 
         // use the R-tree to obtain a reference solution
         rtree.query( bgi::satisfies( [centroid, radius](
-                         std::pair<BPoint, int> const &val ) {
+                                         std::pair<BPoint, int> const &val ) {
                          return bg::distance( centroid, val.first ) <= radius;
                      } ),
                      std::back_inserter( returned_values_within[i] ) );

--- a/packages/Search/test/tstLinearBVH.cpp
+++ b/packages/Search/test/tstLinearBVH.cpp
@@ -11,7 +11,7 @@
 
 #include <Teuchos_UnitTestHarness.hpp>
 
-#include <boost/geometry/index/rtree.hpp>
+#include <boost/geometry.hpp>
 
 #include <algorithm>
 #include <bitset>

--- a/scripts/docker_clang_env.sh
+++ b/scripts/docker_clang_env.sh
@@ -15,7 +15,7 @@ if [ "$SANITIZER" == "undefined_sanitizer" ]
   # Set the ASAN_SYMBOLIZER_PATH environment variable to point to the
   # llvm-symbolizer to make AddressSanitizer symbolize its output.  This makes
   # the reports more human-readable.
-  export ASAN_SYMBOLIZER_PATH=/usr/lib/llvm-4.0/bin/llvm-symbolizer
+  export ASAN_SYMBOLIZER_PATH=/usr/lib/llvm-5.0/bin/llvm-symbolizer
 elif [ "$SANITIZER" == "thread_sanitizer" ]
   then FLAGS="-fsanitize=thread"
 fi

--- a/scripts/docker_clang_env.sh
+++ b/scripts/docker_clang_env.sh
@@ -1,6 +1,6 @@
 # Use clang instead of gcc
-export OMPI_CC=/usr/bin/clang-4.0
-export OMPI_CXX=/usr/bin/clang++-4.0
+export OMPI_CC=/usr/bin/clang-5.0
+export OMPI_CXX=/usr/bin/clang++-5.0
 export CC=mpicc
 export CXX=mpicxx
 

--- a/scripts/setup_hooks.sh
+++ b/scripts/setup_hooks.sh
@@ -11,7 +11,7 @@ cp hooks/pre-commit ../.git/hooks/pre-commit
 ## If there are formatting errors, print the offending lines and fail.
 # Find clang-format that is used with git
 git_clang_name=""
-for name in "git-clang-format-mp-4.0" "git-clang-format-4.0" "git-clang-format" ; do
+for name in "git-clang-format-mp-5.0" "git-clang-format-5.0" "git-clang-format" ; do
     which $name > /dev/null 2>&1
     if [[ $? == 0 ]]; then
         git_clang_name="$name"
@@ -31,7 +31,7 @@ fi
 
 # We actually do have some version of clang-format
 clang_format=""
-for name in "clang-format-mp-4.0" "clang-format-4.0" "clang-format"; do
+for name in "clang-format-mp-5.0" "clang-format-5.0" "clang-format"; do
     which $name > /dev/null 2>&1
     if [[ $? == 0 ]]; then
         clang_format="$name"
@@ -44,9 +44,9 @@ if [[ $clang_format == "" ]]; then
     exit 1
 fi
 
-# Check clang-format version (only work with 4.0)
+# Check clang-format version
 clang_version=`$clang_format --version | awk '{print $3}' | cut -f 1,2 -d .`
-if [[ $clang_version != "4.0" ]]; then
+if [[ $clang_version != "5.0" ]]; then
     echo "Clang-format version is bad: $clang_version"
     git_clang_name=""
     clang_format=""


### PR DESCRIPTION
**edited by @dalg24**
This PR, in its original form, introduced massive changes in our base image.
I reworked it and took out the changes related to installing a new MPI with ABI compatibility because I would like to try it out before we merge into master.
I also postponed the install of an alternate clang version.  My understanding is that @Rombur wanted to test it out in conjunction with CUDA 9.0 but it the meantime we ran into compile issues with Intrepid2 (c.f. #308) with the new version of CUDA.

- Open MPI upgrade to be able to call mpirun outside the container [REMOVED]
- LLVM/Clang/OpenMP runtime upgrade to 5.0.0
- new code formatting enforced by clang-format-5.0
- system package manager install of clang-3.9 [REMOVED]
- boost upgrade
- trilinos and kokkos-tools updates [CHANGED]
- new versions of PETSc and libMesh [ADDED]

NOTE: All PRs will need to be rebased because of the clang-format update to 5.0 and you will want to reset you git pre-commit hooks.