### PR TITLE
Add minmax(view)

### DIFF
--- a/packages/Search/src/details/DTK_DetailsUtils.hpp
+++ b/packages/Search/src/details/DTK_DetailsUtils.hpp
@@ -79,8 +79,8 @@ void exclusivePrefixSum( Kokkos::View<ST, SP...> const &src,
         typename Kokkos::ViewTraits<DT, DP...>::execution_space;
     using ValueType = typename Kokkos::ViewTraits<DT, DP...>::value_type;
 
-    auto const n = src.span();
-    DTK_REQUIRE( n == dst.span() );
+    auto const n = src.extent( 0 );
+    DTK_REQUIRE( n == dst.extent( 0 ) );
     Kokkos::parallel_scan(
         "exclusive_scan", Kokkos::RangePolicy<ExecutionSpace>( 0, n ),
         Details::ExclusiveScanFunctor<ValueType, ExecutionSpace>( src, dst ) );
@@ -114,7 +114,7 @@ lastElement( Kokkos::View<T, P...> const &v )
     static_assert(
         ( unsigned( Kokkos::ViewTraits<T, P...>::rank ) == unsigned( 1 ) ),
         "lastElement requires Views of rank 1" );
-    auto const n = v.span();
+    auto const n = v.extent( 0 );
     DTK_REQUIRE( n > 0 );
     auto v_subview = Kokkos::subview( v, n - 1 );
     auto v_host = Kokkos::create_mirror_view( v_subview );
@@ -148,7 +148,7 @@ void iota( Kokkos::View<T, P...> const &v,
         std::is_same<ValueType, typename Kokkos::ViewTraits<
                                     T, P...>::non_const_value_type>::value,
         "iota requires a View with non-const value type" );
-    auto const n = v.span();
+    auto const n = v.extent( 0 );
     Kokkos::parallel_for(
         "iota", Kokkos::RangePolicy<ExecutionSpace>( 0, n ),
         KOKKOS_LAMBDA( int i ) { v( i ) = value + (ValueType)i; } );

--- a/packages/Search/test/tstDetailsUtils.cpp
+++ b/packages/Search/test/tstDetailsUtils.cpp
@@ -124,6 +124,25 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DetailsUtils, minmax, DeviceType )
     auto const result_int = DataTransferKit::minMax( w );
     TEST_EQUALITY( std::get<0>( result_int ), 255 );
     TEST_EQUALITY( std::get<1>( result_int ), 255 );
+
+    // testing use case in #336
+    Kokkos::View<int[2][3], DeviceType> u( "u" );
+    auto u_host = Kokkos::create_mirror_view( u );
+    u_host( 0, 0 ) = 1; // x
+    u_host( 0, 1 ) = 2; // y
+    u_host( 0, 2 ) = 3; // z
+    u_host( 1, 0 ) = 4; // x
+    u_host( 1, 1 ) = 5; // y
+    u_host( 1, 2 ) = 6; // Z
+    Kokkos::deep_copy( u, u_host );
+    auto const minmax_x =
+        DataTransferKit::minMax( Kokkos::subview( u, Kokkos::ALL, 0 ) );
+    TEST_EQUALITY( std::get<0>( minmax_x ), 1 );
+    TEST_EQUALITY( std::get<1>( minmax_x ), 4 );
+    auto const minmax_y =
+        DataTransferKit::minMax( Kokkos::subview( u, Kokkos::ALL, 1 ) );
+    TEST_EQUALITY( std::get<0>( minmax_y ), 2 );
+    TEST_EQUALITY( std::get<1>( minmax_y ), 5 );
 }
 
 // Include the test macros.

--- a/packages/Search/test/tstDetailsUtils.cpp
+++ b/packages/Search/test/tstDetailsUtils.cpp
@@ -104,6 +104,28 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DetailsUtils, last_element, DeviceType )
     TEST_FLOATING_EQUALITY( DataTransferKit::lastElement( u ), 3.14, 1e-14 );
 }
 
+TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DetailsUtils, minmax, DeviceType )
+{
+    Kokkos::View<double[4], DeviceType> v( "v" );
+    auto v_host = Kokkos::create_mirror_view( v );
+    v_host( 0 ) = 3.14;
+    v_host( 1 ) = 1.41;
+    v_host( 2 ) = 2.71;
+    v_host( 3 ) = 1.62;
+    Kokkos::deep_copy( v, v_host );
+    auto const result_float = DataTransferKit::minMax( v );
+    TEST_FLOATING_EQUALITY( std::get<0>( result_float ), 1.41, 1e-14 );
+    TEST_FLOATING_EQUALITY( std::get<1>( result_float ), 3.14, 1e-14 );
+    Kokkos::View<int *, DeviceType> w( "w" );
+    TEST_THROW( DataTransferKit::minMax( w ),
+                DataTransferKit::DataTransferKitException );
+    Kokkos::resize( w, 1 );
+    Kokkos::deep_copy( w, 255 );
+    auto const result_int = DataTransferKit::minMax( w );
+    TEST_EQUALITY( std::get<0>( result_int ), 255 );
+    TEST_EQUALITY( std::get<1>( result_int ), 255 );
+}
+
 // Include the test macros.
 #include "DataTransferKitSearch_ETIHelperMacros.h"
 
@@ -115,6 +137,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DetailsUtils, last_element, DeviceType )
     TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT( DetailsUtils, prefix_sum,            \
                                           DeviceType##NODE )                   \
     TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT( DetailsUtils, last_element,          \
+                                          DeviceType##NODE )                   \
+    TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT( DetailsUtils, minmax,                \
                                           DeviceType##NODE )
 
 // Demangle the types


### PR DESCRIPTION
* add `minMax()` which is meant to be used in #336 when partitioning parsed meshes along x- and y-axes
* fix possible bug when using `exclusivePrefixSum()`, `lastElement()`, or `iota()` on subviews