### PR TITLE
More unrelated changes to Search package

### DIFF
--- a/packages/Discretization/test/tstMeshGenerator.cpp
+++ b/packages/Discretization/test/tstMeshGenerator.cpp
@@ -9,6 +9,7 @@
 
 #include "MeshGenerator.hpp"
 #include <Teuchos_UnitTestHarness.hpp>
+#include <fstream>
 
 std::tuple<std::vector<std::vector<Coordinate>>, std::vector<unsigned int>>
 readInputFile( std::string const &filename )

--- a/packages/Meshfree/src/DTK_DetailsNearestNeighborOperatorImpl.hpp
+++ b/packages/Meshfree/src/DTK_DetailsNearestNeighborOperatorImpl.hpp
@@ -44,13 +44,13 @@ struct NearestNeighborOperatorImpl
         return DistributedSearchTree<DeviceType>( comm, boxes );
     }
 
-    static Kokkos::View<Details::Nearest *, DeviceType>
+    static Kokkos::View<Details::Nearest<DataTransferKit::Point> *, DeviceType>
     makeNearestNeighborQueries(
         Kokkos::View<Coordinate **, DeviceType> const &target_points )
     {
         int const n_target_points = target_points.extent( 0 );
-        Kokkos::View<Details::Nearest *, DeviceType> nearest_queries(
-            "nearest", n_target_points );
+        Kokkos::View<Details::Nearest<DataTransferKit::Point> *, DeviceType>
+            nearest_queries( "nearest", n_target_points );
         Kokkos::parallel_for(
             REGION_NAME( "setup_queries" ),
             Kokkos::RangePolicy<ExecutionSpace>( 0, n_target_points ),

--- a/packages/Search/examples/bvh_driver/bvh_driver.cpp
+++ b/packages/Search/examples/bvh_driver/bvh_driver.cpp
@@ -144,13 +144,13 @@ int main_( Teuchos::CommandLineProcessor &clp, int argc, char *argv[] )
         }
         Kokkos::deep_copy( k, k_host );
 
-        Kokkos::View<details::Nearest *, DeviceType> nearest_queries(
-            "nearest_queries", n_points );
+        Kokkos::View<details::Nearest<DataTransferKit::Point> *, DeviceType>
+            nearest_queries( "nearest_queries", n_points );
         Kokkos::parallel_for(
             REGION_NAME( "register_nearest_queries" ),
             Kokkos::RangePolicy<ExecutionSpace>( 0, n_points ),
             KOKKOS_LAMBDA( int i ) {
-                nearest_queries( i ) = details::nearest(
+                nearest_queries( i ) = details::nearest<DataTransferKit::Point>(
                     {{point_coords( i, 0 ), point_coords( i, 1 ),
                       point_coords( i, 2 )}},
                     k( i ) );

--- a/packages/Search/src/details/DTK_DetailsAlgorithms.hpp
+++ b/packages/Search/src/details/DTK_DetailsAlgorithms.hpp
@@ -11,6 +11,7 @@
 
 #include <DTK_DetailsBox.hpp>
 #include <DTK_DetailsPoint.hpp>
+#include <DTK_DetailsSphere.hpp>
 #include <DTK_KokkosHelpers.hpp>
 
 #include <Kokkos_Macros.hpp>
@@ -34,6 +35,12 @@ bool equals( Box const &l, Box const &r )
 {
     return equals( l.minCorner(), r.minCorner() ) &&
            equals( l.maxCorner(), r.maxCorner() );
+}
+
+KOKKOS_INLINE_FUNCTION
+bool equals( Sphere const &l, Sphere const &r )
+{
+    return equals( l.centroid(), r.centroid() ) && l.radius() == r.radius();
 }
 
 // distance point-point

--- a/packages/Search/src/details/DTK_DetailsAlgorithms.hpp
+++ b/packages/Search/src/details/DTK_DetailsAlgorithms.hpp
@@ -73,6 +73,14 @@ double distance( Point const &point, Box const &box )
     return distance( point, projected_point );
 }
 
+// distance point-sphere
+KOKKOS_INLINE_FUNCTION
+double distance( Point const &point, Sphere const &sphere )
+{
+    return KokkosHelpers::max(
+        distance( point, sphere.centroid() ) - sphere.radius(), 0. );
+}
+
 // expand an axis-aligned bounding box to include a point
 KOKKOS_INLINE_FUNCTION
 void expand( Box &box, Point const &point )

--- a/packages/Search/src/details/DTK_DetailsAlgorithms.hpp
+++ b/packages/Search/src/details/DTK_DetailsAlgorithms.hpp
@@ -114,9 +114,9 @@ void expand( Box &box, Sphere const &sphere )
     }
 }
 
-// check if two axis-aligned bounding boxes overlap
+// check if two axis-aligned bounding boxes intersect
 KOKKOS_INLINE_FUNCTION
-bool overlaps( Box const &box, Box const &other )
+bool intersects( Box const &box, Box const &other )
 {
     for ( int d = 0; d < 3; ++d )
         if ( box.minCorner()[d] > other.maxCorner()[d] ||

--- a/packages/Search/src/details/DTK_DetailsAlgorithms.hpp
+++ b/packages/Search/src/details/DTK_DetailsAlgorithms.hpp
@@ -95,6 +95,9 @@ void expand( Box &box, Point const &point )
 }
 
 // expand an axis-aligned bounding box to include another box
+// NOTE: Box type is templated here to be able to use expand(box, box) in a
+// Kokkos::parallel_reduce() in which case the arguments must be declared
+// volatile.
 template <typename BOX,
           typename = std::enable_if<std::is_same<
               typename std::remove_volatile<BOX>::type, Box>::value>>

--- a/packages/Search/src/details/DTK_DetailsAlgorithms.hpp
+++ b/packages/Search/src/details/DTK_DetailsAlgorithms.hpp
@@ -99,6 +99,19 @@ void expand( Box &box, Box const &other )
     }
 }
 
+// expand an axis-aligned bounding box to include a sphere
+KOKKOS_INLINE_FUNCTION
+void expand( Box &box, Sphere const &sphere )
+{
+    for ( int d = 0; d < 3; ++d )
+    {
+        box.minCorner()[d] = KokkosHelpers::min(
+            box.minCorner()[d], sphere.centroid()[d] - sphere.radius() );
+        box.maxCorner()[d] = KokkosHelpers::max(
+            box.maxCorner()[d], sphere.centroid()[d] + sphere.radius() );
+    }
+}
+
 // check if two axis-aligned bounding boxes overlap
 KOKKOS_INLINE_FUNCTION
 bool overlaps( Box const &box, Box const &other )

--- a/packages/Search/src/details/DTK_DetailsAlgorithms.hpp
+++ b/packages/Search/src/details/DTK_DetailsAlgorithms.hpp
@@ -125,6 +125,13 @@ bool intersects( Box const &box, Box const &other )
     return true;
 }
 
+// check if a sphere intersects with an  axis-aligned bounding box
+KOKKOS_INLINE_FUNCTION
+bool intersects( Sphere const &sphere, Box const &box )
+{
+    return distance( sphere.centroid(), box ) <= sphere.radius();
+}
+
 // calculate the centroid of a box
 KOKKOS_INLINE_FUNCTION
 void centroid( Box const &box, Point &c )

--- a/packages/Search/src/details/DTK_DetailsDistributedSearchTreeImpl.hpp
+++ b/packages/Search/src/details/DTK_DetailsDistributedSearchTreeImpl.hpp
@@ -29,9 +29,10 @@ class SerializationTraits<Ordinal, DataTransferKit::Details::Within>
 {
 };
 template <typename Ordinal>
-class SerializationTraits<Ordinal, DataTransferKit::Details::Nearest>
-    : public DirectSerializationTraits<Ordinal,
-                                       DataTransferKit::Details::Nearest>
+class SerializationTraits<
+    Ordinal, DataTransferKit::Details::Nearest<DataTransferKit::Point>>
+    : public DirectSerializationTraits<
+          Ordinal, DataTransferKit::Details::Nearest<DataTransferKit::Point>>
 {
 };
 template <typename Ordinal>
@@ -169,7 +170,7 @@ void DistributedSearchTreeImpl<DeviceType>::deviseStrategy(
     Kokkos::parallel_for( REGION_NAME( "fill_overlap_queries" ),
                           Kokkos::RangePolicy<ExecutionSpace>( 0, n_queries ),
                           KOKKOS_LAMBDA( int q ) {
-                              Point point = queries( q )._query_point;
+                              Point point = queries( q )._geometry;
                               Box box = {{{
                                              point[0] - epsilon[0],
                                              point[1] - epsilon[1],

--- a/packages/Search/src/details/DTK_DetailsPredicate.hpp
+++ b/packages/Search/src/details/DTK_DetailsPredicate.hpp
@@ -24,10 +24,6 @@ struct SpatialPredicateTag
 {
 };
 
-// COMMENT: Default constructor and assignment operator are required to be able
-// to declare a Kokkos::View of a predicate type and fill it with a
-// Kokkos::for_parallel.
-
 template <typename Geometry>
 struct Nearest
 {

--- a/packages/Search/src/details/DTK_DetailsPredicate.hpp
+++ b/packages/Search/src/details/DTK_DetailsPredicate.hpp
@@ -28,33 +28,23 @@ struct SpatialPredicateTag
 // to declare a Kokkos::View of a predicate type and fill it with a
 // Kokkos::for_parallel.
 
+template <typename Geometry>
 struct Nearest
 {
     using Tag = NearestPredicateTag;
 
     KOKKOS_INLINE_FUNCTION
-    Nearest()
-        : _query_point( {{0., 0., 0.}} )
-        , _k( 0 )
-    {
-    }
-
-    KOKKOS_INLINE_FUNCTION Nearest &operator=( Nearest const &other )
-    {
-        _query_point = other._query_point;
-        _k = other._k;
-        return *this;
-    }
+    Nearest() = default;
 
     KOKKOS_INLINE_FUNCTION
-    Nearest( Point const &query_point, int k )
-        : _query_point( query_point )
+    Nearest( Geometry const &geometry, int k )
+        : _geometry( geometry )
         , _k( k )
     {
     }
 
-    Point _query_point;
-    int _k;
+    Geometry _geometry;
+    int _k = 0;
 };
 
 template <typename Geometry>
@@ -81,8 +71,12 @@ struct Intersects
 using Within = Intersects<Sphere>;
 using Overlap = Intersects<Box>;
 
-KOKKOS_INLINE_FUNCTION
-Nearest nearest( Point const &p, int k = 1 ) { return Nearest( p, k ); }
+template <typename Geometry>
+KOKKOS_INLINE_FUNCTION Nearest<Geometry> nearest( Geometry const &geometry,
+                                                  int k = 1 )
+{
+    return Nearest<Geometry>( geometry, k );
+}
 
 KOKKOS_INLINE_FUNCTION
 Within within( Point const &p, double r ) { return Within( {p, r} ); }

--- a/packages/Search/src/details/DTK_DetailsPredicate.hpp
+++ b/packages/Search/src/details/DTK_DetailsPredicate.hpp
@@ -57,82 +57,35 @@ struct Nearest
     int _k;
 };
 
-class Within
+template <typename Geometry>
+struct Intersects
 {
-  public:
     using Tag = SpatialPredicateTag;
 
-    KOKKOS_INLINE_FUNCTION
-    Within()
-        : _query_point( {{0., 0., 0.}} )
-        , _radius( 0. )
-    {
-    }
+    KOKKOS_INLINE_FUNCTION Intersects() = default;
 
-    KOKKOS_INLINE_FUNCTION Within &operator=( Within const &other )
-    {
-        _query_point = other._query_point;
-        _radius = other._radius;
-        return *this;
-    }
-
-    KOKKOS_INLINE_FUNCTION
-    Within( Point const &query_point, double const radius )
-        : _query_point( query_point )
-        , _radius( radius )
+    KOKKOS_INLINE_FUNCTION Intersects( Geometry const &geometry )
+        : _geometry( geometry )
     {
     }
 
     KOKKOS_INLINE_FUNCTION
     bool operator()( Node const *node ) const
     {
-        double node_distance = distance( _query_point, node->bounding_box );
-        return ( node_distance <= _radius ) ? true : false;
+        return intersects( _geometry, node->bounding_box );
     }
 
-  private:
-    Point _query_point;
-    double _radius;
+    Geometry _geometry;
 };
 
-class Overlap
-{
-  public:
-    using Tag = SpatialPredicateTag;
-
-    KOKKOS_INLINE_FUNCTION
-    Overlap()
-        : _query_box( Box() )
-    {
-    }
-
-    KOKKOS_INLINE_FUNCTION Overlap &operator=( Overlap const &other )
-    {
-        _query_box = other._query_box;
-        return *this;
-    }
-
-    KOKKOS_INLINE_FUNCTION
-    Overlap( Box const &query_box )
-        : _query_box( query_box )
-    {
-    }
-
-    KOKKOS_INLINE_FUNCTION
-    bool operator()( Node const *node ) const
-    {
-        return overlaps( node->bounding_box, _query_box );
-    }
-
-  private:
-    DataTransferKit::Box _query_box;
-};
+using Within = Intersects<Sphere>;
+using Overlap = Intersects<Box>;
 
 KOKKOS_INLINE_FUNCTION
 Nearest nearest( Point const &p, int k = 1 ) { return Nearest( p, k ); }
 
 KOKKOS_INLINE_FUNCTION
-Within within( Point const &p, double r ) { return Within( p, r ); }
+Within within( Point const &p, double r ) { return Within( {p, r} ); }
 
 KOKKOS_INLINE_FUNCTION
 Overlap overlap( Box const &b ) { return Overlap( b ); }

--- a/packages/Search/src/details/DTK_DetailsSphere.hpp
+++ b/packages/Search/src/details/DTK_DetailsSphere.hpp
@@ -1,0 +1,44 @@
+/****************************************************************************
+ * Copyright (c) 2012-2017 by the DataTransferKit authors                   *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the DataTransferKit library. DataTransferKit is     *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ ****************************************************************************/
+#ifndef DTK_Sphere_HPP
+#define DTK_Sphere_HPP
+
+#include <DTK_DetailsPoint.hpp>
+#include <Kokkos_Macros.hpp>
+
+namespace DataTransferKit
+{
+
+struct Sphere
+{
+    KOKKOS_INLINE_FUNCTION
+    Sphere() = default;
+
+    KOKKOS_INLINE_FUNCTION
+    Sphere( Point const &centroid, double radius )
+        : _centroid( centroid )
+        , _radius( radius )
+    {
+    }
+
+    KOKKOS_INLINE_FUNCTION
+    Point &centroid() { return _centroid; }
+
+    KOKKOS_INLINE_FUNCTION
+    Point const &centroid() const { return _centroid; }
+
+    KOKKOS_INLINE_FUNCTION
+    double radius() const { return _radius; }
+
+    Point _centroid;
+    double _radius = 0.;
+};
+}
+
+#endif

--- a/packages/Search/src/details/DTK_DetailsTreeTraversal.hpp
+++ b/packages/Search/src/details/DTK_DetailsTreeTraversal.hpp
@@ -213,7 +213,7 @@ KOKKOS_INLINE_FUNCTION int
 queryDispatch( BVH<DeviceType> const bvh, Predicate const &pred,
                Insert const &insert, NearestPredicateTag )
 {
-    return nearestQuery( bvh, pred._query_point, pred._k, insert );
+    return nearestQuery( bvh, pred._geometry, pred._k, insert );
 }
 
 } // end namespace Details

--- a/packages/Search/src/details/DTK_DetailsTreeTraversal.hpp
+++ b/packages/Search/src/details/DTK_DetailsTreeTraversal.hpp
@@ -79,9 +79,9 @@ struct TreeTraversal
 // one using nearest neighbours query (see boost::geometry::queries
 // documentation).
 template <typename DeviceType, typename Predicate, typename Insert>
-KOKKOS_FUNCTION int spatial_query( BVH<DeviceType> const bvh,
-                                   Predicate const &predicate,
-                                   Insert const &insert )
+KOKKOS_FUNCTION int spatialQuery( BVH<DeviceType> const bvh,
+                                  Predicate const &predicate,
+                                  Insert const &insert )
 {
     if ( bvh.empty() )
         return 0;
@@ -205,7 +205,7 @@ KOKKOS_INLINE_FUNCTION int
 queryDispatch( BVH<DeviceType> const bvh, Predicate const &pred,
                Insert const &insert, SpatialPredicateTag )
 {
-    return spatial_query( bvh, pred, insert );
+    return spatialQuery( bvh, pred, insert );
 }
 
 template <typename DeviceType, typename Predicate, typename Insert>

--- a/packages/Search/src/details/DTK_DetailsTreeTraversal.hpp
+++ b/packages/Search/src/details/DTK_DetailsTreeTraversal.hpp
@@ -132,9 +132,9 @@ KOKKOS_FUNCTION int spatialQuery( BVH<DeviceType> const bvh,
 }
 
 // query k nearest neighbours
-template <typename DeviceType, typename Insert>
+template <typename DeviceType, typename Distance, typename Insert>
 KOKKOS_FUNCTION int nearestQuery( BVH<DeviceType> const bvh,
-                                  Point const &query_point, int k,
+                                  Distance const &distance, int k,
                                   Insert const &insert )
 {
     if ( bvh.empty() || k < 1 )
@@ -144,8 +144,7 @@ KOKKOS_FUNCTION int nearestQuery( BVH<DeviceType> const bvh,
     {
         Node const *leaf = TreeTraversal<DeviceType>::getRoot( bvh );
         int const leaf_index = TreeTraversal<DeviceType>::getIndex( bvh, leaf );
-        double const leaf_distance =
-            distance( query_point, leaf->bounding_box );
+        double const leaf_distance = distance( leaf );
         insert( leaf_index, leaf_distance );
         return 1;
     }
@@ -191,8 +190,7 @@ KOKKOS_FUNCTION int nearestQuery( BVH<DeviceType> const bvh,
             for ( Node const *child :
                   {node->children.first, node->children.second} )
             {
-                double child_distance =
-                    distance( query_point, child->bounding_box );
+                double const child_distance = distance( child );
                 queue.push( child, child_distance );
             }
         }
@@ -213,7 +211,13 @@ KOKKOS_INLINE_FUNCTION int
 queryDispatch( BVH<DeviceType> const bvh, Predicate const &pred,
                Insert const &insert, NearestPredicateTag )
 {
-    return nearestQuery( bvh, pred._geometry, pred._k, insert );
+    auto const geometry = pred._geometry;
+    auto const k = pred._k;
+    return nearestQuery( bvh,
+                         [geometry]( Node const *node ) {
+                             return distance( geometry, node->bounding_box );
+                         },
+                         k, insert );
 }
 
 } // end namespace Details

--- a/packages/Search/test/Search_UnitTestHelpers.hpp
+++ b/packages/Search/test/Search_UnitTestHelpers.hpp
@@ -169,15 +169,17 @@ makeOverlapQueries( std::vector<DataTransferKit::Box> const &boxes )
 }
 
 template <typename DeviceType>
-Kokkos::View<DataTransferKit::Details::Nearest *, DeviceType>
+Kokkos::View<DataTransferKit::Details::Nearest<DataTransferKit::Point> *,
+             DeviceType>
 makeNearestQueries(
     std::vector<std::pair<DataTransferKit::Point, int>> const &points )
 {
     // NOTE: `points` is not a very descriptive name here. It stores both the
     // actual point and the number k of neighbors to query for.
     int const n = points.size();
-    Kokkos::View<DataTransferKit::Details::Nearest *, DeviceType> queries(
-        "nearest_queries", n );
+    Kokkos::View<DataTransferKit::Details::Nearest<DataTransferKit::Point> *,
+                 DeviceType>
+        queries( "nearest_queries", n );
     auto queries_host = Kokkos::create_mirror_view( queries );
     for ( int i = 0; i < n; ++i )
         queries_host( i ) = DataTransferKit::Details::nearest(

--- a/packages/Search/test/tstDetailsAlgorithms.cpp
+++ b/packages/Search/test/tstDetailsAlgorithms.cpp
@@ -31,6 +31,13 @@ TEUCHOS_UNIT_TEST( DetailsAlgorithms, distance )
                    std::sqrt( 2.0 ) );
     // projection onto corner node
     TEST_EQUALITY( dtk::distance( {{-1.0, 2.0, 2.0}}, box ), std::sqrt( 3.0 ) );
+
+    // unit sphere
+    DataTransferKit::Sphere sphere = {{{0., 0., 0.}}, 1.};
+    TEST_EQUALITY( dtk::distance( {{.5, .5, .5}}, sphere ), 0. );
+    TEST_EQUALITY( dtk::distance( {{2., 0., 0.}}, sphere ), 1. );
+    TEST_EQUALITY( dtk::distance( {{1., 1., 1.}}, sphere ),
+                   std::sqrt( 3. ) - 1. );
 }
 
 TEUCHOS_UNIT_TEST( DetailsAlgorithms, overlaps )

--- a/packages/Search/test/tstDetailsAlgorithms.cpp
+++ b/packages/Search/test/tstDetailsAlgorithms.cpp
@@ -37,42 +37,45 @@ TEUCHOS_UNIT_TEST( DetailsAlgorithms, overlaps )
 {
     DataTransferKit::Box box;
     // uninitialized box does not even overlap with itself
-    TEST_ASSERT( !dtk::overlaps( box, box ) );
+    TEST_ASSERT( !dtk::intersects( box, box ) );
     // box with zero extent does
     box = {{{0.0, 0.0, 0.0}}, {{0.0, 0.0, 0.0}}};
-    TEST_ASSERT( dtk::overlaps( box, box ) );
-    TEST_ASSERT( !dtk::overlaps( box, DataTransferKit::Box() ) );
+    TEST_ASSERT( dtk::intersects( box, box ) );
+    TEST_ASSERT( !dtk::intersects( box, DataTransferKit::Box() ) );
     // overlap with box that contains it
     TEST_ASSERT(
-        dtk::overlaps( box, {{{-1.0, -1.0, -1.0}}, {{1.0, 1.0, 1.0}}} ) );
+        dtk::intersects( box, {{{-1.0, -1.0, -1.0}}, {{1.0, 1.0, 1.0}}} ) );
     // does not overlap with some other box
     TEST_ASSERT(
-        !dtk::overlaps( box, {{{1.0, 1.0, 1.0}}, {{2.0, 2.0, 2.0}}} ) );
+        !dtk::intersects( box, {{{1.0, 1.0, 1.0}}, {{2.0, 2.0, 2.0}}} ) );
     // overlap when only touches another
-    TEST_ASSERT( dtk::overlaps( box, {{{0.0, 0.0, 0.0}}, {{1.0, 1.0, 1.0}}} ) );
+    TEST_ASSERT(
+        dtk::intersects( box, {{{0.0, 0.0, 0.0}}, {{1.0, 1.0, 1.0}}} ) );
     // unit cube
     box = {{{0.0, 0.0, 0.0}}, {{1.0, 1.0, 1.0}}};
-    TEST_ASSERT( dtk::overlaps( box, box ) );
-    TEST_ASSERT( !dtk::overlaps( box, DataTransferKit::Box() ) );
+    TEST_ASSERT( dtk::intersects( box, box ) );
+    TEST_ASSERT( !dtk::intersects( box, DataTransferKit::Box() ) );
     // smaller box inside
     TEST_ASSERT(
-        dtk::overlaps( box, {{{0.25, 0.25, 0.25}}, {{0.75, 0.75, 0.75}}} ) );
+        dtk::intersects( box, {{{0.25, 0.25, 0.25}}, {{0.75, 0.75, 0.75}}} ) );
     // bigger box that contains it
     TEST_ASSERT(
-        dtk::overlaps( box, {{{-1.0, -1.0, -1.0}}, {{2.0, 2.0, 2.0}}} ) );
+        dtk::intersects( box, {{{-1.0, -1.0, -1.0}}, {{2.0, 2.0, 2.0}}} ) );
     // couple boxes that do overlap
-    TEST_ASSERT( dtk::overlaps( box, {{{0.5, 0.5, 0.5}}, {{1.5, 1.5, 1.5}}} ) );
     TEST_ASSERT(
-        dtk::overlaps( box, {{{-0.5, -0.5, -0.5}}, {{0.5, 0.5, 0.5}}} ) );
+        dtk::intersects( box, {{{0.5, 0.5, 0.5}}, {{1.5, 1.5, 1.5}}} ) );
+    TEST_ASSERT(
+        dtk::intersects( box, {{{-0.5, -0.5, -0.5}}, {{0.5, 0.5, 0.5}}} ) );
     // couple boxes that do not
     TEST_ASSERT(
-        !dtk::overlaps( box, {{{-2.0, -2.0, -2.0}}, {{-1.0, -1.0, -1.0}}} ) );
+        !dtk::intersects( box, {{{-2.0, -2.0, -2.0}}, {{-1.0, -1.0, -1.0}}} ) );
     TEST_ASSERT(
-        !dtk::overlaps( box, {{{0.0, 0.0, 2.0}}, {{1.0, 1.0, 3.0}}} ) );
+        !dtk::intersects( box, {{{0.0, 0.0, 2.0}}, {{1.0, 1.0, 3.0}}} ) );
     // boxes overlap if faces touch
-    TEST_ASSERT( dtk::overlaps( box, {{{1.0, 0.0, 0.0}}, {{2.0, 1.0, 1.0}}} ) );
     TEST_ASSERT(
-        dtk::overlaps( box, {{{-0.5, -0.5, -0.5}}, {{0.5, 0.0, 0.5}}} ) );
+        dtk::intersects( box, {{{1.0, 0.0, 0.0}}, {{2.0, 1.0, 1.0}}} ) );
+    TEST_ASSERT(
+        dtk::intersects( box, {{{-0.5, -0.5, -0.5}}, {{0.5, 0.0, 0.5}}} ) );
 }
 
 TEUCHOS_UNIT_TEST( DetailsAlgorithms, equals )

--- a/packages/Search/test/tstDetailsAlgorithms.cpp
+++ b/packages/Search/test/tstDetailsAlgorithms.cpp
@@ -113,6 +113,15 @@ TEUCHOS_UNIT_TEST( DetailsAlgorithms, expand )
     dtk::expand( box, {{{10.0, 10.0, 10.0}}, {{11.0, 11.0, 11.0}}} );
     TEST_ASSERT(
         dtk::equals( box, {{{-1.0, -1.0, -1.0}}, {{11.0, 11.0, 11.0}}} ) );
+
+    // expand box with spheres
+    dtk::expand( box, {{{0., 1., 2.}}, 3.} );
+    TEST_ASSERT( dtk::equals( box, {{{-3., -2., -1.}}, {{11., 11., 11.}}} ) );
+    dtk::expand( box, {{{0., 0., 0.}}, 1.} );
+    TEST_ASSERT( dtk::equals( box, {{{-3., -2., -1.}}, {{11., 11., 11.}}} ) );
+    dtk::expand( box, {{{0., 0., 0.}}, 24.} );
+    TEST_ASSERT(
+        dtk::equals( box, {{{-24., -24., -24.}}, {{24., 24., 24.}}} ) );
 }
 
 TEUCHOS_UNIT_TEST( DetailsAlgorithms, centroid )

--- a/packages/Search/test/tstDetailsAlgorithms.cpp
+++ b/packages/Search/test/tstDetailsAlgorithms.cpp
@@ -78,6 +78,13 @@ TEUCHOS_UNIT_TEST( DetailsAlgorithms, overlaps )
         dtk::intersects( box, {{{-0.5, -0.5, -0.5}}, {{0.5, 0.0, 0.5}}} ) );
 }
 
+TEUCHOS_UNIT_TEST( DetailsAlgorithms, intersects )
+{
+    DataTransferKit::Sphere sphere = {{{0., 0., 0.}}, 1.};
+    TEST_ASSERT( dtk::intersects( sphere, {{{0., 0., 0.}}, {{1., 1., 1.}}} ) );
+    TEST_ASSERT( !dtk::intersects( sphere, {{{1., 2., 3.}}, {{4., 5., 6.}}} ) );
+}
+
 TEUCHOS_UNIT_TEST( DetailsAlgorithms, equals )
 {
     // points

--- a/packages/Search/test/tstDetailsAlgorithms.cpp
+++ b/packages/Search/test/tstDetailsAlgorithms.cpp
@@ -77,12 +77,18 @@ TEUCHOS_UNIT_TEST( DetailsAlgorithms, overlaps )
 
 TEUCHOS_UNIT_TEST( DetailsAlgorithms, equals )
 {
+    // points
     TEST_ASSERT( dtk::equals( {{0., 0., 0.}}, {{0., 0., 0.}} ) );
     TEST_ASSERT( !dtk::equals( {{0., 0., 0.}}, {{1., 1., 1.}} ) );
+    // boxes
     TEST_ASSERT( dtk::equals( {{{0.0, 0.0, 0.0}}, {{1.0, 1.0, 1.0}}},
                               {{{0.0, 0.0, 0.0}}, {{1.0, 1.0, 1.0}}} ) );
     TEST_ASSERT( !dtk::equals( {{{0.0, 0.0, 0.0}}, {{1.0, 0.0, 1.0}}},
                                {{{-1.0, -1.0, -1.0}}, {{1.0, 1.0, 1.0}}} ) );
+    // spheres
+    TEST_ASSERT( dtk::equals( {{{0., 0., 0.}}, 1.}, {{{0., 0., 0.}}, 1.} ) );
+    TEST_ASSERT( !dtk::equals( {{{0., 0., 0.}}, 1.}, {{{0., 1., 2.}}, 1.} ) );
+    TEST_ASSERT( !dtk::equals( {{{0., 0., 0.}}, 1.}, {{{0., 0., 0.}}, 2.} ) );
 }
 
 TEUCHOS_UNIT_TEST( DetailsAlgorithms, expand )

--- a/packages/Search/test/tstDetailsDistributedSearchTreeImpl.cpp
+++ b/packages/Search/test/tstDetailsDistributedSearchTreeImpl.cpp
@@ -13,11 +13,9 @@
 #include <Teuchos_UnitTestHarness.hpp>
 #include <Tpetra_Distributor.hpp>
 
-#include <algorithm>
-#include <bitset>
-#include <iostream>
-#include <random>
-#include <tuple>
+#include <algorithm> // fill
+#include <set>
+#include <vector>
 
 TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DetailsDistributedSearchTreeImpl, recv_from,
                                    DeviceType )

--- a/packages/Search/test/tstDistributedSearchTree.cpp
+++ b/packages/Search/test/tstDistributedSearchTree.cpp
@@ -77,12 +77,14 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DistributedSearchTree, hello_world,
     // x   x        <--2-->            |               |               |
     // 3-->            |               |               |               |
     // |               |               |               |               |
-    Kokkos::View<DataTransferKit::Details::Nearest *, DeviceType>
+    Kokkos::View<DataTransferKit::Details::Nearest<DataTransferKit::Point> *,
+                 DeviceType>
         nearest_queries( "nearest_queries", 1 );
     auto nearest_queries_host = Kokkos::create_mirror_view( nearest_queries );
-    nearest_queries_host( 0 ) = DataTransferKit::Details::nearest(
-        {{0.0 + comm_size - 1 - comm_rank, 0., 0.}},
-        comm_rank < comm_size - 1 ? 3 : 2 );
+    nearest_queries_host( 0 ) =
+        DataTransferKit::Details::nearest<DataTransferKit::Point>(
+            {{0.0 + comm_size - 1 - comm_rank, 0., 0.}},
+            comm_rank < comm_size - 1 ? 3 : 2 );
     deep_copy( nearest_queries, nearest_queries_host );
 
     Kokkos::View<int *, DeviceType> offset( "offset" );

--- a/packages/Search/test/tstLinearBVH.cpp
+++ b/packages/Search/test/tstLinearBVH.cpp
@@ -637,7 +637,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( LinearBVH, rtree, DeviceType )
     Kokkos::deep_copy( k, k_host );
 
     Kokkos::View<details::Nearest<DataTransferKit::Point> *, DeviceType>
-        nearest_queries( "neatest_queries", n_points );
+        nearest_queries( "nearest_queries", n_points );
     Kokkos::parallel_for(
         "register_nearest_queries",
         Kokkos::RangePolicy<ExecutionSpace>( 0, n_points ),

--- a/packages/Search/test/tstLinearBVH.cpp
+++ b/packages/Search/test/tstLinearBVH.cpp
@@ -636,16 +636,17 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( LinearBVH, rtree, DeviceType )
     Kokkos::deep_copy( radii, radii_host );
     Kokkos::deep_copy( k, k_host );
 
-    Kokkos::View<details::Nearest *, DeviceType> nearest_queries(
-        "neatest_queries", n_points );
-    Kokkos::parallel_for( "register_nearest_queries",
-                          Kokkos::RangePolicy<ExecutionSpace>( 0, n_points ),
-                          KOKKOS_LAMBDA( int i ) {
-                              nearest_queries( i ) = details::nearest(
-                                  {{point_coords( i, 0 ), point_coords( i, 1 ),
-                                    point_coords( i, 2 )}},
-                                  k( i ) );
-                          } );
+    Kokkos::View<details::Nearest<DataTransferKit::Point> *, DeviceType>
+        nearest_queries( "neatest_queries", n_points );
+    Kokkos::parallel_for(
+        "register_nearest_queries",
+        Kokkos::RangePolicy<ExecutionSpace>( 0, n_points ),
+        KOKKOS_LAMBDA( int i ) {
+            nearest_queries( i ) = details::nearest<DataTransferKit::Point>(
+                {{point_coords( i, 0 ), point_coords( i, 1 ),
+                  point_coords( i, 2 )}},
+                k( i ) );
+        } );
     Kokkos::fence();
 
     Kokkos::View<details::Within *, DeviceType> within_queries(


### PR DESCRIPTION
* Add Sphere geometric object
* Rename `overlaps(box, box)` algorithm to `intersects()`
* Replace `Overlap` and `Within` predicates by `Intersects<Box>` and `Intersects<Sphere>`
* Template `Nearest` predicate on `Geometry`
* Improve `TreeTraversal::nearestQuery()`