### PR TITLE
Get rid of warnings with CUDA

### DIFF
--- a/scripts/docker_cuda_cmake
+++ b/scripts/docker_cuda_cmake
@@ -6,10 +6,10 @@ source ${SCRIPT_DIR}/set_kokkos_env.sh
 
 CUDA_ARGS=(
     -D CMAKE_CXX_FLAGS="-g -arch=${GPU_ARCH} -lineinfo \
-        -std=c++11 --expt-extended-lambda \
         -Xcudafe --diag_suppress=conversion_function_not_usable \
         -Xcudafe --diag_suppress=cc_clobber_ignored \
         -Xcudafe --diag_suppress=code_is_unreachable"
+    -D Trilinos_CXX11_FLAGS="-std=c++11 --expt-extended-lambda"
     -D TPL_ENABLE_CUDA=ON
     -D Kokkos_ENABLE_Cuda=ON
     -D Kokkos_ENABLE_Cuda_UVM=ON


### PR DESCRIPTION
I stumbled upon trilinos/Trilinos#1888 and turns out we were passing
the `--expt-extended-lambda` flag wrong in our configuration scripts.

This patch gets rid of those silly warnings:
```
cc1: warning: command line option '-std=c++11' is valid for C++/ObjC++ but not for C
```