### PR TITLE
Enable ptrace when running CI containers

### DIFF
--- a/docker/jenkins/docker-compose.yml
+++ b/docker/jenkins/docker-compose.yml
@@ -15,7 +15,10 @@ services:
       - BUILD_TYPE=$BUILD_TYPE
     command: $WORKSPACE/docker/jenkins/build.sh
     cap_add:
+      # required to mount DTK into Trilinos source directory
       - SYS_ADMIN
+      # required to use CLang's LeakSanitizer
+      - SYS_PTRACE
     network_mode: host
 volumes:
   jenkins_data:


### PR DESCRIPTION
It looks like Clang Sanitizer has been having errors for a while and we never realized it because the regex match wasn't looking for the right keywords.

See [last build on jenkins-ci  after merge of #377](https://cloud.cees.ornl.gov/jenkins-ci/job/DataTransferKit-Clang50/304/testReport/projectroot.DataTransferKit.packages.Utils/test/DataTransferKitUtils_Miscellaneous_test_MPI_1/):
```
End Result: TEST PASSED
==4416==LeakSanitizer has encountered a fatal error.
==4416==HINT: For debugging, try setting environment variable LSAN_OPTIONS=verbosity=1:log_threads=1
==4416==HINT: LeakSanitizer does not work under ptrace (strace, gdb, etc)
-------------------------------------------------------
Primary job  terminated normally, but 1 process returned
a non-zero exit code.. Per user-direction, the job has been aborted.
-------------------------------------------------------
--------------------------------------------------------------------------
mpiexec detected that one or more processes exited with non-zero status, thus causing
the job to be terminated. The first process to do so was:

  Process name: [[61376,1],0]
  Exit code:    1
--------------------------------------------------------------------------
```

It seems like me might have missed a [change in behavior in docker](https://github.com/moby/moby/issues/20082).