### PR TITLE
Implement useful functions for distributed search tree

### DIFF
--- a/packages/Search/src/DTK_DistributedSearchTree_def.hpp
+++ b/packages/Search/src/DTK_DistributedSearchTree_def.hpp
@@ -45,6 +45,30 @@ DistributedSearchTree<DeviceType>::DistributedSearchTree(
     _distributed_tree = std::make_shared<BVH<DeviceType>>( boxes );
 }
 
+template <typename DeviceType>
+typename DistributedSearchTree<DeviceType>::SizeType
+DistributedSearchTree<DeviceType>::size() const
+{
+    // Below is an attempt to achieve lazy evaluation while preserving thread
+    // safety.  `_size` is initialized to an invalid state upon construction
+    // and is computed only once as the sum reduce of the local tree size over
+    // all processes.
+    if ( _size == std::numeric_limits<SizeType>::max() )
+    {
+        std::lock_guard<std::mutex> guard( _mutex );
+        std::call_once(
+            _once_flag,
+            []( Teuchos::RCP<Teuchos::Comm<int> const> const &comm,
+                SizeType const &local_size,
+                Teuchos::Ptr<SizeType> const &global_size ) -> void {
+                Teuchos::reduceAll( *comm, Teuchos::REDUCE_SUM, local_size,
+                                    global_size );
+            },
+            _comm, _local_tree.size(), Teuchos::ptrFromRef( _size ) );
+    }
+    return _size;
+}
+
 } // end namespace DataTransferKit
 
 // Explicit instantiation macro

--- a/packages/Search/test/tstDistributedSearchTree.cpp
+++ b/packages/Search/test/tstDistributedSearchTree.cpp
@@ -228,6 +228,27 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DistributedSearchTree, empty_tree_no_queries,
         Kokkos::View<DataTransferKit::Details::Overlap *, DeviceType>(
             "nothing", 0 ),
         {}, {0}, {}, success, out );
+
+    TEST_ASSERT( empty_tree.empty() );
+    TEST_ASSERT( !tree.empty() );
+    TEST_EQUALITY( (int)empty_tree.size(), 0 );
+    TEST_EQUALITY( (int)tree.size(), comm_size );
+    // NOTE: we need that box comparison function or operator== so badly...
+    auto checkBoxesAreEqual = [&out,
+                               &success]( DataTransferKit::Box const &l,
+                                          DataTransferKit::Box const &r ) {
+        for ( int i = 0; i < 6; ++i )
+            TEST_EQUALITY( l[i], r[i] );
+    };
+    checkBoxesAreEqual( empty_tree.bounds(), DataTransferKit::Box() );
+    checkBoxesAreEqual( tree.bounds(), DataTransferKit::Box( {
+                                           0.,
+                                           (double)comm_size,
+                                           0.,
+                                           1.,
+                                           0.,
+                                           1.,
+                                       } ) );
 }
 
 std::vector<std::array<double, 3>>


### PR DESCRIPTION
Implement `DistrtibutedSearchTree::size()`, `::empty()`, and `::bounds()`