### PR TITLE
Mesh Free Problem Generator

### DIFF
--- a/packages/Meshfree/cmake/DataTransferKitMeshfree_config.h.in
+++ b/packages/Meshfree/cmake/DataTransferKitMeshfree_config.h.in
@@ -1,2 +1,4 @@
 /* Define if user requested explicit instantiation of classes into libtpetra */
 #cmakedefine HAVE_DATATRANSFERKIT_EXPLICIT_INSTANTIATION
+
+#cmakedefine HAVE_DTK_NETCDF

--- a/packages/Meshfree/cmake/Dependencies.cmake
+++ b/packages/Meshfree/cmake/Dependencies.cmake
@@ -1,10 +1,12 @@
 TRIBITS_PACKAGE_DEFINE_DEPENDENCIES(
   LIB_REQUIRED_PACKAGES
   DataTransferKitUtils
+  DataTransferKitInterface
   DataTransferKitSearch
   Kokkos
   Teuchos
   Tpetra
   TEST_OPTIONAL_TPLS
   BoostOrg
+  Netcdf
   )

--- a/packages/Meshfree/src/CMakeLists.txt
+++ b/packages/Meshfree/src/CMakeLists.txt
@@ -206,6 +206,12 @@ ENDFUNCTION(DTK_PROCESS_ALL_N_TEMPLATES)
 # A) Package-specific configuration options
 #
 
+# Check for netcdf so we can use it in the tests.
+IF( HAVE_DATATRANSFERKITMESHFREE_NETCDF )
+  GLOBAL_SET( HAVE_DTK_NETCDF TRUE )
+ENDIF()
+
+
 TRIBITS_CONFIGURE_FILE(${PACKAGE_NAME}_config.h)
 
 #
@@ -238,7 +244,6 @@ IF (${PACKAGE_NAME}_ENABLE_EXPLICIT_INSTANTIATION)
   LIST(APPEND SOURCES ${NEARESTNEIGHBOROPERATOR_OUTPUT_FILES})
 
 ENDIF()
-
 
 #
 # C) Define the targets for package's library(s)

--- a/packages/Meshfree/test/CMakeLists.txt
+++ b/packages/Meshfree/test/CMakeLists.txt
@@ -39,3 +39,22 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   STANDARD_PASS_OUTPUT
   FAIL_REGULAR_EXPRESSION "data race;leak;runtime error"
   )
+
+IF (HAVE_DTK_NETCDF)
+  TRIBITS_ADD_EXECUTABLE_AND_TEST(
+    NearestNeighborExodusGenerator
+    SOURCES tstNearestNeighborExodusGenerator.cpp unit_test_main.cpp
+    COMM serial mpi
+    STANDARD_PASS_OUTPUT
+    FAIL_REGULAR_EXPRESSION "data race;leak;runtime error"
+    ENVIRONMENT CUDA_LAUNCH_BLOCKING=1
+    )
+
+  TRIBITS_COPY_FILES_TO_BINARY_DIR(
+    ExodusGeneratorFiles
+    SOURCE_FILES coarse_sphere.exo fine_sphere.exo
+    SOURCE_DIR ${DTK_DATA_DIR}/exodus/
+    DEST_DIR ${CMAKE_CURRENT_BINARY_DIR}
+    EXEDEPS NearestNeighborExodusGenerator
+    )
+ENDIF()

--- a/packages/Meshfree/test/PointCloudProblemGenerator/ExodusProblemGenerator.hpp
+++ b/packages/Meshfree/test/PointCloudProblemGenerator/ExodusProblemGenerator.hpp
@@ -1,0 +1,162 @@
+/****************************************************************************
+ * Copyright (c) 2012-2018 by the DataTransferKit authors                   *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the DataTransferKit library. DataTransferKit is     *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#ifndef DTK_EXODUSPROBLEMGENERATOR_HPP
+#define DTK_EXODUSPROBLEMGENERATOR_HPP
+
+#include "DTK_ConfigDefs.hpp"
+#include "DTK_Types.h"
+#include "PointCloudProblemGenerator.hpp"
+
+#include <Kokkos_View.hpp>
+
+#include <Teuchos_Comm.hpp>
+#include <Teuchos_RCP.hpp>
+
+#include <functional>
+#include <string>
+
+namespace DataTransferKit
+{
+//---------------------------------------------------------------------------//
+// Generate point cloud problem by reading exodus files.
+//
+// The generator reads exodus files and extracts the node coordinates and
+// partitions them across the given communicator.
+//
+// Source files are partitioned in x where each rank gets an even subdivision
+// of space in the x dimension:
+//
+// |          | o        |        |                      |
+// |  o     o |       o  |  o  o  |  o o       o         |
+// |    o     |  o     o |      o |        o      o      |
+// |   o   o  |     o    | o      |     o    o  o        |
+// |          |          |    o   |                      |
+// | rank = 0 | rank = 1 | ...... | rank = comm_size - 1 |
+//
+// Target files are partitioned in y where each rank gets an even subdivision
+// of space in the y dimension.
+//
+// ---------------------------------
+//             o o   o     o
+// rank = 0       o     o   o
+//              o   o   o o
+// ---------------------------------
+//               o   o    o   o
+// rank = 1    o  o   o o    o
+//              o    o oo    o o
+// ---------------------------------
+//               oo  o o o o  oo
+// ....       o   o  o  o  o  o
+//              o  oo  o o oo o o
+// ---------------------------------
+//                   o o o oo
+// rank =             o   o o o
+//   comm_size - 1   o   oo  ooooo
+//
+// ---------------------------------
+//
+// In the uniquely owned case, mesh nodes are given one single, unique
+// destination in the partitioning.
+//
+// In the ghosted case, mesh elements are given one unique destination and
+// all nodes belonging to that element are sent to that
+// destination. Therefore, nodes owned by multiple elements with different
+// destinations will be sent to multiple ranks and thus ghosted.
+//
+template <class Scalar, class SourceDevice, class TargetDevice>
+class ExodusProblemGenerator
+    : public PointCloudProblemGenerator<Scalar, SourceDevice, TargetDevice>
+{
+  public:
+    // Constructor.
+    ExodusProblemGenerator( const Teuchos::RCP<const Teuchos::Comm<int>> &comm,
+                            const std::string &source_exodus_file,
+                            const std::string &target_exodus_file );
+
+    // Create a problem where all points are uniquely owned (i.e. no
+    // ghosting). Both source and target fields have one component and are
+    // initialized to zero.
+    void createUniquelyOwnedProblem(
+        Kokkos::View<Coordinate **, Kokkos::LayoutLeft, SourceDevice>
+            &src_coords,
+        Kokkos::View<Scalar **, Kokkos::LayoutLeft, SourceDevice> &src_field,
+        Kokkos::View<Coordinate **, Kokkos::LayoutLeft, TargetDevice>
+            &tgt_coords,
+        Kokkos::View<Scalar **, Kokkos::LayoutLeft, TargetDevice> &tgt_field )
+        override;
+
+    // Create a general problem where points may exist on multiple
+    // processors. Both source and target fields have 1 component and are
+    // initialized to zero.
+    void createGhostedProblem(
+        Kokkos::View<Coordinate **, Kokkos::LayoutLeft, SourceDevice>
+            &src_coords,
+        Kokkos::View<GlobalOrdinal *, Kokkos::LayoutLeft, SourceDevice>
+            &src_gids,
+        Kokkos::View<Scalar **, Kokkos::LayoutLeft, SourceDevice> &src_field,
+        Kokkos::View<Coordinate **, Kokkos::LayoutLeft, TargetDevice>
+            &tgt_coords,
+        Kokkos::View<GlobalOrdinal *, Kokkos::LayoutLeft, TargetDevice>
+            &tgt_gids,
+        Kokkos::View<Scalar **, Kokkos::LayoutLeft, TargetDevice> &tgt_field )
+        override;
+
+  private:
+    // Get host views of node data from file.
+    void getNodeDataFromFile( const std::string &exodus_file,
+                              Kokkos::View<Coordinate **, Kokkos::LayoutLeft,
+                                           Kokkos::Serial> &host_coords,
+                              Kokkos::View<GlobalOrdinal *, Kokkos::LayoutLeft,
+                                           Kokkos::Serial> &host_gids );
+
+    // Partition a point cloud in a given dimension with one-to-one mapping.
+    template <class Device>
+    void partitionUniquelyOwned( const int dim, const std::string &exodus_file,
+                                 Kokkos::View<Coordinate **, Kokkos::LayoutLeft,
+                                              Device> &device_coords );
+
+    // Partition a point cloud in a given dimension with ghosted connectivity
+    // mapping.
+    template <class Device>
+    void partitionGhostedConnectivity(
+        const int dim, const std::string &exodus_file,
+        Kokkos::View<Coordinate **, Kokkos::LayoutLeft, Device> &device_coords,
+        Kokkos::View<GlobalOrdinal *, Kokkos::LayoutLeft, Device>
+            &device_gids );
+
+    // Given a netcdf handle and a dimension name get the length of that
+    // dimension.
+    size_t getNetcdfDimensionLength( const int nc_id,
+                                     const std::string &dim_name );
+
+  private:
+    // Comm
+    Teuchos::RCP<const Teuchos::Comm<int>> _comm;
+
+    // Filenames
+    std::string _src_exodus_file;
+    std::string _tgt_exodus_file;
+};
+
+//---------------------------------------------------------------------------//
+
+} // end namespace DataTransferKit
+
+//---------------------------------------------------------------------------//
+// Template includes
+//---------------------------------------------------------------------------//
+
+#include "ExodusProblemGenerator_def.hpp"
+
+//---------------------------------------------------------------------------//
+
+#endif // end  DTK_EXODUSPROBLEMGENERATOR_HPP

--- a/packages/Meshfree/test/PointCloudProblemGenerator/ExodusProblemGenerator_def.hpp
+++ b/packages/Meshfree/test/PointCloudProblemGenerator/ExodusProblemGenerator_def.hpp
@@ -1,0 +1,409 @@
+/****************************************************************************
+ * Copyright (c) 2012-2018 by the DataTransferKit authors                   *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the DataTransferKit library. DataTransferKit is     *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#ifndef DTK_EXODUSPROBLEMGENERATOR_DEF_HPP
+#define DTK_EXODUSPROBLEMGENERATOR_DEF_HPP
+
+#include <DTK_DetailsDistributedSearchTreeImpl.hpp>
+#include <DTK_DetailsUtils.hpp>
+
+#include <netcdf.h>
+
+#include <Teuchos_Array.hpp>
+
+#include <Tpetra_Distributor.hpp>
+
+#include <DTK_DBC.hpp>
+
+#include <fstream>
+#include <iostream>
+#include <limits>
+#include <set>
+
+namespace DataTransferKit
+{
+//---------------------------------------------------------------------------//
+template <class Scalar, class SourceDevice, class TargetDevice>
+ExodusProblemGenerator<Scalar, SourceDevice, TargetDevice>::
+    ExodusProblemGenerator( const Teuchos::RCP<const Teuchos::Comm<int>> &comm,
+                            const std::string &source_exodus_file,
+                            const std::string &target_exodus_file )
+    : _comm( comm )
+    , _src_exodus_file( source_exodus_file )
+    , _tgt_exodus_file( target_exodus_file )
+{ /* ... */
+}
+
+//---------------------------------------------------------------------------//
+// Create a problem where all points are uniquely owned (i.e. no ghosting)
+template <class Scalar, class SourceDevice, class TargetDevice>
+void ExodusProblemGenerator<Scalar, SourceDevice, TargetDevice>::
+    createUniquelyOwnedProblem(
+        Kokkos::View<Coordinate **, Kokkos::LayoutLeft, SourceDevice>
+            &src_coords,
+        Kokkos::View<Scalar **, Kokkos::LayoutLeft, SourceDevice> &src_field,
+        Kokkos::View<Coordinate **, Kokkos::LayoutLeft, TargetDevice>
+            &tgt_coords,
+        Kokkos::View<Scalar **, Kokkos::LayoutLeft, TargetDevice> &tgt_field )
+{
+    // Partition the source coordinates in the x direction.
+    partitionUniquelyOwned( 0, _src_exodus_file, src_coords );
+
+    // Partition the target coordinates in the y direction.
+    partitionUniquelyOwned( 1, _tgt_exodus_file, tgt_coords );
+
+    // Allocate the fields and initialize to zero.
+    auto num_src = src_coords.extent( 0 );
+    src_field = Kokkos::View<Scalar **, Kokkos::LayoutLeft, SourceDevice>(
+        "src_field", num_src, 1 );
+    Kokkos::deep_copy( src_field, 0.0 );
+    auto num_tgt = tgt_coords.extent( 0 );
+    tgt_field = Kokkos::View<Scalar **, Kokkos::LayoutLeft, TargetDevice>(
+        "tgt_field", num_tgt, 1 );
+    Kokkos::deep_copy( tgt_field, 0.0 );
+}
+
+//---------------------------------------------------------------------------//
+// Create a general problem where points may exist on multiple
+// processors. Points have a unique global id.
+template <class Scalar, class SourceDevice, class TargetDevice>
+void ExodusProblemGenerator<Scalar, SourceDevice, TargetDevice>::
+    createGhostedProblem(
+        Kokkos::View<Coordinate **, Kokkos::LayoutLeft, SourceDevice>
+            &src_coords,
+        Kokkos::View<GlobalOrdinal *, Kokkos::LayoutLeft, SourceDevice>
+            &src_gids,
+        Kokkos::View<Scalar **, Kokkos::LayoutLeft, SourceDevice> &src_field,
+        Kokkos::View<Coordinate **, Kokkos::LayoutLeft, TargetDevice>
+            &tgt_coords,
+        Kokkos::View<GlobalOrdinal *, Kokkos::LayoutLeft, TargetDevice>
+            &tgt_gids,
+        Kokkos::View<Scalar **, Kokkos::LayoutLeft, TargetDevice> &tgt_field )
+{
+    // Partition the source coordinates in the x direction.
+    partitionGhostedConnectivity( 0, _src_exodus_file, src_coords, src_gids );
+
+    // Partition the target coordinates in the y direction.
+    partitionGhostedConnectivity( 1, _tgt_exodus_file, tgt_coords, tgt_gids );
+
+    // Allocate the fields and initialize to zero.
+    auto num_src = src_coords.extent( 0 );
+    src_field = Kokkos::View<Scalar **, Kokkos::LayoutLeft, SourceDevice>(
+        "src_field", num_src, 1 );
+    Kokkos::deep_copy( src_field, 0.0 );
+    auto num_tgt = tgt_coords.extent( 0 );
+    tgt_field = Kokkos::View<Scalar **, Kokkos::LayoutLeft, TargetDevice>(
+        "tgt_field", num_tgt, 1 );
+    Kokkos::deep_copy( tgt_field, 0.0 );
+}
+
+//---------------------------------------------------------------------------//
+// Read coordinate data from file and generate unqiue global ids for the
+// points.
+template <class Scalar, class SourceDevice, class TargetDevice>
+void ExodusProblemGenerator<Scalar, SourceDevice, TargetDevice>::
+    getNodeDataFromFile( const std::string &exodus_file,
+                         Kokkos::View<Coordinate **, Kokkos::LayoutLeft,
+                                      Kokkos::Serial> &host_coords,
+                         Kokkos::View<GlobalOrdinal *, Kokkos::LayoutLeft,
+                                      Kokkos::Serial> &host_gids )
+{
+    // Only populate views on rank 0.
+    if ( 0 == _comm->getRank() )
+    {
+        // Open the exodus file.
+        int nc_id;
+        DTK_CHECK_ERROR_CODE(
+            nc_open( exodus_file.c_str(), NC_NOWRITE, &nc_id ) );
+
+        // Get the number of nodes.
+        auto num_nodes = getNetcdfDimensionLength( nc_id, "num_nodes" );
+
+        // Allocate the coordinate and global id arrray.
+        host_coords =
+            Kokkos::View<Coordinate **, Kokkos::LayoutLeft, Kokkos::Serial>(
+                "host_coords", num_nodes, 3 );
+        host_gids =
+            Kokkos::View<GlobalOrdinal *, Kokkos::LayoutLeft, Kokkos::Serial>(
+                "host_gids", num_nodes );
+
+        // Get the coordinate variable ids.
+        int coord_var_id_x;
+        DTK_CHECK_ERROR_CODE(
+            nc_inq_varid( nc_id, "coordx", &coord_var_id_x ) );
+        int coord_var_id_y;
+        DTK_CHECK_ERROR_CODE(
+            nc_inq_varid( nc_id, "coordy", &coord_var_id_y ) );
+        int coord_var_id_z;
+        DTK_CHECK_ERROR_CODE(
+            nc_inq_varid( nc_id, "coordz", &coord_var_id_z ) );
+
+        // Get the coordinates.
+        DTK_CHECK_ERROR_CODE(
+            nc_get_var_double( nc_id, coord_var_id_x, host_coords.data() ) );
+        DTK_CHECK_ERROR_CODE( nc_get_var_double(
+            nc_id, coord_var_id_y, host_coords.data() + num_nodes ) );
+        DTK_CHECK_ERROR_CODE( nc_get_var_double(
+            nc_id, coord_var_id_z, host_coords.data() + 2 * num_nodes ) );
+
+        // Close the exodus file.
+        DTK_CHECK_ERROR_CODE( nc_close( nc_id ) );
+
+        // Create unique global ids starting at 1.
+        for ( size_t i = 0; i < num_nodes; ++i )
+            host_gids( i ) = i + 1;
+    }
+    else
+    {
+        host_coords =
+            Kokkos::View<Coordinate **, Kokkos::LayoutLeft, Kokkos::Serial>(
+                "host_coords", 0, 3 );
+        host_gids =
+            Kokkos::View<GlobalOrdinal *, Kokkos::LayoutLeft, Kokkos::Serial>(
+                "host_gids", 0 );
+    }
+}
+
+//---------------------------------------------------------------------------//
+// Partition a point cloud in a given dimension with one-to-one mapping.
+template <class Scalar, class SourceDevice, class TargetDevice>
+template <class Device>
+void ExodusProblemGenerator<Scalar, SourceDevice, TargetDevice>::
+    partitionUniquelyOwned(
+        const int dim, const std::string &exodus_file,
+        Kokkos::View<Coordinate **, Kokkos::LayoutLeft, Device> &device_coords )
+{
+    // Get the node data.
+    Kokkos::View<Coordinate **, Kokkos::LayoutLeft, Kokkos::Serial>
+        export_coords;
+    Kokkos::View<GlobalOrdinal *, Kokkos::LayoutLeft, Kokkos::Serial>
+        export_gids;
+    getNodeDataFromFile( exodus_file, export_coords, export_gids );
+
+    // Build a communication plan. Nodes are partitioned into equal spatial
+    // bins in the given dimension. There is one spatial bin for each comm
+    // rank.
+    int num_node_export = export_coords.extent( 0 );
+    Teuchos::Array<int> export_ranks( num_node_export );
+    if ( 0 < num_node_export )
+    {
+        // Figure out the min and max coordinates in the given dimension.
+        Coordinate dim_max, dim_min;
+        std::tie( dim_min, dim_max ) =
+            minMax( Kokkos::subview( export_coords, Kokkos::ALL, dim ) );
+
+        double dim_frac = 0.0;
+        for ( int n = 0; n < num_node_export; ++n )
+        {
+            dim_frac =
+                ( export_coords( n, dim ) - dim_min ) / ( dim_max - dim_min );
+            export_ranks[n] = ( dim_frac < 1.0 )
+                                  ? std::floor( dim_frac * _comm->getSize() )
+                                  : _comm->getSize() - 1;
+        }
+    }
+    Tpetra::Distributor distributor( _comm );
+    int num_node_import = distributor.createFromSends( export_ranks() );
+
+    // Send the coordinates to their new owning rank.
+    Kokkos::View<Coordinate **, Kokkos::LayoutLeft, Kokkos::Serial>
+        import_coords( "import_coords", num_node_import, 3 );
+    DistributedSearchTreeImpl<Device>::sendAcrossNetwork(
+        distributor, export_coords, import_coords );
+
+    // Move the coordinates to the device.
+    device_coords = Kokkos::View<Coordinate **, Kokkos::LayoutLeft, Device>(
+        "device_coords", num_node_import, 3 );
+    Kokkos::deep_copy( device_coords, import_coords );
+}
+
+//---------------------------------------------------------------------------//
+// Partition a point cloud in a given dimension with ghosted connectivity
+// mapping.
+template <class Scalar, class SourceDevice, class TargetDevice>
+template <class Device>
+void ExodusProblemGenerator<Scalar, SourceDevice, TargetDevice>::
+    partitionGhostedConnectivity(
+        const int dim, const std::string &exodus_file,
+        Kokkos::View<Coordinate **, Kokkos::LayoutLeft, Device> &device_coords,
+        Kokkos::View<GlobalOrdinal *, Kokkos::LayoutLeft, Device> &device_gids )
+{
+    // Get the node data.
+    Kokkos::View<Coordinate **, Kokkos::LayoutLeft, Kokkos::Serial> host_coords;
+    Kokkos::View<GlobalOrdinal *, Kokkos::LayoutLeft, Kokkos::Serial> host_gids;
+    getNodeDataFromFile( exodus_file, host_coords, host_gids );
+
+    // Partition based on the dimension coordinate of the first node in each
+    // cell. All nodes belonging to that cell will be sent to that rank to
+    // simulate an element-based partitioning. This means nodes belonging to
+    // elements on partition boundaries will exist on multiple ranks.
+    Teuchos::Array<GlobalOrdinal> export_gids( 0 );
+    Teuchos::Array<int> export_ranks( 0 );
+    Teuchos::Array<Coordinate> export_coords( 0 );
+    std::set<std::pair<int, GlobalOrdinal>> unique_exports;
+
+    // Read connectivity data on rank 0.
+    if ( 0 == _comm->getRank() )
+    {
+        // Figure out the min and max coordinates.
+        Coordinate dim_max, dim_min;
+        std::tie( dim_min, dim_max ) =
+            minMax( Kokkos::subview( host_coords, Kokkos::ALL, dim ) );
+
+        // Open the exodus file.
+        int nc_id;
+        DTK_CHECK_ERROR_CODE(
+            nc_open( exodus_file.c_str(), NC_NOWRITE, &nc_id ) );
+
+        // Get the number of element blocks.
+        auto num_el_blks = getNetcdfDimensionLength( nc_id, "num_el_blk" );
+
+        // Loop over blocks. Block ids start at 1.
+        GlobalOrdinal node_gid;
+        double x_frac = 0.0;
+        int send_rank;
+        for ( size_t b = 1; b < num_el_blks + 1; ++b )
+        {
+            // Get the number of elements in the block.
+            std::string num_elem_dim_name =
+                "num_el_in_blk" + std::to_string( b );
+            auto num_elem =
+                getNetcdfDimensionLength( nc_id, num_elem_dim_name );
+
+            // Get the number of nodes per element in the block.
+            std::string node_per_elem_dim_name =
+                "num_nod_per_el" + std::to_string( b );
+            auto node_per_elem =
+                getNetcdfDimensionLength( nc_id, node_per_elem_dim_name );
+
+            // Allocate a temporary view to load the block connectivity data.
+            Kokkos::View<int **, Kokkos::LayoutLeft, Kokkos::Serial>
+                connectivity( "connectivity", node_per_elem, num_elem );
+
+            // Get the connectivity.
+            std::string conn_var_name = "connect" + std::to_string( b );
+            int conn_var_id;
+            DTK_CHECK_ERROR_CODE(
+                nc_inq_varid( nc_id, conn_var_name.c_str(), &conn_var_id ) );
+            DTK_CHECK_ERROR_CODE(
+                nc_get_var_int( nc_id, conn_var_id, connectivity.data() ) );
+
+            // Loop over elements in the block
+            for ( size_t e = 0; e < num_elem; ++e )
+            {
+                // Get the first element node - connectivity indices start at 1.
+                node_gid = connectivity( 0, e );
+
+                // Partition in the given dimension. Each comm rank is
+                // assigned a spatial bin along the given dimension. All
+                // elements that have their first node in this spatial bin are
+                // assigned to that comm rank.
+                x_frac = ( host_coords( node_gid - 1, dim ) - dim_min ) /
+                         ( dim_max - dim_min );
+                send_rank = ( x_frac < 1.0 )
+                                ? std::floor( x_frac * _comm->getSize() )
+                                : _comm->getSize() - 1;
+
+                // Only add this node/rank combo if we haven't already. This
+                // keeps us from sending the same node to the same rank more
+                // than once.
+                bool inserted = false;
+                std::tie( std::ignore, inserted ) = unique_exports.insert(
+                    std::make_pair( send_rank, node_gid ) );
+                if ( inserted )
+                {
+                    export_gids.push_back( node_gid );
+                    export_ranks.push_back( send_rank );
+                    export_coords.push_back( host_coords( node_gid - 1, 0 ) );
+                    export_coords.push_back( host_coords( node_gid - 1, 1 ) );
+                    export_coords.push_back( host_coords( node_gid - 1, 2 ) );
+                }
+
+                // Add the rest of the cell nodes to that sending rank.
+                for ( size_t n = 1; n < node_per_elem; ++n )
+                {
+                    // Get the next node id.
+                    node_gid = connectivity( n, e );
+
+                    // Only add this node/rank combo if we haven't
+                    // already. This keeps us from sending the same node to
+                    // the same rank more than once.
+                    if ( !unique_exports.count(
+                             std::make_pair( send_rank, node_gid ) ) )
+                    {
+                        export_gids.push_back( node_gid );
+                        export_ranks.push_back( send_rank );
+                        export_coords.push_back(
+                            host_coords( node_gid - 1, 0 ) );
+                        export_coords.push_back(
+                            host_coords( node_gid - 1, 1 ) );
+                        export_coords.push_back(
+                            host_coords( node_gid - 1, 2 ) );
+                        unique_exports.insert(
+                            std::make_pair( send_rank, node_gid ) );
+                    }
+                }
+            }
+        }
+
+        // Close the exodus file.
+        DTK_CHECK_ERROR_CODE( nc_close( nc_id ) );
+    }
+
+    // Build a communication plan for the sources.
+    Tpetra::Distributor distributor( _comm );
+    int num_import = distributor.createFromSends( export_ranks() );
+
+    // Redistribute the sources.
+    Teuchos::Array<GlobalOrdinal> import_gids( num_import );
+    Teuchos::Array<Coordinate> import_coords( 3 * num_import );
+    distributor.doPostsAndWaits( export_gids().getConst(), 1, import_gids() );
+    distributor.doPostsAndWaits( export_coords().getConst(), 3,
+                                 import_coords() );
+
+    // Move the sources to the device.
+    Kokkos::View<Coordinate *, Kokkos::Serial> host_import_gids(
+        "host_import_gids", num_import );
+    Kokkos::View<Coordinate **, Kokkos::LayoutLeft, Kokkos::Serial>
+        host_import_coords( "host_import_coords", num_import, 3 );
+    for ( int n = 0; n < num_import; ++n )
+    {
+        host_import_gids( n ) = import_gids[n];
+        for ( int d = 0; d < 3; ++d )
+            host_import_coords( n, d ) = import_coords[3 * n + d];
+    }
+    device_coords = Kokkos::View<Coordinate **, Kokkos::LayoutLeft, Device>(
+        "device_coords", num_import, 3 );
+    device_gids = Kokkos::View<GlobalOrdinal *, Kokkos::LayoutLeft, Device>(
+        "device_gids", num_import );
+    Kokkos::deep_copy( device_coords, host_import_coords );
+    Kokkos::deep_copy( device_gids, host_import_gids );
+}
+
+//---------------------------------------------------------------------------//
+// Given a netcdf handle and a dimension name get the length of that
+// dimension.
+template <class Scalar, class SourceDevice, class TargetDevice>
+size_t ExodusProblemGenerator<Scalar, SourceDevice, TargetDevice>::
+    getNetcdfDimensionLength( const int nc_id, const std::string &dim_name )
+{
+    int dim_id;
+    DTK_CHECK_ERROR_CODE( nc_inq_dimid( nc_id, dim_name.c_str(), &dim_id ) );
+    size_t dim_len;
+    DTK_CHECK_ERROR_CODE( nc_inq_dimlen( nc_id, dim_id, &dim_len ) );
+    return dim_len;
+}
+
+//---------------------------------------------------------------------------//
+
+} // end namespace DataTransferKit
+
+#endif // end  DTK_EXODUSPROBLEMGENERATOR_DEF_HPP

--- a/packages/Meshfree/test/PointCloudProblemGenerator/PointCloudProblemGenerator.hpp
+++ b/packages/Meshfree/test/PointCloudProblemGenerator/PointCloudProblemGenerator.hpp
@@ -1,0 +1,104 @@
+/****************************************************************************
+ * Copyright (c) 2012-2018 by the DataTransferKit authors                   *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the DataTransferKit library. DataTransferKit is     *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#ifndef DTK_POINTCLOUDPROBLEMGENERATOR_HPP
+#define DTK_POINTCLOUDPROBLEMGENERATOR_HPP
+
+#include "DTK_ConfigDefs.hpp"
+#include "DTK_Types.h"
+
+#include <Kokkos_View.hpp>
+
+namespace DataTransferKit
+{
+//---------------------------------------------------------------------------//
+template <class Scalar, class SourceDevice, class TargetDevice>
+class PointCloudProblemGenerator
+{
+  public:
+    virtual ~PointCloudProblemGenerator() = default;
+
+    /*!
+     * \brief Create a problem where all points are uniquely owned (i.e. no
+     * ghosting)
+     *
+     * \param src_coords Coordinates of the source points. Layout:
+     * (point,dim).
+     *
+     * \param src_field Multi-component field defined on the source points. At
+     * a minimum will be allocated and filled with zeros. Some implementations
+     * may choose to fill this view with non-zero data. Layout: (point,comp).
+     *
+     * \param tgt_coords Coordinates of the target points. Layout:
+     * (point,dim).
+     *
+     * \param tgt_field Multi-component field defined on the target points. At
+     * a minimum will be allocated and filled with zeros. Some implementations
+     * may choose to fill this view with non-zero data corresponding to the
+     * expected result of transferring the src_field from the source points to
+     * the target points. Layout: (point,comp).
+     */
+    virtual void createUniquelyOwnedProblem(
+        Kokkos::View<Coordinate **, Kokkos::LayoutLeft, SourceDevice>
+            &src_coords,
+        Kokkos::View<Scalar **, Kokkos::LayoutLeft, SourceDevice> &src_field,
+        Kokkos::View<Coordinate **, Kokkos::LayoutLeft, TargetDevice>
+            &tgt_coords,
+        Kokkos::View<Scalar **, Kokkos::LayoutLeft, TargetDevice>
+            &tgt_field ) = 0;
+
+    /*!
+     * \brief Create a general problem where points may exist on multiple
+     * processors. Points have a unique global id.
+     *
+     * \param src_coords Coordinates of the source points. Layout:
+     * (point,dim).
+     *
+     * \param src_gids Global ids of the source points. A global id will
+     * appear only once on a given processor but may appear on multiple
+     * processors. Layout: (point).
+     *
+     * \param src_field Multi-component field defined on the source points. At
+     * a minimum will be allocated and filled with zeros. Some implementations
+     * may choose to fill this view with non-zero data. Layout: (point,comp).
+     *
+     * \param tgt_coords Coordinates of the target points. Layout:
+     * (point,dim).
+     *
+     * \param tgt_gids Global ids of the target points. A global id will
+     * appear only once on a given processor but may appear on multiple
+     * processors. Layout: (point).
+     *
+     * \param tgt_field Multi-component field defined on the target points. At
+     * a minimum will be allocated and filled with zeros. Some implementations
+     * may choose to fill this view with non-zero data corresponding to the
+     * expected result of transferring the src_field from the source points to
+     * the target points. Layout: (point,comp).
+     */
+    virtual void createGhostedProblem(
+        Kokkos::View<Coordinate **, Kokkos::LayoutLeft, SourceDevice>
+            &src_coords,
+        Kokkos::View<GlobalOrdinal *, Kokkos::LayoutLeft, SourceDevice>
+            &src_gids,
+        Kokkos::View<Scalar **, Kokkos::LayoutLeft, SourceDevice> &src_field,
+        Kokkos::View<Coordinate **, Kokkos::LayoutLeft, TargetDevice>
+            &tgt_coords,
+        Kokkos::View<GlobalOrdinal *, Kokkos::LayoutLeft, TargetDevice>
+            &tgt_gids,
+        Kokkos::View<Scalar **, Kokkos::LayoutLeft, TargetDevice>
+            &tgt_field ) = 0;
+};
+
+//---------------------------------------------------------------------------//
+
+} // end namespace DataTransferKit
+
+#endif // end  DTK_POINTCLOUDPROBLEMGENERATOR_HPP

--- a/packages/Meshfree/test/tstNearestNeighborExodusGenerator.cpp
+++ b/packages/Meshfree/test/tstNearestNeighborExodusGenerator.cpp
@@ -1,0 +1,407 @@
+/****************************************************************************
+ * Copyright (c) 2012-2018 by the DataTransferKit authors                   *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the DataTransferKit library. DataTransferKit is     *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#include "DTK_ConfigDefs.hpp"
+#include "DTK_Types.h"
+
+#include "PointCloudProblemGenerator/ExodusProblemGenerator.hpp"
+#include "PointCloudProblemGenerator/PointCloudProblemGenerator.hpp"
+#include <DTK_DetailsDistributedSearchTreeImpl.hpp>
+#include <DTK_NearestNeighborOperator.hpp>
+#include <DTK_ParallelTraits.hpp>
+
+#include <Kokkos_View.hpp>
+
+#include <Teuchos_Array.hpp>
+#include <Teuchos_CommHelpers.hpp>
+#include <Teuchos_DefaultComm.hpp>
+#include <Teuchos_RCP.hpp>
+#include <Teuchos_UnitTestHarness.hpp>
+
+#include <Tpetra_Export.hpp>
+#include <Tpetra_Import.hpp>
+#include <Tpetra_Map.hpp>
+#include <Tpetra_Vector.hpp>
+
+#include <cmath>
+#include <limits>
+#include <string>
+
+//---------------------------------------------------------------------------//
+// Brute-force calculate the nearest neighbors
+template <class... CoordViewProperties>
+void computeNeighborsBruteForce(
+    const Teuchos::RCP<const Teuchos::Comm<int>> &comm,
+    const Kokkos::View<DataTransferKit::Coordinate **, CoordViewProperties...>
+        &src_coords,
+    const Kokkos::View<DataTransferKit::Coordinate **, CoordViewProperties...>
+        &tgt_coords,
+    Kokkos::View<DataTransferKit::Coordinate **, Kokkos::LayoutLeft,
+                 Kokkos::Serial> &src_nearest_coords )
+{
+    // Copy coordinates to the host.
+    size_t num_src = src_coords.extent( 0 );
+    size_t num_tgt = tgt_coords.extent( 0 );
+    size_t space_dim = src_coords.extent( 1 );
+    auto host_sources = Kokkos::create_mirror_view( src_coords );
+    Kokkos::deep_copy( host_sources, src_coords );
+    auto host_targets = Kokkos::create_mirror_view( tgt_coords );
+    Kokkos::deep_copy( host_targets, tgt_coords );
+
+    // Get the number of source points on each rank.
+    int comm_size = comm->getSize();
+    int comm_rank = comm->getRank();
+    Teuchos::Array<size_t> rank_num_src( comm_size, 0 );
+    rank_num_src[comm_rank] = num_src;
+    Teuchos::Array<size_t> local_sizes( comm_size, 0 );
+    Teuchos::reduceAll( *comm, Teuchos::REDUCE_SUM, comm_size,
+                        rank_num_src.getRawPtr(), local_sizes.getRawPtr() );
+
+    // Compute the global number of source points.
+    size_t num_global = 0;
+    for ( const auto &l : local_sizes )
+        num_global += l;
+
+    // Calculate rank offsets.
+    Teuchos::Array<size_t> offsets( comm_size, 0 );
+    for ( int i = 1; i < comm_size; ++i )
+    {
+        offsets[i] = offsets[i - 1] + local_sizes[i - 1];
+    }
+
+    // Allocate a send and receive view for creating a global list of source
+    // coordinates.
+    Kokkos::View<DataTransferKit::Coordinate **, Kokkos::LayoutLeft,
+                 Kokkos::Serial>
+        rank_src_coords( "rank_src_coords", num_global, space_dim );
+    Kokkos::View<DataTransferKit::Coordinate **, Kokkos::LayoutLeft,
+                 Kokkos::Serial>
+        all_src_coords( "src_nearest_coords", num_global, space_dim );
+
+    // Copy the local rank source coordinates into the appropriate spot in the
+    // send buffer for the global source coordinate view.
+    for ( size_t d = 0; d < space_dim; ++d )
+    {
+        auto src_subview = Kokkos::subview( host_sources, Kokkos::ALL, d );
+        auto send_subview = Kokkos::subview( rank_src_coords, Kokkos::ALL, d );
+        std::copy( src_subview.data(), src_subview.data() + num_src,
+                   send_subview.data() + offsets[comm_rank] );
+    }
+
+    // Reduce source coordinate data across all ranks to build a
+    // globally-replicated source coordinate view.
+    for ( size_t d = 0; d < space_dim; ++d )
+    {
+        auto send_subview = Kokkos::subview( rank_src_coords, Kokkos::ALL, d );
+        auto recv_subview = Kokkos::subview( all_src_coords, Kokkos::ALL, d );
+        Teuchos::reduceAll<int, DataTransferKit::Coordinate>(
+            *comm, Teuchos::REDUCE_SUM, Teuchos::as<int>( num_global ),
+            send_subview.data(), recv_subview.data() );
+    }
+
+    // Allocate the nearest neighbors array.
+    src_nearest_coords = Kokkos::View<DataTransferKit::Coordinate **,
+                                      Kokkos::LayoutLeft, Kokkos::Serial>(
+        "src_nearest_coords", num_tgt, space_dim );
+
+    // Use a brute-force method to find the nearest neighbors. Compute the
+    // distance for each target one at a time compared to all source points.
+    double distance;
+    for ( size_t t = 0; t < num_tgt; ++t )
+    {
+        // Reset the minimum distance for this target.
+        double min_distance = std::numeric_limits<double>::max();
+
+        // Check each source to see if it is the closest.
+        for ( size_t s = 0; s < num_global; ++s )
+        {
+            // Compute the distance between the source and target.
+            distance = 0.0;
+            for ( size_t d = 0; d < space_dim; ++d )
+                distance += ( host_targets( t, d ) - all_src_coords( s, d ) ) *
+                            ( host_targets( t, d ) - all_src_coords( s, d ) );
+            distance = std::sqrt( distance );
+
+            // If the distance is a new minimum for this target set the
+            // source coordinates as the new nearest and update the new
+            // minimum distance.
+            if ( distance < min_distance )
+            {
+                for ( size_t d = 0; d < space_dim; ++d )
+                    src_nearest_coords( t, d ) = all_src_coords( s, d );
+                min_distance = distance;
+            }
+        }
+    }
+}
+
+//---------------------------------------------------------------------------//
+// Test a problem that is uniquely owned. Returns a view of ints in the
+// target decomposition indicating success/failure for each point.
+template <class... ViewProperties>
+void testUniquelyOwnedProblem(
+    const Kokkos::View<DataTransferKit::Coordinate **, ViewProperties...>
+        &src_coords,
+    const Kokkos::View<double **, ViewProperties...> &src_field,
+    const Kokkos::View<DataTransferKit::Coordinate **, ViewProperties...>
+        &tgt_coords,
+    const Kokkos::View<double **, ViewProperties...> &tgt_field, bool &success,
+    Teuchos::FancyOStream &out )
+{
+    // Types.
+    using CoordView =
+        Kokkos::View<DataTransferKit::Coordinate **, ViewProperties...>;
+    using Device = typename CoordView::device_type;
+    using ExecutionSpace = typename Device::execution_space;
+    using Scalar = double;
+
+    // Set an epsilon for the search. The meshes (see below) mesh a sphere of
+    // radius 10. An epsilon of 1.0 is needed to fully capture nearest
+    // neighbors in adjacent partitions.
+    auto const epsilon_default =
+        DataTransferKit::DistributedSearchTreeImpl<Device>::epsilon;
+    DataTransferKit::DistributedSearchTreeImpl<Device>::epsilon = 1.0;
+
+    // Get the communicator.
+    auto comm = Teuchos::DefaultComm<int>::getComm();
+
+    // Sizes
+    size_t space_dim = src_coords.extent( 1 );
+    size_t num_src = src_coords.extent( 0 );
+    size_t num_tgt = tgt_coords.extent( 0 );
+
+    // Data function.
+    auto data_func = KOKKOS_LAMBDA( const double x, const double y,
+                                    const double z, const int comp )
+    {
+        return x * ( comp + 1 ) + y * ( comp + 2 ) + z * ( comp + 3 );
+    };
+
+    // Generate a source field.
+    auto fill_src = KOKKOS_LAMBDA( const size_t i )
+    {
+        src_field( i, 0 ) = data_func( src_coords( i, 0 ), src_coords( i, 1 ),
+                                       src_coords( i, 2 ), 0 );
+    };
+    Kokkos::parallel_for( Kokkos::RangePolicy<ExecutionSpace>( 0, num_src ),
+                          fill_src );
+    Kokkos::fence();
+
+    // For now we copy the coordinates to the device default layout for
+    // compatibility with the current operator definition.
+    Kokkos::View<DataTransferKit::Coordinate **, Device> src_coords_device(
+        "src_coords_device", num_src, space_dim );
+    Kokkos::deep_copy( src_coords_device, src_coords );
+
+    Kokkos::View<DataTransferKit::Coordinate **, Device> tgt_coords_device(
+        "tgt_coords_device", num_tgt, space_dim );
+    Kokkos::deep_copy( tgt_coords_device, tgt_coords );
+
+    // Create a nearest neighbor operator.
+    DataTransferKit::NearestNeighborOperator<Device> nearest_op(
+        comm, src_coords_device, tgt_coords_device );
+
+    // For now we copy the source field and create a target field with views
+    // that use the default layout for the device type. Also note that we are
+    // only using a single field dimension to be compatible with the current
+    // operator definition.
+    Kokkos::View<double *, Device> src_field_device( "src_field_device",
+                                                     num_src );
+    auto src_field_copy = KOKKOS_LAMBDA( const size_t i )
+    {
+        src_field_device( i ) = src_field( i, 0 );
+    };
+    Kokkos::parallel_for( Kokkos::RangePolicy<ExecutionSpace>( 0, num_src ),
+                          src_field_copy );
+    Kokkos::fence();
+
+    Kokkos::View<double *, Device> tgt_field_device( "tgt_field_device",
+                                                     num_tgt );
+
+    // Apply the operator.
+    nearest_op.apply( src_field_device, tgt_field_device );
+
+    // Create the expected nearest coordinates.
+    Kokkos::View<DataTransferKit::Coordinate **, Kokkos::LayoutLeft,
+                 Kokkos::Serial>
+        nearest_src_coords;
+    computeNeighborsBruteForce( comm, src_coords, tgt_coords,
+                                nearest_src_coords );
+
+    // Check that the field evaluated at the points found via brute-force
+    // search is the same as those computed by the operator.
+    auto host_tgt_field = Kokkos::create_mirror_view( tgt_field_device );
+    Kokkos::deep_copy( host_tgt_field, tgt_field_device );
+    double data_val;
+    for ( size_t t = 0; t < num_tgt; ++t )
+    {
+        data_val =
+            data_func( nearest_src_coords( t, 0 ), nearest_src_coords( t, 1 ),
+                       nearest_src_coords( t, 2 ), 0 );
+        TEST_FLOATING_EQUALITY( host_tgt_field( t ), data_val, 1.0e-12 );
+    }
+
+    // Reset the static variable to its original value to avoid interfering
+    // with other unit tests.
+    DataTransferKit::DistributedSearchTreeImpl<Device>::epsilon =
+        epsilon_default;
+}
+
+//---------------------------------------------------------------------------//
+// Partition the grids one-to-one
+TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( ExodusProblemGenerator, one_to_one, Node )
+{
+    // Type aliases.
+    using DeviceType = typename Node::device_type;
+    using Scalar = double;
+
+    // Get the communicator.
+    auto comm = Teuchos::DefaultComm<int>::getComm();
+
+    // Create a problem generator. Two tet meshes of a sphere centered at
+    // (0,0,0) with a radius of 10 are used. The source mesh is represented by
+    // a fine tet mesh and the target mesh is represented by a coarse tet mesh.
+    std::string src_exodus_file = "fine_sphere.exo";
+    std::string tgt_exodus_file = "coarse_sphere.exo";
+    DataTransferKit::ExodusProblemGenerator<Scalar, DeviceType, DeviceType>
+        generator( comm, src_exodus_file, tgt_exodus_file );
+
+    // Generate a uniquely owned problem.
+    Kokkos::View<DataTransferKit::Coordinate **, Kokkos::LayoutLeft, DeviceType>
+        src_coords;
+    Kokkos::View<DataTransferKit::Coordinate **, Kokkos::LayoutLeft, DeviceType>
+        tgt_coords;
+    Kokkos::View<Scalar **, Kokkos::LayoutLeft, DeviceType> src_field;
+    Kokkos::View<Scalar **, Kokkos::LayoutLeft, DeviceType> tgt_field;
+    generator.createUniquelyOwnedProblem( src_coords, src_field, tgt_coords,
+                                          tgt_field );
+
+    // Test the problem.
+    testUniquelyOwnedProblem( src_coords, src_field, tgt_coords, tgt_field,
+                              success, out );
+}
+
+//---------------------------------------------------------------------------//
+// Partition the grids with standard ghosting from connectivity.
+TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( ExodusProblemGenerator, ghosted, Node )
+{
+    // Type aliases.
+    using DeviceType = typename Node::device_type;
+    using Scalar = double;
+    using TpetraMap = Tpetra::Map<int, DataTransferKit::GlobalOrdinal, Node>;
+    using TpetraSerialNode = typename DataTransferKit::ParallelTraits<
+        DataTransferKit::Serial>::TpetraNode;
+    using TpetraCoordVector =
+        Tpetra::MultiVector<DataTransferKit::Coordinate, int,
+                            DataTransferKit::GlobalOrdinal, Node>;
+    using TpetraScalarVector =
+        Tpetra::MultiVector<Scalar, int, DataTransferKit::GlobalOrdinal, Node>;
+    using TpetraIntVector =
+        Tpetra::MultiVector<int, int, DataTransferKit::GlobalOrdinal,
+                            TpetraSerialNode>;
+
+    // Get the communicator.
+    auto comm = Teuchos::DefaultComm<int>::getComm();
+
+    // Create a problem generator. Two tet meshes of a sphere centered at
+    // (0,0,0) with a radius of 10 are used. The source mesh is represented by
+    // a fine tet mesh and the target mesh is represented by a coarse tet mesh.
+    std::string src_exodus_file = "fine_sphere.exo";
+    std::string tgt_exodus_file = "coarse_sphere.exo";
+    DataTransferKit::ExodusProblemGenerator<Scalar, DeviceType, DeviceType>
+        generator( comm, src_exodus_file, tgt_exodus_file );
+
+    // Generate a ghosted owned problem.
+    Kokkos::View<DataTransferKit::Coordinate **, Kokkos::LayoutLeft, DeviceType>
+        src_coords;
+    Kokkos::View<DataTransferKit::Coordinate **, Kokkos::LayoutLeft, DeviceType>
+        tgt_coords;
+    Kokkos::View<DataTransferKit::GlobalOrdinal *, Kokkos::LayoutLeft,
+                 DeviceType>
+        src_gids;
+    Kokkos::View<DataTransferKit::GlobalOrdinal *, Kokkos::LayoutLeft,
+                 DeviceType>
+        tgt_gids;
+    Kokkos::View<Scalar **, Kokkos::LayoutLeft, DeviceType> src_field;
+    Kokkos::View<Scalar **, Kokkos::LayoutLeft, DeviceType> tgt_field;
+    generator.createGhostedProblem( src_coords, src_gids, src_field, tgt_coords,
+                                    tgt_gids, tgt_field );
+
+    // Create Tpetra maps from the problem global ids.
+    auto invalid_ordinal =
+        Teuchos::OrdinalTraits<DataTransferKit::GlobalOrdinal>::invalid();
+    Teuchos::RCP<const TpetraMap> src_ghost_map =
+        Teuchos::rcp( new TpetraMap( invalid_ordinal, src_gids, 0, comm ) );
+    Teuchos::RCP<const TpetraMap> tgt_ghost_map =
+        Teuchos::rcp( new TpetraMap( invalid_ordinal, tgt_gids, 0, comm ) );
+
+    // Create Tpetra vectors from the ghosted problem coordinates.
+    TpetraCoordVector src_coords_ghost( src_ghost_map, src_coords );
+    TpetraCoordVector tgt_coords_ghost( tgt_ghost_map, tgt_coords );
+    TpetraScalarVector src_field_ghost( src_ghost_map, src_field );
+    TpetraScalarVector tgt_field_ghost( tgt_ghost_map, tgt_field );
+
+    // Create unique Tpetra vectors for coordinates and fields.
+    auto src_unique_map = Tpetra::createOneToOne( src_ghost_map );
+    auto tgt_unique_map = Tpetra::createOneToOne( tgt_ghost_map );
+    int space_dim = src_coords.extent( 1 );
+    int field_ncomp = src_field.extent( 1 );
+    TpetraCoordVector src_coords_unique( src_unique_map, space_dim );
+    TpetraCoordVector tgt_coords_unique( tgt_unique_map, space_dim );
+    TpetraScalarVector src_field_unique( src_unique_map, field_ncomp );
+    TpetraScalarVector tgt_field_unique( tgt_unique_map, field_ncomp );
+
+    // Export the ghosted problem coordinates to a uniquely owned
+    // decomposition.
+    auto src_ghost_to_unique_exporter =
+        Tpetra::createExport( src_ghost_map, src_unique_map );
+    auto tgt_ghost_to_unique_exporter =
+        Tpetra::createExport( tgt_ghost_map, tgt_unique_map );
+    src_coords_unique.doExport( src_coords_ghost, *src_ghost_to_unique_exporter,
+                                Tpetra::REPLACE );
+    tgt_coords_unique.doExport( tgt_coords_ghost, *tgt_ghost_to_unique_exporter,
+                                Tpetra::REPLACE );
+    src_field_unique.doExport( src_field_ghost, *src_ghost_to_unique_exporter,
+                               Tpetra::REPLACE );
+    tgt_field_unique.doExport( tgt_field_ghost, *tgt_ghost_to_unique_exporter,
+                               Tpetra::REPLACE );
+
+    // Test the uniquely owned problem.
+    auto src_coords_unique_view =
+        src_coords_unique.template getLocalView<DeviceType>();
+    auto tgt_coords_unique_view =
+        tgt_coords_unique.template getLocalView<DeviceType>();
+    auto src_field_unique_view =
+        src_field_unique.template getLocalView<DeviceType>();
+    auto tgt_field_unique_view =
+        tgt_field_unique.template getLocalView<DeviceType>();
+    testUniquelyOwnedProblem( src_coords_unique_view, src_field_unique_view,
+                              tgt_coords_unique_view, tgt_field_unique_view,
+                              success, out );
+}
+
+//---------------------------------------------------------------------------//
+
+// Include the test macros.
+#include "DataTransferKitMeshfree_ETIHelperMacros.h"
+
+// Create the test group
+#define UNIT_TEST_GROUP( NODE )                                                \
+    TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT( ExodusProblemGenerator, one_to_one,  \
+                                          NODE )                               \
+    TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT( ExodusProblemGenerator, ghosted,     \
+                                          NODE )
+
+// Demangle the types
+DTK_ETI_MANGLING_TYPEDEFS()
+
+// Instantiate the tests
+DTK_INSTANTIATE_N( UNIT_TEST_GROUP )


### PR DESCRIPTION
Summary of PR:

1. Defines an interface to use for point cloud test problem generation. This includes parallel point coordinates, point ids, and field data.
2. Add an implementation of the generator for exodus files. The generator reads the exodus files, partitions the nodes of the elements in the mesh, and returns the problem.
3. Defines tests for the current mesh free operators using the exodus problem generator.

Notes:

- The problem generator builds both uniquely owned and ghosted sets of points with corresponding unique global ids.
- The unit test for `DataTransferKit::NearestNeighborOperator` only uses the unique partitioning of points as the API only takes uniquely partitioned points. The ghosted problem generator will be used when we write tests for the decorators that transition ghosted points to uniquely owned points.

To Do:

- [x] Add ghosted operator test.
- [x] Fix build dependency so generator tests only build when netcdf is available and other tests always build when tests are on.