### PR TITLE
Update README for summitdev

### DIFF
--- a/scripts/README_OLCF_SUMMITDEV.md
+++ b/scripts/README_OLCF_SUMMITDEV.md
@@ -19,7 +19,3 @@ to set `nvcc_wrapper` as the underlying C++ compiler for Spectrum MPI:
 ```
 export OMPI_CXX=$TRILINOS_DIR/packages/kokkos/config/nvcc_wrapper
 ```
-
-# CUDA-aware MPI
-By default, CUDA-awareness is disable by default. To enable it, add the `-gpu`
-flag, to `mpirun`.


### PR DESCRIPTION
mpirun is not accessible on summitdev anymore. It has been replace by jsrun
which does not have an option to enable gpu-aware mpi.