### PR TITLE
[WIP] Priority queue binary search

### DIFF
--- a/packages/Search/src/details/DTK_DetailsPriorityQueue.hpp
+++ b/packages/Search/src/details/DTK_DetailsPriorityQueue.hpp
@@ -51,19 +51,27 @@ class PriorityQueue
         // construct the element to compare to those in the queue
         T elem( std::forward<Args>( args )... );
 
-        // find position of the new element in the sorted array
-        // COMMENT: could consider implementing a binary search here
-        SizeType pos;
-        for ( pos = 0; pos < _size; ++pos )
-            if ( !_compare( _queue[pos], elem ) )
-                break;
+        // find position of the new element in the sorted array (binary search)
+        SizeType low = 0, high = _size;
+        while ( low < high )
+        {
+            SizeType mid = ( low + high ) / 2;
+            if ( _compare( _queue[mid], elem ) )
+            {
+                low = mid + 1;
+            }
+            else
+            {
+                high = mid;
+            }
+        };
 
         // move memory to make room for it
-        for ( SizeType tmp = _size; tmp > pos; --tmp )
+        for ( SizeType tmp = _size; tmp > low; --tmp )
             _queue[tmp] = _queue[tmp - 1];
 
         // insert the new element
-        _queue[pos] = elem;
+        _queue[low] = elem;
 
         // update the size of the queue
         ++_size;

--- a/packages/Search/src/details/DTK_DetailsPriorityQueue.hpp
+++ b/packages/Search/src/details/DTK_DetailsPriorityQueue.hpp
@@ -72,7 +72,7 @@ class PriorityQueue
     KOKKOS_INLINE_FUNCTION void pop()
     {
         assert( _size > 0 );
-        _size--;
+        --_size;
     }
 
     KOKKOS_INLINE_FUNCTION T const &top() const


### PR DESCRIPTION
`DataTransferKitSearch_bvh.exe` Serial, 10M values, 1M queries

With Linear Search (first run second run):
construction 5.53588 5.5373
knn 13.9905 13.8701
radius 14.3755 14.2256

With Binary Search:
construction 5.43541 5.42187
knn 13.186 13.1136
radius 13.9668 13.9157

That's  ~2% Faster construction, ~5% faster KNN Search, 2% faster Radius Search.
Not a lot.

What I did not test, yet, is CUDA and OpenMP.

Should Construction be faster, too?
Or is that a coincidence?

P.S.: Code is from https://stackoverflow.com/questions/22123489/olog-n-algorithm-to-find-best-insert-position-in-sorted-array