### PR TITLE
Amend to #336

### DIFF
--- a/packages/Meshfree/test/PointCloudProblemGenerator/ExodusProblemGenerator_def.hpp
+++ b/packages/Meshfree/test/PointCloudProblemGenerator/ExodusProblemGenerator_def.hpp
@@ -216,7 +216,7 @@ void ExodusProblemGenerator<Scalar, SourceDevice, TargetDevice>::
     // Send the coordinates to their new owning rank.
     Kokkos::View<Coordinate **, Kokkos::LayoutLeft, Kokkos::Serial>
         import_coords( "import_coords", num_node_import, 3 );
-    DistributedSearchTreeImpl<Device>::sendAcrossNetwork(
+    Details::DistributedSearchTreeImpl<Device>::sendAcrossNetwork(
         distributor, export_coords, import_coords );
 
     // Move the coordinates to the device.

--- a/packages/Meshfree/test/tstNearestNeighborExodusGenerator.cpp
+++ b/packages/Meshfree/test/tstNearestNeighborExodusGenerator.cpp
@@ -163,13 +163,6 @@ void testUniquelyOwnedProblem(
     using ExecutionSpace = typename Device::execution_space;
     using Scalar = double;
 
-    // Set an epsilon for the search. The meshes (see below) mesh a sphere of
-    // radius 10. An epsilon of 1.0 is needed to fully capture nearest
-    // neighbors in adjacent partitions.
-    auto const epsilon_default =
-        DataTransferKit::DistributedSearchTreeImpl<Device>::epsilon;
-    DataTransferKit::DistributedSearchTreeImpl<Device>::epsilon = 1.0;
-
     // Get the communicator.
     auto comm = Teuchos::DefaultComm<int>::getComm();
 
@@ -248,11 +241,6 @@ void testUniquelyOwnedProblem(
                        nearest_src_coords( t, 2 ), 0 );
         TEST_FLOATING_EQUALITY( host_tgt_field( t ), data_val, 1.0e-12 );
     }
-
-    // Reset the static variable to its original value to avoid interfering
-    // with other unit tests.
-    DataTransferKit::DistributedSearchTreeImpl<Device>::epsilon =
-        epsilon_default;
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
#361 introduced a couple changes that were not reflected in #336 when it got merged into master:
* `DistributedSearchTreeImpl::epsilon` was removed.  (The nearest neighbors search on the distributed tree does not require this "knob" any more to guarantee the exact result.)
* `DistributedSearchTreeImpl` was moved into `Details::` namespace

This could have been avoided, had the PR been rebased onto master.  Oh well...