### PR TITLE
Add support for multivariate polynomial basis

### DIFF
--- a/packages/Meshfree/src/DTK_MultivariatePolynomialBasis.hpp
+++ b/packages/Meshfree/src/DTK_MultivariatePolynomialBasis.hpp
@@ -1,0 +1,113 @@
+/****************************************************************************
+ * Copyright (c) 2012-2017 by the DataTransferKit authors                   *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the DataTransferKit library. DataTransferKit is     *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ ****************************************************************************/
+
+#ifndef DTK_MULTIVARIATE_POLYNOMIAL_BASIS_HPP
+#define DTK_MULTIVARIATE_POLYNOMIAL_BASIS_HPP
+
+#include <Kokkos_Array.hpp>
+#include <Kokkos_Macros.hpp>
+
+namespace DataTransferKit
+{
+
+struct Linear
+{
+};
+
+struct Quadratic
+{
+};
+
+namespace Details
+{
+
+template <typename Basis, int DIM>
+struct Traits
+{
+    static KOKKOS_INLINE_FUNCTION int constexpr size();
+};
+
+template <>
+struct Traits<Linear, 3>
+{
+    static KOKKOS_INLINE_FUNCTION int constexpr size() { return 4; }
+};
+
+template <>
+struct Traits<Quadratic, 3>
+{
+    static KOKKOS_INLINE_FUNCTION int constexpr size() { return 10; }
+};
+
+template <>
+struct Traits<Linear, 2>
+{
+    static KOKKOS_INLINE_FUNCTION int constexpr size() { return 3; }
+};
+
+template <>
+struct Traits<Quadratic, 2>
+{
+    static KOKKOS_INLINE_FUNCTION int constexpr size() { return 6; }
+};
+
+} // end namespace Details
+
+template <typename Basis, int DIM>
+struct MultivariatePolynomialBasis
+{
+    static KOKKOS_INLINE_FUNCTION int constexpr size()
+    {
+        return Details::Traits<Basis, DIM>::size();
+    }
+    template <typename Point>
+    KOKKOS_INLINE_FUNCTION Kokkos::Array<double, size()>
+    operator()( Point const &p ) const;
+};
+
+// NOTE: For now relying on Point::operator[]( int i ) to access the coordinates
+// which make it possible to use various types such as DTK::Point or
+// Kokkos::Array<double, DIM>
+
+template <>
+template <typename Point>
+KOKKOS_INLINE_FUNCTION Kokkos::Array<double, 4>
+MultivariatePolynomialBasis<Linear, 3>::operator()( Point const &p ) const
+{
+    return {{1., p[0], p[1], p[2]}};
+}
+
+template <>
+template <typename Point>
+KOKKOS_INLINE_FUNCTION Kokkos::Array<double, 10>
+MultivariatePolynomialBasis<Quadratic, 3>::operator()( Point const &p ) const
+{
+    return {{1., p[0], p[1], p[2], p[0] * p[0], p[0] * p[1], p[0] * p[2],
+             p[1] * p[1], p[1] * p[2], p[2] * p[2]}};
+}
+
+template <>
+template <typename Point>
+KOKKOS_INLINE_FUNCTION Kokkos::Array<double, 3>
+MultivariatePolynomialBasis<Linear, 2>::operator()( Point const &p ) const
+{
+    return {{1., p[0], p[1]}};
+}
+
+template <>
+template <typename Point>
+KOKKOS_INLINE_FUNCTION Kokkos::Array<double, 6>
+MultivariatePolynomialBasis<Quadratic, 2>::operator()( Point const &p ) const
+{
+    return {{1., p[0], p[1], p[0] * p[0], p[0] * p[1], p[1] * p[1]}};
+}
+
+} // end namespace DataTransferKit
+
+#endif

--- a/packages/Meshfree/src/DTK_MultivariatePolynomialBasis.hpp
+++ b/packages/Meshfree/src/DTK_MultivariatePolynomialBasis.hpp
@@ -77,16 +77,19 @@ struct MultivariatePolynomialBasis
 
 template <>
 template <typename Point>
-KOKKOS_INLINE_FUNCTION Kokkos::Array<double, 4>
-MultivariatePolynomialBasis<Linear, 3>::operator()( Point const &p ) const
+KOKKOS_INLINE_FUNCTION
+    Kokkos::Array<double, MultivariatePolynomialBasis<Linear, 3>::size()>
+    MultivariatePolynomialBasis<Linear, 3>::operator()( Point const &p ) const
 {
     return {{1., p[0], p[1], p[2]}};
 }
 
 template <>
 template <typename Point>
-KOKKOS_INLINE_FUNCTION Kokkos::Array<double, 10>
-MultivariatePolynomialBasis<Quadratic, 3>::operator()( Point const &p ) const
+KOKKOS_INLINE_FUNCTION
+    Kokkos::Array<double, MultivariatePolynomialBasis<Quadratic, 3>::size()>
+    MultivariatePolynomialBasis<Quadratic, 3>::
+    operator()( Point const &p ) const
 {
     return {{1., p[0], p[1], p[2], p[0] * p[0], p[0] * p[1], p[0] * p[2],
              p[1] * p[1], p[1] * p[2], p[2] * p[2]}};
@@ -94,16 +97,19 @@ MultivariatePolynomialBasis<Quadratic, 3>::operator()( Point const &p ) const
 
 template <>
 template <typename Point>
-KOKKOS_INLINE_FUNCTION Kokkos::Array<double, 3>
-MultivariatePolynomialBasis<Linear, 2>::operator()( Point const &p ) const
+KOKKOS_INLINE_FUNCTION
+    Kokkos::Array<double, MultivariatePolynomialBasis<Linear, 2>::size()>
+    MultivariatePolynomialBasis<Linear, 2>::operator()( Point const &p ) const
 {
     return {{1., p[0], p[1]}};
 }
 
 template <>
 template <typename Point>
-KOKKOS_INLINE_FUNCTION Kokkos::Array<double, 6>
-MultivariatePolynomialBasis<Quadratic, 2>::operator()( Point const &p ) const
+KOKKOS_INLINE_FUNCTION
+    Kokkos::Array<double, MultivariatePolynomialBasis<Quadratic, 2>::size()>
+    MultivariatePolynomialBasis<Quadratic, 2>::
+    operator()( Point const &p ) const
 {
     return {{1., p[0], p[1], p[0] * p[0], p[0] * p[1], p[1] * p[1]}};
 }

--- a/packages/Meshfree/test/CMakeLists.txt
+++ b/packages/Meshfree/test/CMakeLists.txt
@@ -21,3 +21,12 @@ IF (HAVE_DTK_BOOST)
     FAIL_REGULAR_EXPRESSION "data race;leak;runtime error"
     )
 ENDIF()
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  MultivariatePolynomialBasis
+  SOURCES tstMultivariatePolynomialBasis.cpp unit_test_main.cpp
+  COMM serial mpi
+  NUM_MPI_PROCS 1
+  STANDARD_PASS_OUTPUT
+  FAIL_REGULAR_EXPRESSION "data race;leak;runtime error"
+  )

--- a/packages/Meshfree/test/tstMultivariatePolynomialBasis.cpp
+++ b/packages/Meshfree/test/tstMultivariatePolynomialBasis.cpp
@@ -1,0 +1,70 @@
+/****************************************************************************
+ * Copyright (c) 2012-2017 by the DataTransferKit authors                   *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the DataTransferKit library. DataTransferKit is     *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ ****************************************************************************/
+
+#include <DTK_DetailsPoint.hpp>
+#include <DTK_MultivariatePolynomialBasis.hpp>
+
+#include <Kokkos_Array.hpp>
+#include <Teuchos_UnitTestHarness.hpp>
+
+#include <vector>
+
+template <typename PolynomialBasis, typename Point>
+void checkBasisEvaluation( PolynomialBasis const &b, Point const &x,
+                           std::vector<double> const &b_ref, bool &success,
+                           Teuchos::FancyOStream &out )
+{
+    TEST_COMPARE_ARRAYS( b( x ), b_ref );
+}
+
+// NOTE: The extra pairs of parentheses below around
+// MultivariatePolynomialBasis::size() in TEST_EQUALITY() macro are needed.
+// Without them, the Teuchos unit testing macro yields the folowing error:
+//
+//     error: macro "TEST_EQUALITY" passed 3 arguments, but takes just 2
+
+TEUCHOS_UNIT_TEST( MultivariatePolynomialBasis, 2D )
+{
+    using DataTransferKit::Linear;
+    using DataTransferKit::MultivariatePolynomialBasis;
+    using DataTransferKit::Quadratic;
+    // FIXME
+    using Point = Kokkos::Array<double, 2>;
+
+    // (X, Y) -> [ 1, X, Y ]
+    TEST_EQUALITY( ( MultivariatePolynomialBasis<Linear, 2>::size() ), 3 );
+    checkBasisEvaluation( MultivariatePolynomialBasis<Linear, 2>(),
+                          Point{{0., 1.}}, {{1., 0., 1.}}, success, out );
+
+    // (X, Y) -> [ 1, X, Y, X^2, XY, Y^2 ]
+    TEST_EQUALITY( ( MultivariatePolynomialBasis<Quadratic, 2>::size() ), 6 );
+    checkBasisEvaluation( MultivariatePolynomialBasis<Quadratic, 2>(),
+                          Point{{1., 2.}}, {{1., 1., 2., 1., 2., 4.}}, success,
+                          out );
+}
+
+TEUCHOS_UNIT_TEST( MultivariatePolynomialBasis, 3D )
+{
+    using DataTransferKit::Linear;
+    using DataTransferKit::MultivariatePolynomialBasis;
+    using DataTransferKit::Point;
+    using DataTransferKit::Quadratic;
+
+    // (X, Y, Z) -> [ 1, X, Y, Z ]
+    TEST_EQUALITY( ( MultivariatePolynomialBasis<Linear, 3>::size() ), 4 );
+    checkBasisEvaluation( MultivariatePolynomialBasis<Linear, 3>(),
+                          Point{{0., 1., 2.}}, {{1., 0., 1., 2.}}, success,
+                          out );
+
+    // (X, Y, Z) -> [ 1, X, Y, Z, X^2, XY, XZ, Y^2, YZ, Z^2 ]
+    TEST_EQUALITY( ( MultivariatePolynomialBasis<Quadratic, 3>::size() ), 10 );
+    checkBasisEvaluation(
+        MultivariatePolynomialBasis<Quadratic, 3>(), Point{{0., 1., 2.}},
+        {{1., 0., 1., 2., 0., 0., 0., 1., 2., 4.}}, success, out );
+}


### PR DESCRIPTION
This will be used in the moving least squares operator to build the multivariate Vandermonde matrix.