### PR TITLE
Run on Summitdev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@
 *.blg
 *.lot
 *.exo
-/build
+/build*
 /install
 /DTKData
 /doc/browser/doc/html/

--- a/scripts/README_OLCF_SUMMITDEV.md
+++ b/scripts/README_OLCF_SUMMITDEV.md
@@ -1,21 +1,38 @@
 # Building DTK on Summitdev
 The user guide for Summitdev can be found [here](https://www.olcf.ornl.gov/kb_articles/summitdev-quickstart).
 
-## Software environment
-Below are the modules that need to be loaded:
+## Software Environment
+You need to load the following modules:
 ```
-module swap xl gcc/5.4.0
-module load cmake
-module load cuda
-module load boost
-module load netlib-lapack
+module load gcc/5.4.0 cmake cuda boost netlib-lapack
 ```
 
-# Configuring Trilinos with DTK
-This directory constains a configuration script
-([olcf_summitdev_cmake](olcf_summitdev_cmake)) to build DTK and its test suite.
-Don't forget to set `CMAKE_INSTALL_PREFIX` and `TRILINOS_DIR`. You also need
-to set `nvcc_wrapper` as the underlying C++ compiler for Spectrum MPI:
-```
+## Download, Configure, Build Trilinos+DTK
+```bash
+git clone https://github.com/trilinos/Trilinos.git
+cd Trilinos
+export TRILINOS_DIR=$PWD
+
+git clone https://github.com/ORNL-CEES/DataTransferKit.git
+cd DataTransferKit
+
+mkdir build
+cd build
+
+module load cmake gcc/5.4.0 cuda boost netlib-lapack
 export OMPI_CXX=$TRILINOS_DIR/packages/kokkos/bin/nvcc_wrapper
+
+../scripts/olcf_summitdev_cmake
+make -j8
+```
+
+## Run Tests
+
+In `Trilinos/DataTransferKit/build` run:
+```
+bsub -P YOUR_PROJECT_ID -nnodes 1 -W 120 -Is $SHELL
+module load cmake gcc/5.4.0 cuda boost netlib-lapack
+export OMP_NUM_THREADS=5 # jsrun needs this
+
+ctest
 ```

--- a/scripts/olcf_summitdev_cmake
+++ b/scripts/olcf_summitdev_cmake
@@ -5,11 +5,11 @@ ARGS=(
     -D BUILD_SHARED_LIBS=ON
     ### COMPILERS AND FLAGS ###
     -D CMAKE_CXX_FLAGS="-g -arch=sm_60 -lineinfo \
-        -std=c++11 --expt-extended-lambda \
         -Xcudafe --diag_suppress=conversion_function_not_usable \
         -Xcudafe --diag_suppress=cc_clobber_ignored \
         -Xcudafe --diag_suppress=code_is_unreachable"
     -D DataTransferKit_CXX_FLAGS="-Wall -Wno-shadow -Wpedantic"
+    -D Trilinos_CXX11_FLAGS="-std=c++11 --expt-extended-lambda"
     ### TPLs ###
     -D TPL_ENABLE_MPI=ON
     -D TPL_ENABLE_BLAS=ON

--- a/scripts/olcf_summitdev_cmake
+++ b/scripts/olcf_summitdev_cmake
@@ -15,6 +15,9 @@ ARGS=(
         -Xcudafe --diag_suppress=code_is_unreachable"
     -D DataTransferKit_CXX_FLAGS="-Wall -Wno-shadow -Wpedantic"
     -D Trilinos_CXX11_FLAGS="-std=c++11 --expt-extended-lambda"
+    -D MPI_EXEC="jsrun"
+    -D MPI_EXEC_NUMPROCS_FLAG="-n"
+    -D MPI_EXEC_POST_NUMPROCS_FLAGS="-a1;-c5;-bpacked:5;-g1"
     ### TPLs ###
     -D TPL_ENABLE_MPI=ON
     -D TPL_ENABLE_BLAS=ON

--- a/scripts/olcf_summitdev_cmake
+++ b/scripts/olcf_summitdev_cmake
@@ -1,4 +1,9 @@
 #!/bin/bash
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source ${SCRIPT_DIR}/set_kokkos_env.sh
+
+rm -f  CMakeCache.txt
+rm -rf CMakeFiles/
 EXTRA_ARGS=("$@")
 ARGS=(
     -D CMAKE_BUILD_TYPE=Debug


### PR DESCRIPTION
The magic is 
```
-D MPI_EXEC="jsrun"
-D MPI_EXEC_NUMPROCS_FLAG="-n"
-D MPI_EXEC_POST_NUMPROCS_FLAGS="-a1;-c5;-bpacked:5"
```
- semicolons in MPI_EXEC_POST_NUMPROCS_FLAGS instead of spaces!
- `-n` means number of resource sets
- `-a1` means one task/mpirank per resource set
- `-c5` means use 5 cores per resource set
- `bpacked` means threads per task/mpirank.
- `-g1`means one GPU per resource set

Since in cmake max procs for MPI is set to 4, I've set 5 threads per rank maximum to not create more threads then there are cores.
Technically -c and -bpacked are supposed to be total cores (20) divided by number of ranks.

If you want more threads, you'd either make -c and -bpacked adaptable or live with using hyperthreading / multiple threads per core.