### PR TITLE
Compile boost with rpath support

### DIFF
--- a/docker/.vimrc
+++ b/docker/.vimrc
@@ -1,3 +1,5 @@
+set encoding=utf-8
+
 set nocompatible              " be iMproved, required
 filetype off                  " required
 

--- a/docker/.vimrc
+++ b/docker/.vimrc
@@ -46,3 +46,4 @@ autocmd BufWinEnter * match ExtraWhitespace /\s\+$/
 " Configure clang-format
 let g:clang_format#command = "clang-format-5.0"
 let g:clang_format#detect_style_file = 1
+let g:clang_format#auto_format = 1

--- a/docker/Dockerfile_stack
+++ b/docker/Dockerfile_stack
@@ -121,10 +121,12 @@ RUN export BOOST_URL=https://dl.bintray.com/boostorg/release/1.65.1/source/boost
         --prefix=${BOOST_INSTALL_DIR} \
         && \
     echo "using mpi ;" >> project-config.jam && \
-    ./b2 install -j${NPROC} \
+    ./b2 -j${NPROC} \
+        --build-dir=${BOOST_BUILD_DIR} \
+        hardcode-dll-paths=true dll-path=${BOOST_INSTALL_DIR}/lib \
         link=shared \
         variant=release \
-        --build-dir=${BOOST_BUILD_DIR} \
+        install \
         && \
     rm -rf ${BOOST_ARCHIVE} && \
     rm -rf ${BOOST_BUILD_DIR} && \

--- a/docker/README.md
+++ b/docker/README.md
@@ -13,10 +13,15 @@ COMMENT: decided to keep PETSc/libMesh for now and updated them to their recomme
 - Use ClangFormat version 5.0 to enforce code formatting style (instead of version 4.0)
 
 ## 17.10.1 (October 16th, 2017)
-### CHange
+### Change
 - Add Open MPI 2.1.2 to replace version 1.10.1 from the system package manager
 COMMENT: intent is to be able to take advantage of MPI ABI compatibility on HPC ressources
 ### TPLs removal
 - Remove PETSc and libMesh
 ## TODO
 Clear things up about install prefix of LLVM OpenMP
+
+## 17.11.0 (November 16th, 2017)
+### Change
+- Fix Boost installation to support RPATH
+- Enable auto formatting for Vim within the dev container


### PR DESCRIPTION
By default, Boost does not support rpath. This is a problem if a boost library
depends on another one (eg. boost.mpi depends on boost.serialization) and boost
lib is not in the LD_LIBRARY_PATH.