### PR TITLE
Communication helpers

### DIFF
--- a/packages/Meshfree/src/DTK_DetailsNearestNeighborOperatorImpl.hpp
+++ b/packages/Meshfree/src/DTK_DetailsNearestNeighborOperatorImpl.hpp
@@ -28,7 +28,7 @@ struct NearestNeighborOperatorImpl
     // boxes in their constructors.
     static DistributedSearchTree<DeviceType> makeDistributedSearchTree(
         Teuchos::RCP<const Teuchos::Comm<int>> const &comm,
-        Kokkos::View<Coordinate **, DeviceType> const &source_points )
+        Kokkos::View<Coordinate const **, DeviceType> source_points )
     {
         int const n_source_points = source_points.extent( 0 );
         Kokkos::View<Box *, DeviceType> boxes( "boxes", n_source_points );
@@ -46,7 +46,7 @@ struct NearestNeighborOperatorImpl
 
     static Kokkos::View<Details::Nearest<DataTransferKit::Point> *, DeviceType>
     makeNearestNeighborQueries(
-        Kokkos::View<Coordinate **, DeviceType> const &target_points )
+        Kokkos::View<Coordinate const **, DeviceType> target_points )
     {
         int const n_target_points = target_points.extent( 0 );
         Kokkos::View<Details::Nearest<DataTransferKit::Point> *, DeviceType>

--- a/packages/Meshfree/src/DTK_DetailsNearestNeighborOperatorImpl.hpp
+++ b/packages/Meshfree/src/DTK_DetailsNearestNeighborOperatorImpl.hpp
@@ -63,13 +63,17 @@ struct NearestNeighborOperatorImpl
         return nearest_queries;
     }
 
+    template <typename View>
     static void
     pullSourceValues( Teuchos::RCP<const Teuchos::Comm<int>> const &comm,
-                      Kokkos::View<double *, DeviceType> source_values,
+                      View source_values,
                       Kokkos::View<int *, DeviceType> &buffer_indices,
                       Kokkos::View<int *, DeviceType> &buffer_ranks,
-                      Kokkos::View<double *, DeviceType> &buffer_values )
+                      typename View::non_const_type &buffer_values )
     {
+        static_assert(
+            View::rank <= 2,
+            "pullSourceValues() requires rank-1 or rank-2 view arguments" );
         int const n_exports = buffer_indices.extent( 0 );
         Tpetra::Distributor distributor( comm );
         int const n_imports =
@@ -99,32 +103,37 @@ struct NearestNeighborOperatorImpl
 
         buffer_indices = import_target_indices;
         buffer_ranks = import_ranks;
-        Kokkos::realloc( buffer_values, n_imports );
+        Kokkos::realloc( buffer_values, n_imports,
+                         source_values.dimension_1() );
         Kokkos::parallel_for(
             DTK_MARK_REGION( "get_source_values" ),
             Kokkos::RangePolicy<ExecutionSpace>( 0, n_imports ),
             KOKKOS_LAMBDA( int i ) {
-                buffer_values( i ) =
-                    source_values( import_source_indices( i ) );
+                for ( int j = 0; j < (int)source_values.dimension_1(); ++j )
+                    buffer_values( i, j ) =
+                        source_values( import_source_indices( i ), j );
             } );
         Kokkos::fence();
     }
 
+    template <typename View>
     static void
     pushTargetValues( Teuchos::RCP<const Teuchos::Comm<int>> const &comm,
                       Kokkos::View<int *, DeviceType> const &buffer_indices,
                       Kokkos::View<int *, DeviceType> const &buffer_ranks,
-                      Kokkos::View<double *, DeviceType> const &buffer_values,
-                      Kokkos::View<double *, DeviceType> target_values )
+                      View const &buffer_values, View target_values )
     {
+        static_assert(
+            View::rank <= 2,
+            "pushTargetValues() requires rank-1 or rank-2 view arguments" );
         Tpetra::Distributor distributor( comm );
         int const n_imports =
             distributor.createFromSends( Teuchos::ArrayView<int>(
                 buffer_ranks.data(), buffer_ranks.extent( 0 ) ) );
 
-        Kokkos::View<double *, DeviceType> export_source_values = buffer_values;
-        Kokkos::View<double *, DeviceType> import_source_values(
-            "source_values", n_imports );
+        View export_source_values = buffer_values;
+        View import_source_values( "source_values", n_imports,
+                                   target_values.dimension_1() );
         DistributedSearchTreeImpl<DeviceType>::sendAcrossNetwork(
             distributor, export_source_values, import_source_values );
 
@@ -138,10 +147,38 @@ struct NearestNeighborOperatorImpl
             DTK_MARK_REGION( "set_target_values" ),
             Kokkos::RangePolicy<ExecutionSpace>( 0, n_imports ),
             KOKKOS_LAMBDA( int i ) {
-                target_values( import_target_indices( i ) ) =
-                    import_source_values( i );
+                for ( int j = 0; j < (int)target_values.dimension_1(); ++j )
+                    target_values( import_target_indices( i ), j ) =
+                        import_source_values( i, j );
             } );
         Kokkos::fence();
+    }
+
+    template <typename View>
+    static typename View::non_const_type
+    fetch( Teuchos::RCP<Teuchos::Comm<int> const> const &comm,
+           Kokkos::View<int const *, DeviceType> ranks,
+           Kokkos::View<int const *, DeviceType> indices, View values )
+    {
+        Kokkos::View<int *, DeviceType> buffer_ranks =
+            Kokkos::create_mirror( DeviceType(), ranks );
+        Kokkos::deep_copy( buffer_ranks, ranks );
+
+        Kokkos::View<int *, DeviceType> buffer_indices =
+            Kokkos::create_mirror( DeviceType(), indices );
+        Kokkos::deep_copy( buffer_indices, indices );
+
+        typename View::non_const_type buffer_values( values.label() );
+
+        pullSourceValues( comm, values, buffer_indices, buffer_ranks,
+                          buffer_values );
+
+        typename View::non_const_type values_out(
+            values.label(), ranks.extent( 0 ), values.dimension_1() );
+
+        pushTargetValues( comm, buffer_indices, buffer_ranks, buffer_values,
+                          values_out );
+        return values_out;
     }
 };
 

--- a/packages/Meshfree/src/DTK_DetailsNearestNeighborOperatorImpl.hpp
+++ b/packages/Meshfree/src/DTK_DetailsNearestNeighborOperatorImpl.hpp
@@ -160,6 +160,8 @@ struct NearestNeighborOperatorImpl
            Kokkos::View<int const *, DeviceType> ranks,
            Kokkos::View<int const *, DeviceType> indices, View values )
     {
+        DTK_REQUIRE( ranks.extent( 0 ) == indices.extent( 0 ) );
+
         Kokkos::View<int *, DeviceType> buffer_ranks =
             Kokkos::create_mirror( DeviceType(), ranks );
         Kokkos::deep_copy( buffer_ranks, ranks );
@@ -178,6 +180,10 @@ struct NearestNeighborOperatorImpl
 
         pushTargetValues( comm, buffer_indices, buffer_ranks, buffer_values,
                           values_out );
+
+        DTK_ENSURE( ( values_out.extent( 0 ) == ranks.extent( 0 ) ) &&
+                    ( values_out.extent( 1 ) == values.extent( 1 ) ) );
+
         return values_out;
     }
 };

--- a/packages/Meshfree/src/DTK_DetailsNearestNeighborOperatorImpl.hpp
+++ b/packages/Meshfree/src/DTK_DetailsNearestNeighborOperatorImpl.hpp
@@ -174,7 +174,7 @@ struct NearestNeighborOperatorImpl
                           buffer_values );
 
         typename View::non_const_type values_out(
-            values.label(), ranks.extent( 0 ), values.dimension_1() );
+            values.label(), ranks.extent( 0 ), values.extent( 1 ) );
 
         pushTargetValues( comm, buffer_indices, buffer_ranks, buffer_values,
                           values_out );

--- a/packages/Meshfree/test/CMakeLists.txt
+++ b/packages/Meshfree/test/CMakeLists.txt
@@ -11,6 +11,15 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   FAIL_REGULAR_EXPRESSION "data race;leak;runtime error"
   )
 
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  DetailsCommunicationHelpers
+  SOURCES tstDetailsCommunicationHelpers.cpp unit_test_main.cpp
+  COMM serial mpi
+  NUM_MPI_PROCS 4
+  STANDARD_PASS_OUTPUT
+  FAIL_REGULAR_EXPRESSION "data race;leak;runtime error"
+  )
+
 IF (HAVE_DTK_BOOST)
   TRIBITS_ADD_EXECUTABLE_AND_TEST(
     CompactlySupportedRadialBasisFunctions

--- a/packages/Meshfree/test/tstDetailsCommunicationHelpers.cpp
+++ b/packages/Meshfree/test/tstDetailsCommunicationHelpers.cpp
@@ -1,0 +1,172 @@
+/****************************************************************************
+ * Copyright (c) 2012-2017 by the DataTransferKit authors                   *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the DataTransferKit library. DataTransferKit is     *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ ****************************************************************************/
+
+#include <DTK_DetailsDistributedSearchTreeImpl.hpp>   // sendAcrossNetwork
+
+#include <Teuchos_DefaultComm.hpp>
+#include <Teuchos_UnitTestHarness.hpp>
+#include <Tpetra_Distributor.hpp>
+
+template <
+    typename View,
+    typename std::enable_if<
+        std::is_same<
+            typename View::traits::memory_space,
+            typename View::traits::host_mirror_space::memory_space>::value,
+        int>::type = 0>
+Teuchos::ArrayView<typename View::const_value_type> toArray( View const &v )
+{
+    return Teuchos::ArrayView<typename View::const_value_type>( v.data(),
+                                                                v.size() );
+}
+
+template <
+    typename View,
+    typename std::enable_if<
+        !std::is_same<
+            typename View::traits::memory_space,
+            typename View::traits::host_mirror_space::memory_space>::value,
+        int>::type = 0>
+Teuchos::Array<typename View::non_const_value_type> toArray( View const &v )
+{
+    auto v_h = Kokkos::create_mirror_view( v );
+    Kokkos::deep_copy( v_h, v );
+
+    return Teuchos::Array<typename View::non_const_value_type>(
+        Teuchos::ArrayView<typename View::const_value_type>( v_h.data(),
+                                                             v_h.size() ) );
+}
+
+// NOTE Shameless hack to get DeviceType from test driver because I don't want
+// to deduce it
+template <typename DeviceType>
+struct Helper
+{
+    template <typename View1, typename View2>
+    static void
+    checkSendAcrossNetwork( Teuchos::RCP<Teuchos::Comm<int> const> const &comm,
+                            View1 const &ranks, View2 const &v_exp,
+                            View2 const &v_ref, bool &success,
+                            Teuchos::FancyOStream &out )
+    {
+        Tpetra::Distributor distributor( comm );
+        distributor.createFromSends( toArray( ranks ) );
+
+        // NOTE here we assume that the reference solution is sized properly
+        auto v_imp =
+            Kokkos::create_mirror( typename View2::memory_space(), v_ref );
+
+        DataTransferKit::DistributedSearchTreeImpl<
+            DeviceType>::sendAcrossNetwork( distributor, v_exp, v_imp );
+
+        // FIXME not sure why I need that guy but I do get a bus error when it
+        // is not here...
+        Kokkos::fence();
+
+        TEST_COMPARE_ARRAYS( toArray( v_imp ), toArray( v_ref ) );
+    }
+};
+
+TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DetailsDistributedSearchTreeImpl,
+                                   send_across_network, DeviceType )
+{
+    using ExecutionSpace = typename DeviceType::execution_space;
+
+    Teuchos::RCP<const Teuchos::Comm<int>> comm =
+        Teuchos::DefaultComm<int>::getComm();
+    int const comm_rank = comm->getRank();
+    int const comm_size = comm->getSize();
+
+    int const DIM = 3;
+
+    // send 1 packet to rank k
+    // receive comm_size packets
+    Kokkos::View<int **, DeviceType> u_exp( "u_exp", comm_size, DIM );
+    Kokkos::parallel_for( "",
+                          Kokkos::RangePolicy<ExecutionSpace>( 0, comm_size ),
+                          KOKKOS_LAMBDA( int i ) {
+                              for ( int j = 0; j < DIM; ++j )
+                                  u_exp( i, j ) = i + j * comm_rank;
+                          } );
+    Kokkos::fence();
+
+    Kokkos::View<int *, DeviceType> ranks_u( "", comm_size );
+    DataTransferKit::iota( ranks_u, 0 );
+
+    Kokkos::View<int **, DeviceType> u_ref( "u_ref", comm_size, DIM );
+    Kokkos::parallel_for( "fill_ref",
+                          Kokkos::RangePolicy<ExecutionSpace>( 0, comm_size ),
+                          KOKKOS_LAMBDA( int i ) {
+                              for ( int j = 0; j < DIM; ++j )
+                                  u_ref( i, j ) = comm_rank + i * j;
+                          } );
+    Kokkos::fence();
+
+    Helper<DeviceType>::checkSendAcrossNetwork( comm, ranks_u, u_exp, u_ref,
+                                                success, out );
+
+    // send k packets to rank k
+    // receive k*comm_size packets
+    Kokkos::View<int *, DeviceType> tn( "tn", comm_size + 1 );
+    Kokkos::parallel_for(
+        "", Kokkos::RangePolicy<ExecutionSpace>( 0, comm_size + 1 ),
+        KOKKOS_LAMBDA( int i ) { tn( i ) = ( i * ( i - 1 ) ) / 2; } );
+    Kokkos::fence();
+
+    Kokkos::View<int **, DeviceType> v_exp(
+        "v_exp", DataTransferKit::lastElement( tn ), DIM );
+    Kokkos::parallel_for( "fill_exp",
+                          Kokkos::RangePolicy<ExecutionSpace>( 0, comm_size ),
+                          KOKKOS_LAMBDA( int i ) {
+                              for ( int j = tn( i ); j < tn( i + 1 ); ++j )
+                                  for ( int k = 0; k < DIM; ++k )
+                                      v_exp( j, k ) = i * k;
+                          } );
+    Kokkos::fence();
+
+    Kokkos::View<int *, DeviceType> ranks_v(
+        "", DataTransferKit::lastElement( tn ) );
+    Kokkos::parallel_for( "fill_exp",
+                          Kokkos::RangePolicy<ExecutionSpace>( 0, comm_size ),
+                          KOKKOS_LAMBDA( int i ) {
+                              for ( int j = tn( i ); j < tn( i + 1 ); ++j )
+                                  ranks_v( j ) = i;
+                          } );
+    Kokkos::fence();
+
+    Kokkos::View<int **, DeviceType> v_ref( "v_ref", comm_size * comm_rank,
+                                            DIM );
+    Kokkos::parallel_for(
+        "fill_ref",
+        Kokkos::RangePolicy<ExecutionSpace>( 0, comm_size * comm_rank ),
+        KOKKOS_LAMBDA( int i ) {
+            for ( int j = 0; j < DIM; ++j )
+                v_ref( i, j ) = j * comm_rank;
+        } );
+    Kokkos::fence();
+
+    Helper<DeviceType>::checkSendAcrossNetwork( comm, ranks_v, v_exp, v_ref,
+                                                success, out );
+}
+
+// Include the test macros.
+#include "DataTransferKitSearch_ETIHelperMacros.h"
+
+// Create the test group
+#define UNIT_TEST_GROUP( NODE )                                                \
+    using DeviceType##NODE = typename NODE::device_type;                       \
+    TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT( DetailsDistributedSearchTreeImpl,    \
+                                          send_across_network,                 \
+                                          DeviceType##NODE )                   \
+
+// Demangle the types
+DTK_ETI_MANGLING_TYPEDEFS()
+
+// Instantiate the tests
+DTK_INSTANTIATE_N( UNIT_TEST_GROUP )

--- a/packages/Meshfree/test/tstDetailsCommunicationHelpers.cpp
+++ b/packages/Meshfree/test/tstDetailsCommunicationHelpers.cpp
@@ -176,8 +176,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DetailsNearestNeighborOperatorImpl, fetch,
     // make communicaton plan
     Kokkos::View<int *, DeviceType> indices( "indices", comm_size );
     Kokkos::View<int *, DeviceType> ranks( "ranks", comm_size );
-    Kokkos::parallel_for( "fill_indices_and_ranks",
-                          Kokkos::RangePolicy<ExecutionSpace>( 0, comm_size ),
+    Kokkos::parallel_for( Kokkos::RangePolicy<ExecutionSpace>( 0, comm_size ),
                           KOKKOS_LAMBDA( int i ) {
                               indices( i ) = ( comm_rank + i ) % comm_size;
                               ranks( i ) = comm_size - 1 - comm_rank;
@@ -189,11 +188,11 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DetailsNearestNeighborOperatorImpl, fetch,
     DataTransferKit::iota( v_exp, comm_rank * comm_size );
 
     Kokkos::View<int *, DeviceType> v_ref( "v_ref", comm_size );
-    Kokkos::parallel_for(
-        "fill_values", Kokkos::RangePolicy<ExecutionSpace>( 0, comm_size ),
-        KOKKOS_LAMBDA( int i ) {
-            v_ref( i ) = ranks( i ) * comm_size + indices( i );
-        } );
+    Kokkos::parallel_for( Kokkos::RangePolicy<ExecutionSpace>( 0, comm_size ),
+                          KOKKOS_LAMBDA( int i ) {
+                              v_ref( i ) =
+                                  ranks( i ) * comm_size + indices( i );
+                          } );
     Kokkos::fence();
 
     Helper<DeviceType>::checkFetch( comm, ranks, indices, v_exp, v_ref, success,
@@ -207,8 +206,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DetailsNearestNeighborOperatorImpl, fetch,
                                i * comm_size + comm_rank * comm_size * DIM );
 
     Kokkos::View<int **, DeviceType> w_ref( "w_ref", comm_size, DIM );
-    Kokkos::parallel_for( "fill_values",
-                          Kokkos::RangePolicy<ExecutionSpace>( 0, comm_size ),
+    Kokkos::parallel_for( Kokkos::RangePolicy<ExecutionSpace>( 0, comm_size ),
                           KOKKOS_LAMBDA( int i ) {
                               for ( int j = 0; j < DIM; ++j )
                                   w_ref( i, j ) = ranks( i ) * comm_size * DIM +

--- a/packages/Meshfree/test/tstDetailsCommunicationHelpers.cpp
+++ b/packages/Meshfree/test/tstDetailsCommunicationHelpers.cpp
@@ -101,8 +101,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DetailsDistributedSearchTreeImpl,
     // send 1 packet to rank k
     // receive comm_size packets
     Kokkos::View<int **, DeviceType> u_exp( "u_exp", comm_size, DIM );
-    Kokkos::parallel_for( "",
-                          Kokkos::RangePolicy<ExecutionSpace>( 0, comm_size ),
+    Kokkos::parallel_for( Kokkos::RangePolicy<ExecutionSpace>( 0, comm_size ),
                           KOKKOS_LAMBDA( int i ) {
                               for ( int j = 0; j < DIM; ++j )
                                   u_exp( i, j ) = i + j * comm_rank;
@@ -113,8 +112,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DetailsDistributedSearchTreeImpl,
     DataTransferKit::iota( ranks_u, 0 );
 
     Kokkos::View<int **, DeviceType> u_ref( "u_ref", comm_size, DIM );
-    Kokkos::parallel_for( "fill_ref",
-                          Kokkos::RangePolicy<ExecutionSpace>( 0, comm_size ),
+    Kokkos::parallel_for( Kokkos::RangePolicy<ExecutionSpace>( 0, comm_size ),
                           KOKKOS_LAMBDA( int i ) {
                               for ( int j = 0; j < DIM; ++j )
                                   u_ref( i, j ) = comm_rank + i * j;
@@ -128,14 +126,13 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DetailsDistributedSearchTreeImpl,
     // receive k*comm_size packets
     Kokkos::View<int *, DeviceType> tn( "tn", comm_size + 1 );
     Kokkos::parallel_for(
-        "", Kokkos::RangePolicy<ExecutionSpace>( 0, comm_size + 1 ),
+        Kokkos::RangePolicy<ExecutionSpace>( 0, comm_size + 1 ),
         KOKKOS_LAMBDA( int i ) { tn( i ) = ( i * ( i - 1 ) ) / 2; } );
     Kokkos::fence();
 
     Kokkos::View<int **, DeviceType> v_exp(
         "v_exp", DataTransferKit::lastElement( tn ), DIM );
-    Kokkos::parallel_for( "fill_exp",
-                          Kokkos::RangePolicy<ExecutionSpace>( 0, comm_size ),
+    Kokkos::parallel_for( Kokkos::RangePolicy<ExecutionSpace>( 0, comm_size ),
                           KOKKOS_LAMBDA( int i ) {
                               for ( int j = tn( i ); j < tn( i + 1 ); ++j )
                                   for ( int k = 0; k < DIM; ++k )
@@ -145,8 +142,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DetailsDistributedSearchTreeImpl,
 
     Kokkos::View<int *, DeviceType> ranks_v(
         "", DataTransferKit::lastElement( tn ) );
-    Kokkos::parallel_for( "fill_exp",
-                          Kokkos::RangePolicy<ExecutionSpace>( 0, comm_size ),
+    Kokkos::parallel_for( Kokkos::RangePolicy<ExecutionSpace>( 0, comm_size ),
                           KOKKOS_LAMBDA( int i ) {
                               for ( int j = tn( i ); j < tn( i + 1 ); ++j )
                                   ranks_v( j ) = i;
@@ -156,7 +152,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DetailsDistributedSearchTreeImpl,
     Kokkos::View<int **, DeviceType> v_ref( "v_ref", comm_size * comm_rank,
                                             DIM );
     Kokkos::parallel_for(
-        "fill_ref",
         Kokkos::RangePolicy<ExecutionSpace>( 0, comm_size * comm_rank ),
         KOKKOS_LAMBDA( int i ) {
             for ( int j = 0; j < DIM; ++j )

--- a/packages/Meshfree/test/tstNearestNeighborOperator.cpp
+++ b/packages/Meshfree/test/tstNearestNeighborOperator.cpp
@@ -193,17 +193,10 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( NearestNeighborOperator, structured_clouds,
     DataTransferKit::NearestNeighborOperator<DeviceType> nnop(
         comm, source_points, target_points );
 
-    // FIXME: Wish I could use subview but Kokkos doesn't like apply's
-    // interface
-    using ExecutionSpace = typename DeviceType::execution_space;
     Kokkos::View<double *, DeviceType> source_values( "source_values",
                                                       n_points );
-    Kokkos::parallel_for( "create_subview",
-                          Kokkos::RangePolicy<ExecutionSpace>( 0, n_points ),
-                          KOKKOS_LAMBDA( int i ) {
-                              source_values( i ) = source_points( i, 0 );
-                          } );
-    Kokkos::fence();
+    Kokkos::deep_copy( source_values,
+                       Kokkos::subview( source_points, Kokkos::ALL, 0 ) );
 
     nnop.apply( source_values, target_values );
 
@@ -286,12 +279,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( NearestNeighborOperator, mixed_clouds,
     unsigned int const n_points = source_points.extent( 0 );
     Kokkos::View<double *, DeviceType> source_values( "source_values",
                                                       n_points );
-    Kokkos::parallel_for( "create_subview",
-                          Kokkos::RangePolicy<ExecutionSpace>( 0, n_points ),
-                          KOKKOS_LAMBDA( int i ) {
-                              source_values( i ) = source_points( i, 0 );
-                          } );
-    Kokkos::fence();
+    Kokkos::deep_copy( source_values,
+                       Kokkos::subview( source_points, Kokkos::ALL, 0 ) );
 
     nnop.apply( source_values, target_values );
 

--- a/packages/Search/src/details/DTK_DetailsDistributedSearchTreeImpl.hpp
+++ b/packages/Search/src/details/DTK_DetailsDistributedSearchTreeImpl.hpp
@@ -19,6 +19,8 @@
 #include <Kokkos_Sort.hpp>
 #include <Tpetra_Distributor.hpp>
 
+#include <numeric> // accumulate
+
 namespace DataTransferKit
 {
 
@@ -152,13 +154,22 @@ DistributedSearchTreeImpl<DeviceType>::sendAcrossNetwork(
     Tpetra::Distributor &distributor, View exports,
     typename View::non_const_type imports )
 {
-    DTK_REQUIRE( ( exports.dimension_1() == imports.dimension_1() ) &&
+    DTK_REQUIRE( ( exports.dimension_0() ==
+                   std::accumulate( std::begin( distributor.getLengthsTo() ),
+                                    std::end( distributor.getLengthsTo() ),
+                                    size_t( 0 ) ) ) &&
+                 ( imports.dimension_0() ==
+                   std::accumulate( std::begin( distributor.getLengthsFrom() ),
+                                    std::end( distributor.getLengthsFrom() ),
+                                    size_t( 0 ) ) ) &&
+                 ( exports.dimension_1() == imports.dimension_1() ) &&
                  ( exports.dimension_2() == imports.dimension_2() ) &&
                  ( exports.dimension_3() == imports.dimension_3() ) &&
                  ( exports.dimension_4() == imports.dimension_4() ) &&
                  ( exports.dimension_5() == imports.dimension_5() ) &&
                  ( exports.dimension_6() == imports.dimension_6() ) &&
                  ( exports.dimension_7() == imports.dimension_7() ) );
+
     auto const num_packets = exports.dimension_1() * exports.dimension_2() *
                              exports.dimension_3() * exports.dimension_4() *
                              exports.dimension_5() * exports.dimension_6() *

--- a/packages/Search/src/details/DTK_DetailsDistributedSearchTreeImpl.hpp
+++ b/packages/Search/src/details/DTK_DetailsDistributedSearchTreeImpl.hpp
@@ -106,6 +106,45 @@ struct DistributedSearchTreeImpl
 template <typename DeviceType>
 double DistributedSearchTreeImpl<DeviceType>::epsilon = 1.0e-6;
 
+template <typename View>
+inline Kokkos::View<typename View::traits::data_type, Kokkos::LayoutRight,
+                    typename View::traits::host_mirror_space>
+create_layout_right_mirror_view(
+    View const &src,
+    typename std::enable_if<!(
+        ( std::is_same<typename View::traits::array_layout,
+                       Kokkos::LayoutRight>::value ||
+          View::rank == 1 && !std::is_same<typename View::traits::array_layout,
+                                           Kokkos::LayoutStride>::value ) &&
+        std::is_same<typename View::traits::memory_space,
+                     typename View::traits::host_mirror_space::memory_space>::
+            value )>::type * = 0 )
+{
+    return Kokkos::View<typename View::traits::data_type, Kokkos::LayoutRight,
+                        typename View::traits::host_mirror_space>(
+        std::string( src.label() ).append( "_layout_right_mirror" ),
+        src.dimension_0(), src.dimension_1(), src.dimension_2(),
+        src.dimension_3(), src.dimension_4(), src.dimension_5(),
+        src.dimension_6(), src.dimension_7() );
+}
+
+template <typename View>
+inline Kokkos::View<typename View::traits::data_type, Kokkos::LayoutRight,
+                    typename View::traits::host_mirror_space>
+create_layout_right_mirror_view(
+    View const &src,
+    typename std::enable_if<(
+        ( std::is_same<typename View::traits::array_layout,
+                       Kokkos::LayoutRight>::value ||
+          View::rank == 1 && !std::is_same<typename View::traits::array_layout,
+                                           Kokkos::LayoutStride>::value ) &&
+        std::is_same<typename View::traits::memory_space,
+                     typename View::traits::host_mirror_space::memory_space>::
+            value )>::type * = 0 )
+{
+    return src;
+}
+
 template <typename DeviceType>
 template <typename T>
 void DistributedSearchTreeImpl<DeviceType>::sendAcrossNetwork(


### PR DESCRIPTION
* Updated `DistributedSearchTreeImpl::sendAcrossNetwork()` to handle view with rank > 1
* Added `Details::NearestNeighborOperatorImpl::fetch()` that will also be used in the MLS operator