### PR TITLE
Changing data structure in Box

### DIFF
--- a/packages/Search/examples/bvh_driver/bvh_driver.cpp
+++ b/packages/Search/examples/bvh_driver/bvh_driver.cpp
@@ -107,9 +107,7 @@ int main_( Teuchos::CommandLineProcessor &clp, int argc, char *argv[] )
         double x = std::get<0>( point );
         double y = std::get<1>( point );
         double z = std::get<2>( point );
-        bounding_boxes_host[i] = {
-            x, x, y, y, z, z,
-        };
+        bounding_boxes_host[i] = {{{x, y, z}}, {{x, y, z}}};
     }
     Kokkos::deep_copy( bounding_boxes, bounding_boxes_host );
 

--- a/packages/Search/src/DTK_DistributedSearchTree_def.hpp
+++ b/packages/Search/src/DTK_DistributedSearchTree_def.hpp
@@ -39,7 +39,7 @@ DistributedSearchTree<DeviceType>::DistributedSearchTree(
                         reinterpret_cast<double *>( &boxes_host( comm_rank ) ),
                         6 * comm_size, bounds.getRawPtr() );
     for ( int i = 0; i < comm_size; ++i )
-        boxes_host( i ) = Box( &( bounds[6 * i] ) );
+        boxes_host( i ) = reinterpret_cast<Box const &>( bounds[6 * i] );
     Kokkos::deep_copy( boxes, boxes_host );
 
     _distributed_tree = BVH<DeviceType>( boxes );

--- a/packages/Search/src/details/DTK_DetailsBox.hpp
+++ b/packages/Search/src/details/DTK_DetailsBox.hpp
@@ -9,8 +9,9 @@
 #ifndef DTK_Box_HPP
 #define DTK_Box_HPP
 
+#include <DTK_DetailsPoint.hpp>
 #include <Kokkos_ArithTraits.hpp>
-#include <Kokkos_Core.hpp>
+#include <Kokkos_Macros.hpp>
 
 namespace DataTransferKit
 {
@@ -21,68 +22,46 @@ namespace DataTransferKit
  */
 struct Box
 {
-    using ArrayType = double[6]; // Kokkos::Array<double, 6>;
-    using SizeType = size_t;     // ArrayType::size_type;
+    KOKKOS_INLINE_FUNCTION
+    Box() = default;
 
     KOKKOS_INLINE_FUNCTION
-    Box()
+    Box( Point const &min_corner, Point const &max_corner )
+        : _min_corner( min_corner )
+        , _max_corner( max_corner )
     {
-        _minmax[0] = Kokkos::ArithTraits<double>::max();
-        _minmax[1] = -Kokkos::ArithTraits<double>::max();
-        _minmax[2] = Kokkos::ArithTraits<double>::max();
-        _minmax[3] = -Kokkos::ArithTraits<double>::max();
-        _minmax[4] = Kokkos::ArithTraits<double>::max();
-        _minmax[5] = -Kokkos::ArithTraits<double>::max();
     }
 
     KOKKOS_INLINE_FUNCTION
-    Box( ArrayType const &minmax )
-    {
-        for ( unsigned int i = 0; i < 6; ++i )
-            _minmax[i] = minmax[i];
-    }
+    Point &minCorner() { return _min_corner; }
 
     KOKKOS_INLINE_FUNCTION
-    Box( double const *minmax )
-    {
-        for ( unsigned int i = 0; i < 6; ++i )
-            _minmax[i] = minmax[i];
-    }
+    Point const &minCorner() const { return _min_corner; }
 
     KOKKOS_INLINE_FUNCTION
-    Box &operator=( ArrayType const &minmax )
-    {
-        for ( unsigned int i = 0; i < 6; ++i )
-            _minmax[i] = minmax[i];
-
-        return *this;
-    }
+    Point volatile &minCorner() volatile { return _min_corner; }
 
     KOKKOS_INLINE_FUNCTION
-    double &operator[]( SizeType i ) { return _minmax[i]; }
+    Point volatile const &minCorner() volatile const { return _min_corner; }
 
     KOKKOS_INLINE_FUNCTION
-    double const &operator[]( SizeType i ) const { return _minmax[i]; }
+    Point &maxCorner() { return _max_corner; }
 
     KOKKOS_INLINE_FUNCTION
-    volatile double &operator[]( SizeType i ) volatile { return _minmax[i]; }
+    Point const &maxCorner() const { return _max_corner; }
 
     KOKKOS_INLINE_FUNCTION
-    volatile double const &operator[]( SizeType i ) volatile const
-    {
-        return _minmax[i];
-    }
+    Point volatile &maxCorner() volatile { return _max_corner; }
 
-    ArrayType _minmax;
+    KOKKOS_INLINE_FUNCTION
+    Point volatile const &maxCorner() volatile const { return _max_corner; }
 
-    friend std::ostream &operator<<( std::ostream &os, Box const &aabb )
-    {
-        os << "{";
-        for ( int d = 0; d < 3; ++d )
-            os << " [" << aabb[2 * d + 0] << ", " << aabb[2 * d + 1] << "],";
-        os << "}";
-        return os;
-    }
+    Point _min_corner = {{Kokkos::ArithTraits<double>::max(),
+                          Kokkos::ArithTraits<double>::max(),
+                          Kokkos::ArithTraits<double>::max()}};
+    Point _max_corner = {{-Kokkos::ArithTraits<double>::max(),
+                          -Kokkos::ArithTraits<double>::max(),
+                          -Kokkos::ArithTraits<double>::max()}};
 };
 }
 

--- a/packages/Search/src/details/DTK_DetailsDistributedSearchTreeImpl.hpp
+++ b/packages/Search/src/details/DTK_DetailsDistributedSearchTreeImpl.hpp
@@ -170,14 +170,16 @@ void DistributedSearchTreeImpl<DeviceType>::deviseStrategy(
                           Kokkos::RangePolicy<ExecutionSpace>( 0, n_queries ),
                           KOKKOS_LAMBDA( int q ) {
                               Point point = queries( q )._query_point;
-                              Box box( {
-                                  point[0] - epsilon[0],
-                                  point[0] + epsilon[0],
-                                  point[1] - epsilon[1],
-                                  point[1] + epsilon[1],
-                                  point[2] - epsilon[2],
-                                  point[2] + epsilon[2],
-                              } );
+                              Box box = {{{
+                                             point[0] - epsilon[0],
+                                             point[1] - epsilon[1],
+                                             point[2] - epsilon[2],
+                                         }},
+                                         {{
+                                             point[0] + epsilon[0],
+                                             point[1] + epsilon[1],
+                                             point[2] + epsilon[2],
+                                         }}};
                               overlap_queries( q ) = Details::Overlap( box );
                           } );
     Kokkos::fence();

--- a/packages/Search/src/details/DTK_DetailsPoint.hpp
+++ b/packages/Search/src/details/DTK_DetailsPoint.hpp
@@ -18,10 +18,22 @@ class Point
 {
   public:
     KOKKOS_INLINE_FUNCTION
-    const double &operator[]( unsigned int i ) const { return _coords[i]; }
+    double &operator[]( unsigned int i ) { return _coords[i]; }
 
     KOKKOS_INLINE_FUNCTION
-    double &operator[]( unsigned int i ) { return _coords[i]; }
+    double const &operator[]( unsigned int i ) const { return _coords[i]; }
+
+    KOKKOS_INLINE_FUNCTION
+    double volatile &operator[]( unsigned int i ) volatile
+    {
+        return _coords[i];
+    }
+
+    KOKKOS_INLINE_FUNCTION
+    double const volatile &operator[]( unsigned int i ) const volatile
+    {
+        return _coords[i];
+    }
 
     // This should be private but if we make public we can use the list
     // initializer constructor.

--- a/packages/Search/src/details/DTK_DetailsTreeConstruction_def.hpp
+++ b/packages/Search/src/details/DTK_DetailsTreeConstruction_def.hpp
@@ -49,8 +49,8 @@ class AssignMortonCodesFunctor
         // scale coordinates with respect to bounding box of the scene
         for ( int d = 0; d < 3; ++d )
         {
-            a = _scene_bounding_box[2 * d];
-            b = _scene_bounding_box[2 * d + 1];
+            a = _scene_bounding_box.minCorner()[d];
+            b = _scene_bounding_box.maxCorner()[d];
             xyz[d] = ( a != b ? ( xyz[d] - a ) / ( b - a ) : 0 );
         }
         _morton_codes[i] =

--- a/packages/Search/test/Search_UnitTestHelpers.hpp
+++ b/packages/Search/test/Search_UnitTestHelpers.hpp
@@ -160,12 +160,12 @@ void testBoxEquality( DataTransferKit::Box const &l,
                       DataTransferKit::Box const &r, bool &success,
                       Teuchos::FancyOStream &out )
 {
-    TEST_EQUALITY( l[0], r[0] );
-    TEST_EQUALITY( l[1], r[1] );
-    TEST_EQUALITY( l[2], r[2] );
-    TEST_EQUALITY( l[3], r[3] );
-    TEST_EQUALITY( l[4], r[4] );
-    TEST_EQUALITY( l[5], r[5] );
+    TEST_EQUALITY( l.minCorner()[0], r.minCorner()[0] );
+    TEST_EQUALITY( l.minCorner()[1], r.minCorner()[1] );
+    TEST_EQUALITY( l.minCorner()[2], r.minCorner()[2] );
+    TEST_EQUALITY( l.maxCorner()[0], r.maxCorner()[0] );
+    TEST_EQUALITY( l.maxCorner()[1], r.maxCorner()[1] );
+    TEST_EQUALITY( l.maxCorner()[2], r.maxCorner()[2] );
 }
 
 template <typename DeviceType>

--- a/packages/Search/test/tstDetailsAlgorithms.cpp
+++ b/packages/Search/test/tstDetailsAlgorithms.cpp
@@ -14,32 +14,23 @@ namespace dtk = DataTransferKit::Details;
 
 TEUCHOS_UNIT_TEST( DetailsAlgorithms, distance )
 {
-    TEST_EQUALITY( dtk::distance( DataTransferKit::Point( {{1.0, 2.0, 3.0}} ),
-                                  DataTransferKit::Point( {{1.0, 1.0, 1.0}} ) ),
+    TEST_EQUALITY( dtk::distance( {{1.0, 2.0, 3.0}}, {{1.0, 1.0, 1.0}} ),
                    std::sqrt( 5.0 ) );
 
     // box is unit cube
-    DataTransferKit::Box box( {{0.0, 1.0, 0.0, 1.0, 0.0, 1.0}} );
+    DataTransferKit::Box box = {{{0.0, 0.0, 0.0}}, {{1.0, 1.0, 1.0}}};
+
     // distance is zero if the point is inside the box
-    TEST_EQUALITY(
-        dtk::distance( DataTransferKit::Point( {{0.5, 0.5, 0.5}} ), box ),
-        0.0 );
+    TEST_EQUALITY( dtk::distance( {{0.5, 0.5, 0.5}}, box ), 0.0 );
     // or anywhere on the boundary
-    TEST_EQUALITY(
-        dtk::distance( DataTransferKit::Point( {{0.0, 0.0, 0.5}} ), box ),
-        0.0 );
+    TEST_EQUALITY( dtk::distance( {{0.0, 0.0, 0.5}}, box ), 0.0 );
     // normal projection onto center of one face
-    TEST_EQUALITY(
-        dtk::distance( DataTransferKit::Point( {{2.0, 0.5, 0.5}} ), box ),
-        1.0 );
+    TEST_EQUALITY( dtk::distance( {{2.0, 0.5, 0.5}}, box ), 1.0 );
     // projection onto edge
-    TEST_EQUALITY(
-        dtk::distance( DataTransferKit::Point( {{2.0, 0.75, -1.0}} ), box ),
-        std::sqrt( 2.0 ) );
+    TEST_EQUALITY( dtk::distance( {{2.0, 0.75, -1.0}}, box ),
+                   std::sqrt( 2.0 ) );
     // projection onto corner node
-    TEST_EQUALITY(
-        dtk::distance( DataTransferKit::Point( {{-1.0, 2.0, 2.0}} ), box ),
-        std::sqrt( 3.0 ) );
+    TEST_EQUALITY( dtk::distance( {{-1.0, 2.0, 2.0}}, box ), std::sqrt( 3.0 ) );
 }
 
 TEUCHOS_UNIT_TEST( DetailsAlgorithms, overlaps )
@@ -48,43 +39,40 @@ TEUCHOS_UNIT_TEST( DetailsAlgorithms, overlaps )
     // uninitialized box does not even overlap with itself
     TEST_ASSERT( !dtk::overlaps( box, box ) );
     // box with zero extent does
-    box = {{0.0, 0.0, 0.0, 0.0, 0.0, 0.0}};
+    box = {{{0.0, 0.0, 0.0}}, {{0.0, 0.0, 0.0}}};
     TEST_ASSERT( dtk::overlaps( box, box ) );
     TEST_ASSERT( !dtk::overlaps( box, DataTransferKit::Box() ) );
     // overlap with box that contains it
-    TEST_ASSERT( dtk::overlaps(
-        box, DataTransferKit::Box( {{-1.0, 1.0, -1.0, 1.0, -1.0, 1.0}} ) ) );
+    TEST_ASSERT(
+        dtk::overlaps( box, {{{-1.0, -1.0, -1.0}}, {{1.0, 1.0, 1.0}}} ) );
     // does not overlap with some other box
-    TEST_ASSERT( !dtk::overlaps(
-        box, DataTransferKit::Box( {{1.0, 2.0, 1.0, 2.0, 1.0, 2.0}} ) ) );
+    TEST_ASSERT(
+        !dtk::overlaps( box, {{{1.0, 1.0, 1.0}}, {{2.0, 2.0, 2.0}}} ) );
     // overlap when only touches another
-    TEST_ASSERT( dtk::overlaps(
-        box, DataTransferKit::Box( {{0.0, 1.0, 0.0, 1.0, 0.0, 1.0}} ) ) );
+    TEST_ASSERT( dtk::overlaps( box, {{{0.0, 0.0, 0.0}}, {{1.0, 1.0, 1.0}}} ) );
     // unit cube
-    box = {{0.0, 1.0, 0.0, 1.0, 0.0, 1.0}};
+    box = {{{0.0, 0.0, 0.0}}, {{1.0, 1.0, 1.0}}};
     TEST_ASSERT( dtk::overlaps( box, box ) );
     TEST_ASSERT( !dtk::overlaps( box, DataTransferKit::Box() ) );
     // smaller box inside
-    TEST_ASSERT( dtk::overlaps(
-        box, DataTransferKit::Box( {{0.25, 0.75, 0.25, 0.75, 0.25, 0.75}} ) ) );
+    TEST_ASSERT(
+        dtk::overlaps( box, {{{0.25, 0.25, 0.25}}, {{0.75, 0.75, 0.75}}} ) );
     // bigger box that contains it
-    TEST_ASSERT( dtk::overlaps(
-        box, DataTransferKit::Box( {{-1.0, 2.0, -1.0, 2.0, -1.0, 2.0}} ) ) );
+    TEST_ASSERT(
+        dtk::overlaps( box, {{{-1.0, -1.0, -1.0}}, {{2.0, 2.0, 2.0}}} ) );
     // couple boxes that do overlap
-    TEST_ASSERT( dtk::overlaps(
-        box, DataTransferKit::Box( {{0.5, 1.5, 0.5, 1.5, 0.5, 1.5}} ) ) );
-    TEST_ASSERT( dtk::overlaps(
-        box, DataTransferKit::Box( {{-0.5, 0.5, -0.5, 0.5, -0.5, 0.5}} ) ) );
+    TEST_ASSERT( dtk::overlaps( box, {{{0.5, 0.5, 0.5}}, {{1.5, 1.5, 1.5}}} ) );
+    TEST_ASSERT(
+        dtk::overlaps( box, {{{-0.5, -0.5, -0.5}}, {{0.5, 0.5, 0.5}}} ) );
     // couple boxes that do not
-    TEST_ASSERT( !dtk::overlaps(
-        box, DataTransferKit::Box( {{-2.0, -1.0, -2.0, -1.0, -2.0, -1.0}} ) ) );
-    TEST_ASSERT( !dtk::overlaps(
-        box, DataTransferKit::Box( {{0.0, 1.0, 0.0, 1.0, 2.0, 3.0}} ) ) );
+    TEST_ASSERT(
+        !dtk::overlaps( box, {{{-2.0, -2.0, -2.0}}, {{-1.0, -1.0, -1.0}}} ) );
+    TEST_ASSERT(
+        !dtk::overlaps( box, {{{0.0, 0.0, 2.0}}, {{1.0, 1.0, 3.0}}} ) );
     // boxes overlap if faces touch
-    TEST_ASSERT( dtk::overlaps(
-        box, DataTransferKit::Box( {{1.0, 2.0, 0.0, 1.0, 0.0, 1.0}} ) ) );
-    TEST_ASSERT( dtk::overlaps(
-        box, DataTransferKit::Box( {{-0.5, 0.5, -0.5, 0.0, -0.5, 0.5}} ) ) );
+    TEST_ASSERT( dtk::overlaps( box, {{{1.0, 0.0, 0.0}}, {{2.0, 1.0, 1.0}}} ) );
+    TEST_ASSERT(
+        dtk::overlaps( box, {{{-0.5, -0.5, -0.5}}, {{0.5, 0.0, 0.5}}} ) );
 }
 
 TEUCHOS_UNIT_TEST( DetailsAlgorithms, expand )
@@ -92,49 +80,47 @@ TEUCHOS_UNIT_TEST( DetailsAlgorithms, expand )
     // convenience utility to compare boxes
     auto checkBoxesEquality = []( DataTransferKit::Box const &a,
                                   DataTransferKit::Box const &b ) {
-        for ( int i = 0; i < 6; ++i )
-            if ( a[i] != b[i] )
+        for ( int d = 0; d < 3; ++d )
+            if ( ( a.minCorner()[d] != b.minCorner()[d] ) ||
+                 ( a.maxCorner()[d] != b.maxCorner()[d] ) )
                 return false;
         return true;
     };
     // check that the utility does its job properly
-    TEST_ASSERT( checkBoxesEquality(
-        DataTransferKit::Box( {{0.0, 1.0, 0.0, 1.0, 0.0, 1.0}} ),
-        DataTransferKit::Box( {{0.0, 1.0, 0.0, 1.0, 0.0, 1.0}} ) ) );
-    TEST_ASSERT( !checkBoxesEquality(
-        DataTransferKit::Box( {{0.0, 1.0, 0.0, 1.0, 0.0, 1.0}} ),
-        DataTransferKit::Box( {{-1.0, 1.0, -1.0, 1.0, -1.0, 1.0}} ) ) );
+    TEST_ASSERT( checkBoxesEquality( {{{0.0, 0.0, 0.0}}, {{1.0, 1.0, 1.0}}},
+                                     {{{0.0, 0.0, 0.0}}, {{1.0, 1.0, 1.0}}} ) );
+    TEST_ASSERT(
+        !checkBoxesEquality( {{{0.0, 0.0, 0.0}}, {{1.0, 0.0, 1.0}}},
+                             {{{-1.0, -1.0, -1.0}}, {{1.0, 1.0, 1.0}}} ) );
 
     DataTransferKit::Box box;
 
     // expand box with points
-    dtk::expand( box, DataTransferKit::Point( {{0.0, 0.0, 0.0}} ) );
-    TEST_ASSERT( checkBoxesEquality(
-        box, DataTransferKit::Box( {{0.0, 0.0, 0.0, 0.0, 0.0, 0.0}} ) ) );
-    dtk::expand( box, DataTransferKit::Point( {{1.0, 1.0, 1.0}} ) );
-    TEST_ASSERT( checkBoxesEquality(
-        box, DataTransferKit::Box( {{0.0, 1.0, 0.0, 1.0, 0.0, 1.0}} ) ) );
-    dtk::expand( box, DataTransferKit::Point( {{0.25, 0.75, 0.25}} ) );
-    TEST_ASSERT( checkBoxesEquality(
-        box, DataTransferKit::Box( {{0.0, 1.0, 0.0, 1.0, 0.0, 1.0}} ) ) );
-    dtk::expand( box, DataTransferKit::Point( {{-1.0, -1.0, -1.0}} ) );
-    TEST_ASSERT( checkBoxesEquality(
-        box, DataTransferKit::Box( {{-1.0, 1.0, -1.0, 1.0, -1.0, 1.0}} ) ) );
+    dtk::expand( box, {{0.0, 0.0, 0.0}} );
+    TEST_ASSERT(
+        checkBoxesEquality( box, {{{0.0, 0.0, 0.0}}, {{0.0, 0.0, 0.0}}} ) );
+    dtk::expand( box, {{1.0, 1.0, 1.0}} );
+    TEST_ASSERT(
+        checkBoxesEquality( box, {{{0.0, 0.0, 0.0}}, {{1.0, 1.0, 1.0}}} ) );
+    dtk::expand( box, {{0.25, 0.75, 0.25}} );
+    TEST_ASSERT(
+        checkBoxesEquality( box, {{{0.0, 0.0, 0.0}}, {{1.0, 1.0, 1.0}}} ) );
+    dtk::expand( box, {{-1.0, -1.0, -1.0}} );
+    TEST_ASSERT(
+        checkBoxesEquality( box, {{{-1.0, -1.0, -1.0}}, {{1.0, 1.0, 1.0}}} ) );
 
     // expand box with boxes
-    dtk::expand(
-        box, DataTransferKit::Box( {{0.25, 0.75, 0.25, 0.75, 0.25, 0.75}} ) );
+    dtk::expand( box, {{{0.25, 0.25, 0.25}}, {{0.75, 0.75, 0.75}}} );
+    TEST_ASSERT(
+        checkBoxesEquality( box, {{{-1.0, -1.0, -1.0}}, {{1.0, 1.0, 1.0}}} ) );
+    dtk::expand( box, {{{10.0, 10.0, 10.0}}, {{11.0, 11.0, 11.0}}} );
     TEST_ASSERT( checkBoxesEquality(
-        box, DataTransferKit::Box( {{-1.0, 1.0, -1.0, 1.0, -1.0, 1.0}} ) ) );
-    dtk::expand(
-        box, DataTransferKit::Box( {{10.0, 11.0, 10.0, 11.0, 10.0, 11.0}} ) );
-    TEST_ASSERT( checkBoxesEquality(
-        box, DataTransferKit::Box( {{-1.0, 11.0, -1.0, 11.0, -1.0, 11.0}} ) ) );
+        box, {{{-1.0, -1.0, -1.0}}, {{11.0, 11.0, 11.0}}} ) );
 }
 
 TEUCHOS_UNIT_TEST( DetailsAlgorithms, centroid )
 {
-    DataTransferKit::Box box( {{-10.0, 0.0, 0.0, 10.0, 10.0, 20.0}} );
+    DataTransferKit::Box box = {{{-10.0, 0.0, 10.0}}, {{0.0, 10.0, 20.0}}};
     DataTransferKit::Point centroid;
     dtk::centroid( box, centroid );
     TEST_EQUALITY( centroid[0], -5.0 );

--- a/packages/Search/test/tstDetailsTreeConstruction.cpp
+++ b/packages/Search/test/tstDetailsTreeConstruction.cpp
@@ -62,8 +62,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DetailsBVH, morton_codes, DeviceType )
 
     for ( int d = 0; d < 3; ++d )
     {
-        TEST_EQUALITY( scene_host[0][2 * d + 0], 0.0 );
-        TEST_EQUALITY( scene_host[0][2 * d + 1], 1024.0 );
+        TEST_EQUALITY( scene_host[0].minCorner()[d], 0.0 );
+        TEST_EQUALITY( scene_host[0].maxCorner()[d], 1024.0 );
     }
 
     Kokkos::View<unsigned int *, DeviceType> morton_codes( "morton_codes", n );

--- a/packages/Search/test/tstDistributedSearchTree.cpp
+++ b/packages/Search/test/tstDistributedSearchTree.cpp
@@ -228,14 +228,15 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DistributedSearchTree, unique_leaf_on_rank_0,
         ( comm_rank == 0 ? makeDistributedSearchTree<DeviceType>(
                                comm,
                                {
-                                   {{0., 1., 0., 1., 0., 1.}},
+                                   {{{0., 0., 0.}}, {{1., 1., 1.}}},
                                } )
                          : makeDistributedSearchTree<DeviceType>( comm, {} ) );
 
     TEST_ASSERT( !tree.empty() );
     TEST_EQUALITY( tree.size(), 1 );
 
-    testBoxEquality( tree.bounds(), {{0., 1., 0., 1., 0., 1.}}, success, out );
+    testBoxEquality( tree.bounds(), {{{0., 0., 0.}}, {{1., 1., 1.}}}, success,
+                     out );
 
     checkResults( tree, makeOverlapQueries<DeviceType>( {} ), {}, {0}, {},
                   success, out );
@@ -260,25 +261,27 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DistributedSearchTree, one_leaf_per_rank,
 
     // tree has one leaf per rank
     auto const tree = makeDistributedSearchTree<DeviceType>(
-        comm, {
-                  {{(double)comm_rank, (double)comm_rank + 1., 0., 1., 0., 1.}},
-              } );
+        comm,
+        {
+            {{{(double)comm_rank, 0., 0.}}, {{(double)comm_rank + 1., 1., 1.}}},
+        } );
 
     TEST_ASSERT( !tree.empty() );
     TEST_EQUALITY( (int)tree.size(), comm_size );
 
-    testBoxEquality( tree.bounds(), {{0., (double)comm_size, 0., 1., 0., 1.}},
-                     success, out );
+    testBoxEquality( tree.bounds(),
+                     {{{0., 0., 0.}}, {{(double)comm_size, 1., 1.}}}, success,
+                     out );
 
-    checkResults(
-        tree,
-        makeOverlapQueries<DeviceType>( {
-            {{(double)comm_size - (double)comm_rank - .5,
-              (double)comm_size - (double)comm_rank - .5, .5, .5, .5, .5}},
-            {{(double)comm_rank + .5, (double)comm_rank + .5, .5, .5, .5, .5}},
-        } ),
-        {0, 0}, {0, 1, 2}, {comm_size - 1 - comm_rank, comm_rank}, success,
-        out );
+    checkResults( tree,
+                  makeOverlapQueries<DeviceType>( {
+                      {{{(double)comm_size - (double)comm_rank - .5, .5, .5}},
+                       {{(double)comm_size - (double)comm_rank - .5, .5, .5}}},
+                      {{{(double)comm_rank + .5, .5, .5}},
+                       {{(double)comm_rank + .5, .5, .5}}},
+                  } ),
+                  {0, 0}, {0, 1, 2}, {comm_size - 1 - comm_rank, comm_rank},
+                  success, out );
 
     checkResults( tree, makeNearestQueries<DeviceType>( {} ), {}, {0}, {},
                   success, out );
@@ -351,7 +354,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DistributedSearchTree, boost_comparison,
             double const x = std::get<0>( point );
             double const y = std::get<1>( point );
             double const z = std::get<2>( point );
-            bounding_boxes_host[i / comm_size] = {x, x, y, y, z, z};
+            bounding_boxes_host[i / comm_size] = {{{x, y, z}}, {{x, y, z}}};
         }
     }
 


### PR DESCRIPTION
To construct a unit box we use to have to do
```C++
Box box = {{0., 1., 0., 1., 0., 1.}};
```

This PR changes it to
```C++
Box box = {{{0., 0., 0.}}, {{ 1., 1., 1.}}};
```