### PR TITLE
Improve Details::DistributedSearchTreeImpl::sortResults()

### DIFF
--- a/packages/Search/src/details/DTK_DetailsDistributedSearchTreeImpl.hpp
+++ b/packages/Search/src/details/DTK_DetailsDistributedSearchTreeImpl.hpp
@@ -269,6 +269,8 @@ template <typename BinSort, typename View, typename... OtherViews>
 void applyPermutations( BinSort &bin_sort, View view,
                         OtherViews... other_views )
 {
+    DTK_REQUIRE( bin_sort.get_permute_vector().extent( 0 ) ==
+                 view.extent( 0 ) );
     bin_sort.sort( view );
     applyPermutations( bin_sort, other_views... );
 }

--- a/packages/Search/test/tstDetailsDistributedSearchTreeImpl.cpp
+++ b/packages/Search/test/tstDetailsDistributedSearchTreeImpl.cpp
@@ -199,6 +199,12 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DetailsDistributedSearchTreeImpl,
             TEST_EQUALITY( sorted_results[q].count( results_host[i] ), 1 );
             TEST_EQUALITY( sorted_ranks[q].count( ranks_host[i] ), 1 );
         }
+
+    Kokkos::View<int *, DeviceType> not_sized_properly( "", m );
+    TEST_THROW(
+        DataTransferKit::DistributedSearchTreeImpl<DeviceType>::sortResults(
+            ids, not_sized_properly ),
+        DataTransferKit::DataTransferKitException );
 }
 
 TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DetailsDistributedSearchTreeImpl,


### PR DESCRIPTION
The goal is to enable reuse in interpolation operator.