### PR TITLE
Fix bug with duplicate morton codes

### DIFF
--- a/packages/Search/test/tstLinearBVH.cpp
+++ b/packages/Search/test/tstLinearBVH.cpp
@@ -207,6 +207,34 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( LinearBVH, couple_leaves_tree, DeviceType )
                   success, out );
 }
 
+TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( LinearBVH, duplicated_leaves, DeviceType )
+{
+    // The tree contains multiple (more than two) leaves that will be assigned
+    // the same Morton code.  This was able to trigger a bug that we discovered
+    // when building trees over ~10M indexable values.  The hierarchy generated
+    // at construction had leaves with no parent which yielded a segfault later
+    // when computing bounding boxes and walking the hierarchy toward the root.
+    auto const bvh = makeBvh<DeviceType>( {
+        {{{0., 0., 0.}}, {{0., 0., 0.}}},
+        {{{1., 1., 1.}}, {{1., 1., 1.}}},
+        {{{1., 1., 1.}}, {{1., 1., 1.}}},
+        {{{1., 1., 1.}}, {{1., 1., 1.}}},
+    } );
+
+    // I commented out the test below because it will fail unless we modify
+    // checkResults() such that it sorts the results for each query before
+    // comparing arrays because there is no way to predict the ordering of the
+    // indices for the duplicate leaves.  This is fine, the point of this test
+    // was to fix the segfault we would get when calling the constructor of BVH.
+    // checkResults( bvh,
+    //              makeWithinQueries<DeviceType>( {
+    //                  {{{0., 0., 0.}}, 1.},
+    //                  {{{1., 1., 1.}}, 1.},
+    //                  {{{.5, .5, .5}}, 1.},
+    //              } ),
+    //              {0, 1, 2, 3, 0, 1, 2, 3}, {0, 1, 4, 8}, success, out );
+}
+
 TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( LinearBVH, miscellaneous, DeviceType )
 {
     auto const bvh = makeBvh<DeviceType>( {
@@ -710,6 +738,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( LinearBVH, rtree, DeviceType )
     TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT( LinearBVH, single_leaf_tree,         \
                                           DeviceType##NODE )                   \
     TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT( LinearBVH, couple_leaves_tree,       \
+                                          DeviceType##NODE )                   \
+    TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT( LinearBVH, duplicated_leaves,        \
                                           DeviceType##NODE )                   \
     TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT( LinearBVH, miscellaneous,            \
                                           DeviceType##NODE )                   \


### PR DESCRIPTION
The original `findSplit()` code was taken from [Karras's post on Nvidia Developer Blog](https://devblogs.nvidia.com/thinking-parallel-part-iii-tree-construction-gpu/).  The algorithm relies on all the keys (Morton codes) being unique.  In order to handle duplicates, following [another article also by Karras [1]](https://devblogs.nvidia.com/wp-content/uploads/2012/11/karras2012hpg_paper.pdf), I had implemented `commonPrefix()` that augment each key by a bit representation of its index (i.e., if k_i = k_j use I and j as fallback) but I had missed a couple places with direct calls to `clz(first_code ^ second_code)`.  As a result, the hierarchy generated had leaves with parent pointing to null which yielded a segfault later when walking the hierarchy toward the root to compute the internal nodes bounding boxes.  We never saw this bug before because the algorithm did not seem to be affected with 2x duplicates.  I saw it for the first time when building a tree over 10M random points.

[1] Tero Karras, "Maximizing Parallelism in the Construction of BVHs, Octrees, and k-d Trees", *High Performance Graphics (2012)*