### PR TITLE
Update Open MPI in base image to be able to run mpiexec from outside the container

### DIFF
--- a/docker/Dockerfile_stack
+++ b/docker/Dockerfile_stack
@@ -1,4 +1,4 @@
-from ubuntu:16.04
+FROM ubuntu:16.04
 
 ARG NPROC=4
 

--- a/docker/Dockerfile_stack
+++ b/docker/Dockerfile_stack
@@ -5,7 +5,6 @@ ARG NPROC=4
 RUN apt-get update && apt-get install -y \
         build-essential \
         gfortran \
-        libopenmpi-dev \
         curl \
         cmake \
         git \
@@ -78,6 +77,34 @@ RUN export OPENMP_VERSION=5.0.0 && \
     rm -rf ${OPENMP_BUILD_DIR} && \
     rm -rf ${OPENMP_SOURCE_DIR}
 
+
+# Install OpenMPI
+RUN export OPENMPI_VERSION=2.1.2 && \
+    export OPENMPI_VERSION_SHORT=2.1 && \
+    export OPENMPI_SHA1=4d43bb407eb8b9da099a555e8dc083352c6a1d02 && \
+    export OPENMPI_URL=https://www.open-mpi.org/software/ompi/v${OPENMPI_VERSION_SHORT}/downloads/openmpi-${OPENMPI_VERSION}.tar.bz2 && \
+    export OPENMPI_ARCHIVE=${PREFIX}/archive/openmpi-${OPENMPI_VERSION}.tar.bz2 && \
+    export OPENMPI_SOURCE_DIR=${PREFIX}/source/openmpi/${OPENMPI_VERSION} && \
+    export OPENMPI_BUILD_DIR=${PREFIX}/build/openmpi/${OPENMPI_VERSION} && \
+    export OPENMPI_INSTALL_DIR=/opt/openmpi/${OPENMPI_VERSION_SHORT} && \
+    wget --quiet ${OPENMPI_URL} --output-document=${OPENMPI_ARCHIVE} && \
+    echo "${OPENMPI_SHA1} ${OPENMPI_ARCHIVE}" | sha1sum -c && \
+    mkdir -p ${OPENMPI_SOURCE_DIR} && \
+    tar -xf ${OPENMPI_ARCHIVE} -C ${OPENMPI_SOURCE_DIR} --strip-components=1 && \
+    mkdir -p ${OPENMPI_BUILD_DIR} && \
+    cd ${OPENMPI_BUILD_DIR} && \
+    ${OPENMPI_SOURCE_DIR}/configure --prefix=${OPENMPI_INSTALL_DIR} && \
+    make -j${NPROC} install && \
+    rm -rf ${OPENMPI_ARCHIVE} && \
+    rm -rf ${OPENMPI_BUILD_DIR} && \
+    rm -rf ${OPENMPI_SOURCE_DIR}
+
+ENV MPI_DIR=/opt/openmpi/2.1
+# Put OPENMPI_DIR at the end of the path so that /ust/local/bin/mpiexec will
+# overwrite it
+ENV PATH=$PATH:${MPI_DIR}/bin
+
+
 # install Boost
 RUN export BOOST_URL=https://dl.bintray.com/boostorg/release/1.65.1/source/boost_1_65_1.tar.bz2 && \
     export BOOST_SHA256=9807a5d16566c57fd74fb522764e0b134a8bbe6b6e8967b83afefd30dcd3be81 && \
@@ -149,7 +176,7 @@ RUN export NETCDF_VERSION=4.4.1.1 && \
         --enable-netcdf-4 \
         --enable-shared \
         --disable-static \
-        CC=/usr/bin/mpicc \
+        CC=${MPI_DIR}/bin/mpicc \
         CFLAGS="-I${HDF5_DIR}/include" \
         LDFLAGS="-L${HDF5_DIR}/lib -lhdf5" \
         && \
@@ -210,8 +237,9 @@ ENV KOKKOS_TOOLS_DIR=/scratch/source/kokkos-tools/${KOKKOS_TOOLS_SHORT_HASH}/src
 
 # append the option flag --allow-run-as-root to mpiexec
 RUN echo '#!/usr/bin/env bash' > /usr/local/bin/mpiexec && \
-    echo '/usr/bin/mpiexec --allow-run-as-root "$@"' >> /usr/local/bin/mpiexec && \
-    chmod +x /usr/local/bin/mpiexec
+    echo '${MPI_DIR}/bin/mpiexec --allow-run-as-root "$@"' >> /usr/local/bin/mpiexec && \
+    chmod +x /usr/local/bin/mpiexec && \
+    mpiexec --version
 
 # setup vim
 COPY .vimrc /root/.vimrc

--- a/docker/Dockerfile_stack
+++ b/docker/Dockerfile_stack
@@ -160,60 +160,6 @@ RUN export NETCDF_VERSION=4.4.1.1 && \
 
 ENV NETCDF_DIR=/opt/netcdf/4.4.1.1
 
-# install PETSc
-RUN export PETSC_VERSION=3.7.5 && \
-    export PETSC_URL=http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-${PETSC_VERSION}.tar.gz && \
-    export PETSC_ARCHIVE=${PREFIX}/archive/petsc-${PETSC_VERSION}.tar.gz && \
-    export PETSC_SOURCE_DIR=${PREFIX}/source/petsc/${PETSC_VERSION} && \
-    export PETSC_BUILD_DIR=${PREFIX}/build/petsc/${PETSC_VERSION} && \
-    export PETSC_INSTALL_DIR=/opt/petsc/${PETSC_VERSION} && \
-    wget --quiet ${PETSC_URL} --output-document=${PETSC_ARCHIVE} && \
-    mkdir -p ${PETSC_SOURCE_DIR} && \
-    tar -xf ${PETSC_ARCHIVE} -C ${PETSC_SOURCE_DIR} --strip-components=1 && \
-    mkdir -p ${PETSC_BUILD_DIR} && \
-    cd  ${PETSC_SOURCE_DIR} && \
-    ${PETSC_SOURCE_DIR}/configure \
-        --prefix=${PETSC_INSTALL_DIR} \
-        --with-shared-libraries \
-        --with-cc=/usr/bin/mpicc \
-        --with-cxx=/usr/bin/mpicxx \
-        --with-fc=/usr/bin/mpifort \
-        --with-debugging=0 \
-        && \
-    make MAKE_NP=${NPROC} && \
-    make MAKE_NP=${NPROC} install && \
-    rm -rf ${PETSC_ARCHIVE} && \
-    rm -rf ${PETSC_BUILD_DIR} && \
-    rm -rf ${PETSC_SOURCE_DIR}
-
-ENV PETSC_DIR=/opt/petsc/3.7.5
-
-
-# install libMesh
-RUN export LIBMESH_VERSION=1.2.1 && \
-    export LIBMESH_URL=https://github.com/libMesh/libmesh/releases/download/v${LIBMESH_VERSION}/libmesh-${LIBMESH_VERSION}.tar.bz2 && \
-    export LIBMESH_ARCHIVE=${PREFIX}/archive/libmesh-${LIBMESH_VERSION}.tar.bz2 && \
-    export LIBMESH_SOURCE_DIR=${PREFIX}/source/libmesh/${LIBMESH_VERSION} && \
-    export LIBMESH_BUILD_DIR=${PREFIX}/build/libmesh/${LIBMESH_VERSION} && \
-    export LIBMESH_INSTALL_DIR=/opt/libmesh/${LIBMESH_VERSION} && \
-    wget --quiet ${LIBMESH_URL} --output-document=${LIBMESH_ARCHIVE} && \
-    mkdir -p ${LIBMESH_SOURCE_DIR} && \
-    tar -xf ${LIBMESH_ARCHIVE} -C ${LIBMESH_SOURCE_DIR} --strip-components=1 && \
-    mkdir -p  ${LIBMESH_BUILD_DIR} && \
-    cd  ${LIBMESH_BUILD_DIR} && \
-    ${LIBMESH_SOURCE_DIR}/configure \
-        --prefix=${LIBMESH_INSTALL_DIR} \
-        --enable-unique_id \
-        --disable-hdf5 \
-        --with-methods="opt" \
-        && \
-    make -j${NPROC} install && \
-    rm -rf ${LIBMESH_ARCHIVE} && \
-    rm -rf ${LIBMESH_BUILD_DIR} && \
-    rm -rf ${LIBMESH_SOURCE_DIR}
-
-ENV LIBMESH_DIR=/opt/libmesh/1.2.1
-
 
 # download Trilinos
 # git clone --depth 1 only works for the last commit -> use a tarball instead

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,22 @@
+# Changelog
+
+## 17.10.0 (October 5th, 2017)
+### TPLs update
+- Updated Boost from 1.63.0 to 1.65.1
+- Updated Trilinos from 4c8adc9 to 89b8c7f which has been tagged as release 12.12.1 on GitHub
+- Updated Kokkos Profiling and Debugging Tools to latest version
+- Updated PETSc from 3.6.4 to 3.7.5
+- Updated libMesh from 1.2.0 to 1.2.1
+COMMENT: decided to keep PETSc/libMesh for now and updated them to their recommended versions in MOOSE installation guidelines
+### Change
+- Upgrade versions of LLVM, Clang, and OpenMP runtime to 5.0.0
+- Use ClangFormat version 5.0 to enforce code formatting style (instead of version 4.0)
+
+## 17.10.1 (October 16th, 2017)
+### CHange
+- Add Open MPI 2.1.2 to replace version 1.10.1 from the system package manager
+COMMENT: intent is to be able to take advantage of MPI ABI compatibility on HPC ressources
+### TPLs removal
+- Remove PETSc and libMesh
+## TODO
+Clear things up about install prefix of LLVM OpenMP

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,6 +1,7 @@
 # Building DTK
 - To build DTK on ALCF ressources see [README_ALCF.md](README_ALCF.md)
 - To build DTK on Summitdev see [README_OLCF_SUMMITDEV.md](README_OLCF_SUMMITDEV.md)
+- To build DTK on CADES ressources see [README_CADES.md](README_CADES.md)
 
 # Changelog generation
 We are using [github_changelog_generator](https://github.com/skywinder/github-changelog-generator) which is a Ruby-based fully automatic changelog generator based on **tags**, **issues** and merged **pull requests**.

--- a/scripts/README_CADES.md
+++ b/scripts/README_CADES.md
@@ -1,0 +1,44 @@
+# Building DTK on CADES SHPC Condo
+
+The CADES SHPC Condo user guide in available [here](http://support.cades.ornl.gov/user-documentation/_book/#).
+
+## Software stack
+From the available modules, below are the ones that need to be loaded:
+```bash
+$ module load git cmake
+$ module load PE-gnu
+$ module switch openmpi/1.10.3 openmpi/2.1.1
+$ module load cuda/8.0
+$ module load boost
+$ module load ATLAS
+```
+It is recommended to create a script that you will be able to source later to load these modules.
+You probably want to export the environment variable `TRILINOS_DIR` to specify the path to your Trilinos project source directory in that same script.
+
+## Download Trilinos/DTK, configure, build
+This directory contains a configuration script ([cades_shpc_condo_cmake](cades_shpc_condo_cmake)) to build on Condo.
+Here are some instructions you could run to build DTK:
+```bash
+$ git clone https://github.com/trilinos/Trilinos.git
+$ cd Trilinos
+$ export TRILINOS_DIR=$PWD
+$ git clone https://github.com/ORNL-CEES/DataTransferKit.git
+$ cd DataTransferKit
+$ mkdir build && cd build
+$ source ../script/set_kokkos_env.sh
+$ ../script/cades_shpc_condo_cmake
+$ make -j4
+```
+
+## Execute a job on your SHPC Condo allocation to run the tests/examples
+Please refer to the [CADES user guide](http://support.cades.ornl.gov/user-documentation/_book/condos/condo-mpi-hello-world.html)
+for more details on how to create a portable batch system (PBS) script and execute a job on SHPC Condo.
+Below is how you may start an interactive session on a node that has GPUs:
+```bash
+$ qsub -I -l nodes=1:ppn=16 -l walltime=0:10:00 -W group_list=cades-birthright -A birthright -q gpu
+```
+Then you would need to load appropriate programming environement again using `module load` and you would do:
+```bash
+$ cd $TRILINOS_DIR/DataTransferKit/build
+$ ctest
+```

--- a/scripts/cades_shpc_condo_cmake
+++ b/scripts/cades_shpc_condo_cmake
@@ -1,0 +1,59 @@
+#!/bin/bash
+GPU_ARCH=sm_37
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source ${SCRIPT_DIR}/set_kokkos_env.sh
+
+rm -f  CMakeCache.txt
+rm -rf CMakeFiles/
+EXTRA_ARGS=("$@")
+ARGS=(
+    -D CMAKE_BUILD_TYPE=Debug
+    -D BUILD_SHARED_LIBS=ON
+    ### COMPILERS AND FLAGS ###
+    -D CMAKE_CXX_FLAGS="-g -arch=${GPU_ARCH} -lineinfo \
+        -std=c++11 --expt-extended-lambda \
+        -Xcudafe --diag_suppress=conversion_function_not_usable \
+        -Xcudafe --diag_suppress=cc_clobber_ignored \
+        -Xcudafe --diag_suppress=code_is_unreachable"
+    -D DataTransferKit_CXX_FLAGS="-Wall -Wno-shadow -Wpedantic"
+    -D Trilinos_TPL_SYSTEM_INCLUDE_DIRS=ON
+    ### TPLs ###
+    -D TPL_ENABLE_MPI=ON
+    -D TPL_ENABLE_BLAS=ON
+        -D BLAS_LIBRARY_DIRS="${ATLAS_DIR}/lib;${GCC_LIB}"
+        -D BLAS_LIBRARY_NAMES="f77blas;cblas;atlas;gfortran"
+    -D TPL_ENABLE_LAPACK=ON
+        -D LAPACK_LIBRARY_DIRS=${ATLAS_DIR}/lib
+        -D LAPACK_LIBRARY_NAMES="lapack"
+    -D TPL_ENABLE_Boost=ON
+    -D TPL_ENABLE_BoostLib=ON
+    -D TPL_ENABLE_CUDA=ON
+    ### ETI ###
+    -D Trilinos_ENABLE_EXPLICIT_INSTANTIATION=ON
+    ### PACKAGES CONFIGURATION ###
+    -D Trilinos_ENABLE_ALL_PACKAGES=OFF
+    -D Trilinos_ENABLE_ALL_OPTIONAL_PACKAGES=OFF
+    -D Trilinos_ENABLE_TESTS=OFF
+    -D Trilinos_ENABLE_EXAMPLES=OFF
+    -D Trilinos_ENABLE_OpenMP=ON
+    -D Trilinos_ENABLE_Tpetra=ON
+        -D Tpetra_INST_INT_UNSIGNED_LONG=ON
+        -D Tpetra_INST_COMPLEX_DOUBLE=OFF
+        -D Tpetra_INST_COMPLEX_FLOAT=OFF
+        -D Tpetra_INST_SERIAL=ON
+        -D Tpetra_INST_OPENMP=ON
+        -D Tpetra_INST_CUDA=ON
+        -D Kokkos_ENABLE_Serial=ON
+        -D Kokkos_ENABLE_OpenMP=ON
+        -D Kokkos_ENABLE_Cuda=ON
+        -D Kokkos_ENABLE_Cuda_UVM=ON
+        -D Kokkos_ENABLE_Cuda_Lambda=ON
+    ### DTK ###
+    -D Trilinos_EXTRA_REPOSITORIES="DataTransferKit"
+    -D Trilinos_ENABLE_DataTransferKit=ON
+        -D DataTransferKit_ENABLE_DBC=ON
+        -D DataTransferKit_ENABLE_TESTS=ON
+        -D DataTransferKit_ENABLE_EXAMPLES=ON
+    )
+cmake "${ARGS[@]}" "${EXTRA_ARGS[@]}" $TRILINOS_DIR

--- a/scripts/docker_cmake
+++ b/scripts/docker_cmake
@@ -22,9 +22,6 @@ ARGS=(
     -D TPL_ENABLE_Netcdf=ON
         -D Netcdf_INCLUDE_DIRS=$NETCDF_DIR/include
         -D Netcdf_LIBRARY_DIRS=$NETCDF_DIR/lib
-    -D TPL_ENABLE_Libmesh=ON
-        -D Libmesh_INCLUDE_DIRS=$LIBMESH_DIR/include
-        -D Libmesh_LIBRARY_DIRS=$LIBMESH_DIR/lib
     ### ETI ###
     -D Trilinos_ENABLE_EXPLICIT_INSTANTIATION=ON
     ### PACKAGES CONFIGURATION ###


### PR DESCRIPTION
I ended up separating this out from #307
This is not ready for review yet.

I tagged a new 17.10.1 image on Docker Hub.  It has Open MPI version 2.1 instead of the 3.0 @Rombur had in his PR.  I want us to test it out with Singularity before we merge.

- [x] experiment with Singularity
- [x] add documentation