### PR TITLE
Implement "exact" nearest neighbors search on distributed tree

### DIFF
--- a/packages/Discretization/src/DTK_PointSearch_def.hpp
+++ b/packages/Discretization/src/DTK_PointSearch_def.hpp
@@ -353,16 +353,16 @@ PointSearch<DeviceType>::getSearchResults()
     Kokkos::View<unsigned int *, DeviceType> imported_query_ids(
         "imported_query_ids", n_imports );
 
-    DistributedSearchTreeImpl<DeviceType>::sendAcrossNetwork(
+    Details::DistributedSearchTreeImpl<DeviceType>::sendAcrossNetwork(
         _target_to_source_distributor, ranks, imported_ranks );
-    DistributedSearchTreeImpl<DeviceType>::sendAcrossNetwork(
+    Details::DistributedSearchTreeImpl<DeviceType>::sendAcrossNetwork(
         _target_to_source_distributor, cell_indices, imported_cell_indices );
-    DistributedSearchTreeImpl<DeviceType>::sendAcrossNetwork(
+    Details::DistributedSearchTreeImpl<DeviceType>::sendAcrossNetwork(
         _target_to_source_distributor, ref_pts, imported_ref_pts );
-    DistributedSearchTreeImpl<DeviceType>::sendAcrossNetwork(
+    Details::DistributedSearchTreeImpl<DeviceType>::sendAcrossNetwork(
         _target_to_source_distributor, query_ids, imported_query_ids );
 
-    DistributedSearchTreeImpl<DeviceType>::sortResults(
+    Details::DistributedSearchTreeImpl<DeviceType>::sortResults(
         imported_query_ids, imported_query_ids, imported_cell_indices,
         imported_ranks, imported_ref_pts );
 
@@ -549,7 +549,7 @@ void PointSearch<DeviceType>::performDistributedSearch(
 
     // Communicate cell indices
     Kokkos::realloc( imported_cell_indices, n_imports );
-    DistributedSearchTreeImpl<DeviceType>::sendAcrossNetwork(
+    Details::DistributedSearchTreeImpl<DeviceType>::sendAcrossNetwork(
         source_to_target_distributor, indices, imported_cell_indices );
     // Duplicate the points_coord for the communication. Duplicating the points
     // allows us to use the same distributor.
@@ -576,13 +576,13 @@ void PointSearch<DeviceType>::performDistributedSearch(
 
     // Communicate the points
     Kokkos::realloc( imported_points, n_imports );
-    DistributedSearchTreeImpl<DeviceType>::sendAcrossNetwork(
+    Details::DistributedSearchTreeImpl<DeviceType>::sendAcrossNetwork(
         source_to_target_distributor, exported_points, imported_points );
 
     // Communicate the query_ids. We communicate the query_ids to keep track of
     // which points is associated to which query.
     Kokkos::realloc( imported_query_ids, n_imports );
-    DistributedSearchTreeImpl<DeviceType>::sendAcrossNetwork(
+    Details::DistributedSearchTreeImpl<DeviceType>::sendAcrossNetwork(
         source_to_target_distributor, exported_query_ids, imported_query_ids );
 
     // Communicate the ranks of the sending processors. This will be used to
@@ -591,7 +591,7 @@ void PointSearch<DeviceType>::performDistributedSearch(
     Kokkos::View<int *, DeviceType> exported_ranks( "exported_ranks",
                                                     indices_size );
     Kokkos::deep_copy( exported_ranks, _comm->getRank() );
-    DistributedSearchTreeImpl<DeviceType>::sendAcrossNetwork(
+    Details::DistributedSearchTreeImpl<DeviceType>::sendAcrossNetwork(
         source_to_target_distributor, exported_ranks, ranks );
 }
 

--- a/packages/Meshfree/test/tstDetailsCommunicationHelpers.cpp
+++ b/packages/Meshfree/test/tstDetailsCommunicationHelpers.cpp
@@ -65,7 +65,7 @@ struct Helper
         auto v_imp =
             Kokkos::create_mirror( typename View2::memory_space(), v_ref );
 
-        DataTransferKit::DistributedSearchTreeImpl<
+        DataTransferKit::Details::DistributedSearchTreeImpl<
             DeviceType>::sendAcrossNetwork( distributor, v_exp, v_imp );
 
         // FIXME not sure why I need that guy but I do get a bus error when it

--- a/packages/Meshfree/test/tstNearestNeighborOperator.cpp
+++ b/packages/Meshfree/test/tstNearestNeighborOperator.cpp
@@ -11,8 +11,7 @@
 
 #include <Teuchos_UnitTestHarness.hpp>
 
-#include <DTK_DBC.hpp>                              // DataTransferKitException
-#include <DTK_DetailsDistributedSearchTreeImpl.hpp> // epsilon
+#include <DTK_DBC.hpp> // DataTransferKitException
 #include <DTK_NearestNeighborOperator.hpp>
 #include <Kokkos_Core.hpp>
 #include <Teuchos_DefaultComm.hpp>
@@ -112,14 +111,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( NearestNeighborOperator, unique_source_point,
         target_points_host( 0, d ) = (double)comm_rank;
     Kokkos::deep_copy( target_points, target_points_host );
 
-    // Shameless hack to help the distributed tree with the nearest neighbor
-    // search.
-    auto const epsilon_default =
-        DataTransferKit::Details::DistributedSearchTreeImpl<
-            DeviceType>::epsilon;
-    DataTransferKit::Details::DistributedSearchTreeImpl<DeviceType>::epsilon =
-        (double)comm_size;
-
     DataTransferKit::NearestNeighborOperator<DeviceType> nnop(
         comm, source_points, target_points );
 
@@ -145,11 +136,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( NearestNeighborOperator, unique_source_point,
     Kokkos::deep_copy( target_values_host, target_values );
     std::vector<double> target_values_ref = {255.};
     TEST_COMPARE_ARRAYS( target_values_host, target_values_ref );
-
-    // Reset the static variable to its original value to avoid interfering
-    // with other unit tests.
-    DataTransferKit::Details::DistributedSearchTreeImpl<DeviceType>::epsilon =
-        epsilon_default;
 }
 
 TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( NearestNeighborOperator, structured_clouds,
@@ -251,33 +237,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( NearestNeighborOperator, mixed_clouds,
     Kokkos::View<double *, DeviceType> target_values( "target_values",
                                                       n_target_points );
 
-    // Approximate nearest neighbor search may fail in some situations:
-    //
-    //    X     X     X     X     X  source points
-    //    ------------>     <------
-    //    rank 0            rank 1
-    //
-    //                   ^
-    //                   target point that falls in the gap does not overlap
-    //                   with local trees so it won't be able to find its
-    //                   neighbors
-    auto const epsilon_default =
-        DataTransferKit::Details::DistributedSearchTreeImpl<
-            DeviceType>::epsilon;
-    TEST_THROW( DataTransferKit::NearestNeighborOperator<DeviceType>(
-                    comm, source_points, target_points ),
-                DataTransferKit::DataTransferKitException );
-
-    // Determine appropriate tolerance for the approximate nearest neighbor
-    // search on the distributed tree.
-    DataTransferKit::Details::DistributedSearchTreeImpl<DeviceType>::epsilon =
-        std::max( {Lx / nx, Ly / ny, Lz / nz} );
-
-    // This time we do not get the exception when we call the constructor.
     DataTransferKit::NearestNeighborOperator<DeviceType> nnop(
         comm, source_points, target_points );
-    DataTransferKit::Details::DistributedSearchTreeImpl<DeviceType>::epsilon =
-        epsilon_default;
 
     unsigned int const n_points = source_points.extent( 0 );
     Kokkos::View<double *, DeviceType> source_values( "source_values",

--- a/packages/Meshfree/test/tstNearestNeighborOperator.cpp
+++ b/packages/Meshfree/test/tstNearestNeighborOperator.cpp
@@ -115,8 +115,9 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( NearestNeighborOperator, unique_source_point,
     // Shameless hack to help the distributed tree with the nearest neighbor
     // search.
     auto const epsilon_default =
-        DataTransferKit::DistributedSearchTreeImpl<DeviceType>::epsilon;
-    DataTransferKit::DistributedSearchTreeImpl<DeviceType>::epsilon =
+        DataTransferKit::Details::DistributedSearchTreeImpl<
+            DeviceType>::epsilon;
+    DataTransferKit::Details::DistributedSearchTreeImpl<DeviceType>::epsilon =
         (double)comm_size;
 
     DataTransferKit::NearestNeighborOperator<DeviceType> nnop(
@@ -147,7 +148,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( NearestNeighborOperator, unique_source_point,
 
     // Reset the static variable to its original value to avoid interfering
     // with other unit tests.
-    DataTransferKit::DistributedSearchTreeImpl<DeviceType>::epsilon =
+    DataTransferKit::Details::DistributedSearchTreeImpl<DeviceType>::epsilon =
         epsilon_default;
 }
 
@@ -261,20 +262,21 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( NearestNeighborOperator, mixed_clouds,
     //                   with local trees so it won't be able to find its
     //                   neighbors
     auto const epsilon_default =
-        DataTransferKit::DistributedSearchTreeImpl<DeviceType>::epsilon;
+        DataTransferKit::Details::DistributedSearchTreeImpl<
+            DeviceType>::epsilon;
     TEST_THROW( DataTransferKit::NearestNeighborOperator<DeviceType>(
                     comm, source_points, target_points ),
                 DataTransferKit::DataTransferKitException );
 
     // Determine appropriate tolerance for the approximate nearest neighbor
     // search on the distributed tree.
-    DataTransferKit::DistributedSearchTreeImpl<DeviceType>::epsilon =
+    DataTransferKit::Details::DistributedSearchTreeImpl<DeviceType>::epsilon =
         std::max( {Lx / nx, Ly / ny, Lz / nz} );
 
     // This time we do not get the exception when we call the constructor.
     DataTransferKit::NearestNeighborOperator<DeviceType> nnop(
         comm, source_points, target_points );
-    DataTransferKit::DistributedSearchTreeImpl<DeviceType>::epsilon =
+    DataTransferKit::Details::DistributedSearchTreeImpl<DeviceType>::epsilon =
         epsilon_default;
 
     unsigned int const n_points = source_points.extent( 0 );

--- a/packages/Search/src/DTK_DistributedSearchTree_decl.hpp
+++ b/packages/Search/src/DTK_DistributedSearchTree_decl.hpp
@@ -18,8 +18,8 @@
 #include <Teuchos_RCP.hpp>
 
 #include <DTK_DBC.hpp>
+#include <DTK_DetailsDistributedSearchTreeImpl.hpp>
 #include <DTK_LinearBVH.hpp>
-#include <details/DTK_DetailsDistributedSearchTreeImpl.hpp>
 
 #include "DTK_ConfigDefs.hpp"
 
@@ -47,7 +47,7 @@ class DistributedSearchTree
     using SizeType = typename BVH<DeviceType>::SizeType;
     /** Returns the global number of objects stored in the tree.
      */
-    inline SizeType size() const { return _size; }
+    inline SizeType size() const { return _top_tree_size; }
 
     /** Indicates whether the tree is empty on all processes.
      */
@@ -99,7 +99,8 @@ class DistributedSearchTree
     Teuchos::RCP<Teuchos::Comm<int> const> _comm;
     BVH<DeviceType> _top_tree;    // replicated
     BVH<DeviceType> _bottom_tree; // local
-    SizeType _size;
+    SizeType _top_tree_size;
+    Kokkos::View<SizeType *, DeviceType> _bottom_tree_sizes;
 };
 
 template <typename DeviceType>

--- a/packages/Search/src/DTK_DistributedSearchTree_decl.hpp
+++ b/packages/Search/src/DTK_DistributedSearchTree_decl.hpp
@@ -42,7 +42,7 @@ class DistributedSearchTree
     /** Returns the smallest axis-aligned box able to contain all the objects
      *  stored in the tree or an invalid box if the tree is empty.
      */
-    inline Box bounds() const { return _distributed_tree.bounds(); }
+    inline Box bounds() const { return _top_tree.bounds(); }
 
     using SizeType = typename BVH<DeviceType>::SizeType;
     /** Returns the global number of objects stored in the tree.
@@ -97,8 +97,8 @@ class DistributedSearchTree
 
   private:
     Teuchos::RCP<Teuchos::Comm<int> const> _comm;
-    BVH<DeviceType> _local_tree;
-    BVH<DeviceType> _distributed_tree;
+    BVH<DeviceType> _top_tree;    // replicated
+    BVH<DeviceType> _bottom_tree; // local
     SizeType _size;
 };
 
@@ -112,7 +112,7 @@ void DistributedSearchTree<DeviceType>::query(
 {
     using Tag = typename Query::Tag;
     DistributedSearchTreeImpl<DeviceType>::queryDispatch(
-        _comm, _distributed_tree, _local_tree, queries, indices, offset, ranks,
+        _comm, _top_tree, _bottom_tree, queries, indices, offset, ranks,
         Tag{} );
 }
 
@@ -130,8 +130,8 @@ DistributedSearchTree<DeviceType>::query(
 {
     using Tag = typename Query::Tag;
     DistributedSearchTreeImpl<DeviceType>::queryDispatch(
-        _comm, _distributed_tree, _local_tree, queries, indices, offset, ranks,
-        Tag{}, &distances );
+        _comm, _top_tree, _bottom_tree, queries, indices, offset, ranks, Tag{},
+        &distances );
 }
 
 } // end namespace DataTransferKit

--- a/packages/Search/src/DTK_DistributedSearchTree_decl.hpp
+++ b/packages/Search/src/DTK_DistributedSearchTree_decl.hpp
@@ -112,7 +112,7 @@ void DistributedSearchTree<DeviceType>::query(
     Kokkos::View<int *, DeviceType> &ranks ) const
 {
     using Tag = typename Query::Tag;
-    DistributedSearchTreeImpl<DeviceType>::queryDispatch(
+    Details::DistributedSearchTreeImpl<DeviceType>::queryDispatch(
         _comm, _top_tree, _bottom_tree, queries, indices, offset, ranks,
         Tag{} );
 }
@@ -130,7 +130,7 @@ DistributedSearchTree<DeviceType>::query(
     Kokkos::View<double *, DeviceType> &distances ) const
 {
     using Tag = typename Query::Tag;
-    DistributedSearchTreeImpl<DeviceType>::queryDispatch(
+    Details::DistributedSearchTreeImpl<DeviceType>::queryDispatch(
         _comm, _top_tree, _bottom_tree, queries, indices, offset, ranks, Tag{},
         &distances );
 }

--- a/packages/Search/src/DTK_DistributedSearchTree_decl.hpp
+++ b/packages/Search/src/DTK_DistributedSearchTree_decl.hpp
@@ -96,6 +96,7 @@ class DistributedSearchTree
            Kokkos::View<double *, DeviceType> &distances ) const;
 
   private:
+    friend struct Details::DistributedSearchTreeImpl<DeviceType>;
     Teuchos::RCP<Teuchos::Comm<int> const> _comm;
     BVH<DeviceType> _top_tree;    // replicated
     BVH<DeviceType> _bottom_tree; // local
@@ -113,8 +114,7 @@ void DistributedSearchTree<DeviceType>::query(
 {
     using Tag = typename Query::Tag;
     Details::DistributedSearchTreeImpl<DeviceType>::queryDispatch(
-        _comm, _top_tree, _bottom_tree, queries, indices, offset, ranks,
-        Tag{} );
+        *this, queries, indices, offset, ranks, Tag{} );
 }
 
 template <typename DeviceType>
@@ -131,8 +131,7 @@ DistributedSearchTree<DeviceType>::query(
 {
     using Tag = typename Query::Tag;
     Details::DistributedSearchTreeImpl<DeviceType>::queryDispatch(
-        _comm, _top_tree, _bottom_tree, queries, indices, offset, ranks, Tag{},
-        &distances );
+        *this, queries, indices, offset, ranks, Tag{}, &distances );
 }
 
 } // end namespace DataTransferKit

--- a/packages/Search/src/details/DTK_DetailsDistributedSearchTreeImpl.hpp
+++ b/packages/Search/src/details/DTK_DetailsDistributedSearchTreeImpl.hpp
@@ -26,6 +26,9 @@
 namespace DataTransferKit
 {
 
+namespace Details
+{
+
 template <typename DeviceType>
 struct DistributedSearchTreeImpl
 {
@@ -586,6 +589,7 @@ void DistributedSearchTreeImpl<DeviceType>::filterResults(
     offset = _offset;
 }
 
+} // end namespace Details
 } // end namespace DataTransferKit
 
 #endif

--- a/packages/Search/src/details/DTK_DetailsDistributedSearchTreeImpl.hpp
+++ b/packages/Search/src/details/DTK_DetailsDistributedSearchTreeImpl.hpp
@@ -110,15 +110,7 @@ struct DistributedSearchTreeImpl
     static typename std::enable_if<Kokkos::is_view<View>::value>::type
     sendAcrossNetwork( Tpetra::Distributor &distributor, View exports,
                        typename View::non_const_type imports );
-
-    static double epsilon;
 };
-
-// Default value for epsilon matches the inclusion tolerance in DTK-2.0 which
-// is arbitrary and might need adjustement in client code.  See
-// https://github.com/ORNL-CEES/DataTransferKit/blob/dtk-2.0/packages/Operators/src/Search/DTK_CoarseGlobalSearch.cpp#L61
-template <typename DeviceType>
-double DistributedSearchTreeImpl<DeviceType>::epsilon = 1.0e-6;
 
 template <typename View>
 inline Kokkos::View<typename View::traits::data_type, Kokkos::LayoutRight,

--- a/packages/Search/src/details/DTK_DetailsDistributedSearchTreeImpl.hpp
+++ b/packages/Search/src/details/DTK_DetailsDistributedSearchTreeImpl.hpp
@@ -543,7 +543,7 @@ void DistributedSearchTreeImpl<DeviceType>::filterResults(
 
     exclusivePrefixSum( _offset );
 
-    int const n_truncated_results = _offset( n_queries );
+    int const n_truncated_results = lastElement( _offset );
     Kokkos::View<int *, DeviceType> _indices( indices.label(),
                                               n_truncated_results );
     Kokkos::View<int *, DeviceType> _ranks( ranks.label(),

--- a/packages/Search/test/tstDetailsDistributedSearchTreeImpl.cpp
+++ b/packages/Search/test/tstDetailsDistributedSearchTreeImpl.cpp
@@ -186,8 +186,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DetailsDistributedSearchTreeImpl,
         ranks_host( i ) = ranks_[i];
     Kokkos::deep_copy( ranks, ranks_host );
 
-    DataTransferKit::DistributedSearchTreeImpl<DeviceType>::sortResults(
-        ids, results, ranks );
+    DataTransferKit::Details::DistributedSearchTreeImpl<
+        DeviceType>::sortResults( ids, results, ranks );
 
     // COMMENT: ids are untouched
     Kokkos::deep_copy( ids_host, ids );
@@ -203,10 +203,9 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DetailsDistributedSearchTreeImpl,
         }
 
     Kokkos::View<int *, DeviceType> not_sized_properly( "", m );
-    TEST_THROW(
-        DataTransferKit::DistributedSearchTreeImpl<DeviceType>::sortResults(
-            ids, not_sized_properly ),
-        DataTransferKit::DataTransferKitException );
+    TEST_THROW( DataTransferKit::Details::DistributedSearchTreeImpl<
+                    DeviceType>::sortResults( ids, not_sized_properly ),
+                DataTransferKit::DataTransferKitException );
 }
 
 TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DetailsDistributedSearchTreeImpl,
@@ -229,8 +228,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DetailsDistributedSearchTreeImpl,
 
     Kokkos::View<int *, DeviceType> offset( "offset" );
 
-    DataTransferKit::DistributedSearchTreeImpl<DeviceType>::countResults(
-        m, ids, offset );
+    DataTransferKit::Details::DistributedSearchTreeImpl<
+        DeviceType>::countResults( m, ids, offset );
 
     auto offset_host = Kokkos::create_mirror_view( offset );
     Kokkos::deep_copy( offset_host, offset );
@@ -287,7 +286,7 @@ inline void checkNewViewWasAllocated( View1 const &v1, View2 const &v2,
 TEUCHOS_UNIT_TEST( DetailsDistributedSearchTreeImpl,
                    create_layout_right_mirror_view )
 {
-    using DataTransferKit::create_layout_right_mirror_view;
+    using DataTransferKit::Details::create_layout_right_mirror_view;
     using Kokkos::ALL;
     using Kokkos::LayoutLeft;
     using Kokkos::LayoutRight;

--- a/packages/Search/test/tstDetailsUtils.cpp
+++ b/packages/Search/test/tstDetailsUtils.cpp
@@ -147,6 +147,17 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DetailsUtils, minmax, DeviceType )
     TEST_EQUALITY( std::get<1>( minmax_y ), 5 );
 }
 
+TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DetailsUtils, accumulate, DeviceType )
+{
+    Kokkos::View<int[6], DeviceType> v( "v" );
+    Kokkos::deep_copy( v, 5 );
+    TEST_EQUALITY( DataTransferKit::accumulate( v, 3 ), 33 );
+
+    Kokkos::View<int *, DeviceType> w( "w", 5 );
+    DataTransferKit::iota( w, 2 );
+    TEST_EQUALITY( DataTransferKit::accumulate( w, 4 ), 24 );
+}
+
 // Include the test macros.
 #include "DataTransferKitSearch_ETIHelperMacros.h"
 
@@ -160,6 +171,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DetailsUtils, minmax, DeviceType )
     TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT( DetailsUtils, last_element,          \
                                           DeviceType##NODE )                   \
     TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT( DetailsUtils, minmax,                \
+                                          DeviceType##NODE )                   \
+    TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT( DetailsUtils, accumulate,            \
                                           DeviceType##NODE )
 
 // Demangle the types

--- a/packages/Search/test/tstDistributedSearchTree.cpp
+++ b/packages/Search/test/tstDistributedSearchTree.cpp
@@ -31,9 +31,10 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DistributedSearchTree, hello_world,
     int const comm_rank = Teuchos::rank( *comm );
     int const comm_size = Teuchos::size( *comm );
 
-    auto default_epsilon =
-        DataTransferKit::DistributedSearchTreeImpl<DeviceType>::epsilon;
-    DataTransferKit::DistributedSearchTreeImpl<DeviceType>::epsilon = 0.5;
+    auto default_epsilon = DataTransferKit::Details::DistributedSearchTreeImpl<
+        DeviceType>::epsilon;
+    DataTransferKit::Details::DistributedSearchTreeImpl<DeviceType>::epsilon =
+        0.5;
 
     int const n = 4;
     Kokkos::View<DataTransferKit::Box *, DeviceType> boxes( "boxes", n );
@@ -151,7 +152,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DistributedSearchTree, hello_world,
         TEST_EQUALITY( ranks_host( 1 ), comm_size - 1 - comm_rank );
     }
 
-    DataTransferKit::DistributedSearchTreeImpl<DeviceType>::epsilon =
+    DataTransferKit::Details::DistributedSearchTreeImpl<DeviceType>::epsilon =
         default_epsilon;
 }
 
@@ -327,7 +328,11 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DistributedSearchTree,
     TEST_ASSERT( !tree.empty() );
     TEST_EQUALITY( (int)tree.size(), 2 * comm_size );
 
-    DataTransferKit::DistributedSearchTreeImpl<DeviceType>::epsilon = .5;
+    auto const default_epsilon =
+        DataTransferKit::Details::DistributedSearchTreeImpl<
+            DeviceType>::epsilon;
+    DataTransferKit::Details::DistributedSearchTreeImpl<DeviceType>::epsilon =
+        .5;
 
     //  +----------0----------1----------2----------3
     //  |          |          |          |          |
@@ -351,6 +356,9 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DistributedSearchTree,
                 {{{(double)( comm_size - 1 - comm_rank ) + .75, 0., 0.}}, 1},
             } ),
             {0}, {0, 1}, {comm_size - 1}, success, out );
+
+    DataTransferKit::Details::DistributedSearchTreeImpl<DeviceType>::epsilon =
+        default_epsilon;
 }
 
 std::vector<std::array<double, 3>>

--- a/packages/Search/test/tstDistributedSearchTree.cpp
+++ b/packages/Search/test/tstDistributedSearchTree.cpp
@@ -31,11 +31,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DistributedSearchTree, hello_world,
     int const comm_rank = Teuchos::rank( *comm );
     int const comm_size = Teuchos::size( *comm );
 
-    auto default_epsilon = DataTransferKit::Details::DistributedSearchTreeImpl<
-        DeviceType>::epsilon;
-    DataTransferKit::Details::DistributedSearchTreeImpl<DeviceType>::epsilon =
-        0.5;
-
     int const n = 4;
     Kokkos::View<DataTransferKit::Box *, DeviceType> boxes( "boxes", n );
     auto boxes_host = Kokkos::create_mirror_view( boxes );
@@ -151,9 +146,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DistributedSearchTree, hello_world,
         TEST_EQUALITY( indices_host( 1 ), 1 );
         TEST_EQUALITY( ranks_host( 1 ), comm_size - 1 - comm_rank );
     }
-
-    DataTransferKit::Details::DistributedSearchTreeImpl<DeviceType>::epsilon =
-        default_epsilon;
 }
 
 TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DistributedSearchTree, empty_tree,
@@ -328,12 +320,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DistributedSearchTree,
     TEST_ASSERT( !tree.empty() );
     TEST_EQUALITY( (int)tree.size(), 2 * comm_size );
 
-    auto const default_epsilon =
-        DataTransferKit::Details::DistributedSearchTreeImpl<
-            DeviceType>::epsilon;
-    DataTransferKit::Details::DistributedSearchTreeImpl<DeviceType>::epsilon =
-        .5;
-
     //  +----------0----------1----------2----------3
     //  |          |          |          |          |
     //  |          |          |          |          |
@@ -356,9 +342,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DistributedSearchTree,
                 {{{(double)( comm_size - 1 - comm_rank ) + .75, 0., 0.}}, 1},
             } ),
             {0}, {0, 1}, {comm_size - 1}, success, out );
-
-    DataTransferKit::Details::DistributedSearchTreeImpl<DeviceType>::epsilon =
-        default_epsilon;
 }
 
 std::vector<std::array<double, 3>>

--- a/packages/Search/test/tstDistributedSearchTree.cpp
+++ b/packages/Search/test/tstDistributedSearchTree.cpp
@@ -31,7 +31,10 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DistributedSearchTree, hello_world,
     int const comm_rank = Teuchos::rank( *comm );
     int const comm_size = Teuchos::size( *comm );
 
+    auto default_epsilon =
+        DataTransferKit::DistributedSearchTreeImpl<DeviceType>::epsilon;
     DataTransferKit::DistributedSearchTreeImpl<DeviceType>::epsilon = 0.5;
+
     int const n = 4;
     Kokkos::View<DataTransferKit::Box *, DeviceType> boxes( "boxes", n );
     auto boxes_host = Kokkos::create_mirror_view( boxes );
@@ -147,6 +150,9 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DistributedSearchTree, hello_world,
         TEST_EQUALITY( indices_host( 1 ), 1 );
         TEST_EQUALITY( ranks_host( 1 ), comm_size - 1 - comm_rank );
     }
+
+    DataTransferKit::DistributedSearchTreeImpl<DeviceType>::epsilon =
+        default_epsilon;
 }
 
 TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DistributedSearchTree, empty_tree,


### PR DESCRIPTION
Previous implementation would only yield an "approximate" nearest neighbors.  It was leveraging `Details::DistributedSearchTreeImpl::epsilon` to produce an algorithm equivalent to what was in DTK-2.0.

Note that `DistributedSearchTreeImpl` was moved into `Details::` namespace which will affect you if you use `sendAcrossNetwork()`.  I plan on moving this functionality, along with `fetch()`, into some communication helpers `struct` soon.