### PR TITLE
Use heap in priority queue implementation

### DIFF
--- a/packages/Search/examples/bvh_driver/bvh_driver.cpp
+++ b/packages/Search/examples/bvh_driver/bvh_driver.cpp
@@ -198,7 +198,7 @@ int main( int argc, char *argv[] )
         }
         else if ( node == "serial" )
         {
-#ifdef KOKKOS_HAVE_SERIAL
+#ifdef KOKKOS_ENABLE_SERIAL
             typedef Kokkos::Compat::KokkosSerialWrapperNode Node;
             main_<Node>( clp, argc, argv );
 #else
@@ -207,7 +207,7 @@ int main( int argc, char *argv[] )
         }
         else if ( node == "openmp" )
         {
-#ifdef KOKKOS_HAVE_OPENMP
+#ifdef KOKKOS_ENABLE_OPENMP
             typedef Kokkos::Compat::KokkosOpenMPWrapperNode Node;
             main_<Node>( clp, argc, argv );
 #else
@@ -216,7 +216,7 @@ int main( int argc, char *argv[] )
         }
         else if ( node == "cuda" )
         {
-#ifdef KOKKOS_HAVE_CUDA
+#ifdef KOKKOS_ENABLE_CUDA
             typedef Kokkos::Compat::KokkosCudaWrapperNode Node;
             main_<Node>( clp, argc, argv );
 #else

--- a/packages/Search/src/details/DTK_DetailsPriorityQueue.hpp
+++ b/packages/Search/src/details/DTK_DetailsPriorityQueue.hpp
@@ -107,17 +107,21 @@ class PriorityQueue
         _size--;
     }
 
+    // in TreeTraversal::nearestQuery, pop() is often followed by push which is
+    // an opportunity for doing a single bubble-down operation instead of paying
+    // for both one bubble-down and one bubble-up
     template <typename... Args>
     KOKKOS_INLINE_FUNCTION void pop_push( Args &&... args )
     {
         assert( _size < _max_size );
 
+        // size will be decremented by pop()
         _size++;
+
+        // put the new element at the bottom level
         _heap[_size - 1] = T{std::forward<Args>( args )...};
 
-        // This works, because pop will remove the 0th element,
-        // insert the last one on top (added in the previous line), and bubble
-        // it down
+        // replace the root with that new element and bubble it down
         pop();
     }
 

--- a/packages/Search/src/details/DTK_DetailsPriorityQueue.hpp
+++ b/packages/Search/src/details/DTK_DetailsPriorityQueue.hpp
@@ -107,6 +107,20 @@ class PriorityQueue
         _size--;
     }
 
+    template <typename... Args>
+    KOKKOS_INLINE_FUNCTION void pop_push( Args &&... args )
+    {
+        assert( _size < _max_size );
+
+        _size++;
+        _heap[_size - 1] = T{std::forward<Args>( args )...};
+
+        // This works, because pop will remove the 0th element,
+        // insert the last one on top (added in the previous line), and bubble
+        // it down
+        pop();
+    }
+
     KOKKOS_INLINE_FUNCTION T const &top() const
     {
         assert( _size > 0 );

--- a/packages/Search/src/details/DTK_DetailsPriorityQueue.hpp
+++ b/packages/Search/src/details/DTK_DetailsPriorityQueue.hpp
@@ -38,12 +38,17 @@ class PriorityQueue
   public:
     using SizeType = size_t;
     using ValueType = T;
+    using ValueCompare = Compare;
 
     KOKKOS_FUNCTION PriorityQueue() = default;
 
     KOKKOS_INLINE_FUNCTION bool empty() const { return _size == 0; }
 
     KOKKOS_INLINE_FUNCTION IndexType size() const { return _size; }
+
+    KOKKOS_INLINE_FUNCTION void clear() { _size = 0; }
+
+    KOKKOS_INLINE_FUNCTION ValueCompare value_comp() const { return _compare; }
 
     template <typename... Args>
     KOKKOS_INLINE_FUNCTION void push( Args &&... args )

--- a/packages/Search/src/details/DTK_DetailsPriorityQueue.hpp
+++ b/packages/Search/src/details/DTK_DetailsPriorityQueue.hpp
@@ -37,10 +37,13 @@ class PriorityQueue
 {
   public:
     using SizeType = size_t;
+    using ValueType = T;
 
     KOKKOS_FUNCTION PriorityQueue() = default;
 
     KOKKOS_INLINE_FUNCTION bool empty() const { return _size == 0; }
+
+    KOKKOS_INLINE_FUNCTION IndexType size() const { return _size; }
 
     template <typename... Args>
     KOKKOS_INLINE_FUNCTION void push( Args &&... args )

--- a/packages/Search/src/details/DTK_DetailsPriorityQueue.hpp
+++ b/packages/Search/src/details/DTK_DetailsPriorityQueue.hpp
@@ -26,7 +26,7 @@ template <typename T>
 struct Less
 {
   public:
-    KOKKOS_INLINE_FUNCTION bool operator()( T const &x, T const &y )
+    KOKKOS_INLINE_FUNCTION bool operator()( T const &x, T const &y ) const
     {
         return x < y;
     }

--- a/packages/Search/src/details/DTK_DetailsPriorityQueue.hpp
+++ b/packages/Search/src/details/DTK_DetailsPriorityQueue.hpp
@@ -22,16 +22,6 @@ namespace DataTransferKit
 namespace Details
 {
 
-// FIXME probably doesnt belong here
-// also not sure if I actually cannot use std::move() with CUDA
-template <typename T>
-KOKKOS_INLINE_FUNCTION void swap( T &a, T &b )
-{
-    T c{std::move( a )};
-    a = std::move( b );
-    b = std::move( c );
-}
-
 template <typename T>
 struct Less
 {

--- a/packages/Search/src/details/DTK_DetailsPriorityQueue.hpp
+++ b/packages/Search/src/details/DTK_DetailsPriorityQueue.hpp
@@ -36,7 +36,7 @@ template <typename T, typename Compare = Less<T>>
 class PriorityQueue
 {
   public:
-    using SizeType = size_t;
+    using IndexType = std::ptrdiff_t;
     using ValueType = T;
     using ValueCompare = Compare;
 
@@ -57,7 +57,7 @@ class PriorityQueue
         assert( _size < _max_size );
 
         // add the element to the bottom level of the heap
-        SizeType pos = _size;
+        IndexType pos = _size;
         T elem{std::forward<Args>( args )...};
 
         // perform up-heap operation
@@ -66,7 +66,7 @@ class PriorityQueue
             // compare the added element with its parent
             // if they are in correct order, stop
             // if not, swap them and continue
-            SizeType const parent = ( pos - 1 ) / 2;
+            IndexType const parent = ( pos - 1 ) / 2;
             if ( !_compare( _heap[parent], elem ) )
                 break;
             _heap[pos] = _heap[parent];
@@ -85,7 +85,7 @@ class PriorityQueue
         assert( _size > 0 );
 
         // replace the root with the last element on the last level
-        SizeType pos = 0;
+        IndexType pos = 0;
 
         // perform down-heap operation
         while ( true )
@@ -93,10 +93,10 @@ class PriorityQueue
             // compare the new root with its children
             // if they are in the correct order, stop
             // if not, swap the element with one of its children and continue
-            SizeType const left_child = 2 * pos + 1;
-            SizeType const right_child = 2 * pos + 2;
-            SizeType next_pos = _size - 1;
-            for ( SizeType child : {left_child, right_child} )
+            IndexType const left_child = 2 * pos + 1;
+            IndexType const right_child = 2 * pos + 2;
+            IndexType next_pos = _size - 1;
+            for ( IndexType child : {left_child, right_child} )
                 if ( child < _size - 1 &&
                      _compare( _heap[next_pos], _heap[child] ) )
                     next_pos = child;
@@ -137,9 +137,9 @@ class PriorityQueue
     }
 
   private:
-    static SizeType constexpr _max_size = 256;
+    static IndexType constexpr _max_size = 256;
     T _heap[_max_size];
-    SizeType _size = 0;
+    IndexType _size = 0;
     Compare _compare;
 };
 

--- a/packages/Search/src/details/DTK_DetailsPriorityQueue.hpp
+++ b/packages/Search/src/details/DTK_DetailsPriorityQueue.hpp
@@ -60,7 +60,7 @@ class PriorityQueue
 
         // add the element to the bottom level of the heap
         SizeType pos = _size;
-        _heap[pos] = T{std::forward<Args>( args )...};
+        T elem{std::forward<Args>( args )...};
 
         // perform up-heap operation
         while ( pos > 0 )
@@ -69,11 +69,13 @@ class PriorityQueue
             // if they are in correct order, stop
             // if not, swap them and continue
             SizeType const parent = ( pos - 1 ) / 2;
-            if ( !_compare( _heap[parent], _heap[pos] ) )
+            if ( !_compare( _heap[parent], elem ) )
                 break;
-            swap( _heap[pos], _heap[parent] );
+            _heap[pos] = _heap[parent];
             pos = parent;
         }
+
+        _heap[pos] = elem;
 
         // update the size of the heap
         ++_size;
@@ -85,7 +87,6 @@ class PriorityQueue
         assert( _size > 0 );
 
         // replace the root with the last element on the last level
-        _heap[0] = _heap[_size - 1];
         SizeType pos = 0;
 
         // perform down-heap operation
@@ -96,16 +97,18 @@ class PriorityQueue
             // if not, swap the element with one of its children and continue
             SizeType const left_child = 2 * pos + 1;
             SizeType const right_child = 2 * pos + 2;
-            SizeType next_pos = pos;
+            SizeType next_pos = _size - 1;
             for ( SizeType child : {left_child, right_child} )
                 if ( child < _size - 1 &&
                      _compare( _heap[next_pos], _heap[child] ) )
                     next_pos = child;
-            if ( pos == next_pos )
+            if ( next_pos == _size - 1 )
                 break;
-            swap( _heap[pos], _heap[next_pos] );
+            _heap[pos] = _heap[next_pos];
             pos = next_pos;
         }
+
+        _heap[pos] = _heap[_size - 1];
 
         // update the size of the heap
         _size--;

--- a/packages/Search/src/details/DTK_DetailsTreeTraversal.hpp
+++ b/packages/Search/src/details/DTK_DetailsTreeTraversal.hpp
@@ -177,9 +177,9 @@ nearestQuery( BoundingVolumeHierarchy<DeviceType> const &bvh,
         double const node_distance = queue.top().second;
         // NOTE: it would be nice to be able to do something like
         // tie( node, node_distance = queue.top();
-        queue.pop();
         if ( TreeTraversal<DeviceType>::isLeaf( node ) )
         {
+            queue.pop();
             insert( TreeTraversal<DeviceType>::getIndex( bvh, node ),
                     node_distance );
             count++;
@@ -187,12 +187,14 @@ nearestQuery( BoundingVolumeHierarchy<DeviceType> const &bvh,
         else
         {
             // insert children of the node in the priority list
-            for ( Node const *child :
-                  {node->children.first, node->children.second} )
-            {
-                double const child_distance = distance( child );
-                queue.push( child, child_distance );
-            }
+
+            auto const c1 = node->children.first;
+            auto const c2 = node->children.second;
+
+            queue.pop_push( c1,
+                            distance( c1 ) ); // combine popping with the first
+                                              // push to save one bubble-up
+            queue.push( c2, distance( c2 ) );
         }
     }
     return count;

--- a/packages/Search/src/details/DTK_DetailsTreeTraversal.hpp
+++ b/packages/Search/src/details/DTK_DetailsTreeTraversal.hpp
@@ -177,6 +177,10 @@ nearestQuery( BoundingVolumeHierarchy<DeviceType> const &bvh,
         double const node_distance = queue.top().second;
         // NOTE: it would be nice to be able to do something like
         // tie( node, node_distance = queue.top();
+
+        // NOTE: not calling queue.pop() here so that it can be combined with
+        // the next push in case the node is internal (thus sparing a bubble-up
+        // operation)
         if ( TreeTraversal<DeviceType>::isLeaf( node ) )
         {
             queue.pop();
@@ -188,13 +192,10 @@ nearestQuery( BoundingVolumeHierarchy<DeviceType> const &bvh,
         {
             // insert children of the node in the priority list
 
-            auto const c1 = node->children.first;
-            auto const c2 = node->children.second;
-
-            queue.pop_push( c1,
-                            distance( c1 ) ); // combine popping with the first
-                                              // push to save one bubble-up
-            queue.push( c2, distance( c2 ) );
+            auto const left_child = node->children.first;
+            auto const right_child = node->children.second;
+            queue.pop_push( left_child, distance( left_child ) );
+            queue.push( right_child, distance( right_child ) );
         }
     }
     return count;

--- a/packages/Search/src/details/DTK_DetailsTreeTraversal.hpp
+++ b/packages/Search/src/details/DTK_DetailsTreeTraversal.hpp
@@ -153,8 +153,9 @@ nearestQuery( BoundingVolumeHierarchy<DeviceType> const &bvh,
 
     struct CompareDistance
     {
-        KOKKOS_INLINE_FUNCTION bool operator()( PairNodePtrDistance const &lhs,
-                                                PairNodePtrDistance const &rhs )
+        KOKKOS_INLINE_FUNCTION bool
+        operator()( PairNodePtrDistance const &lhs,
+                    PairNodePtrDistance const &rhs ) const
         {
             // reverse order (larger distance means lower priority)
             return lhs.second > rhs.second;

--- a/packages/Search/test/tstDetailsTreeTraversal.cpp
+++ b/packages/Search/test/tstDetailsTreeTraversal.cpp
@@ -58,3 +58,60 @@ TEUCHOS_UNIT_TEST( LinearBVH, priority_queue )
     queue.pop();
     TEST_ASSERT( queue.empty() );
 }
+
+TEUCHOS_UNIT_TEST( LinearBVH, push_heap )
+{
+    // Here checking against the example of binary heap insertion from
+    // https://en.wikipedia.org/wiki/Binary_heap#Insert
+    DataTransferKit::Details::PriorityQueue<int> queue;
+    auto heap = reinterpret_cast<int *>( &queue );
+
+    queue.push( 11 );
+    queue.push( 5 );
+    queue.push( 8 );
+    queue.push( 3 );
+    queue.push( 4 );
+    TEST_EQUALITY( queue.top(), 11 );
+    TEST_EQUALITY( heap[0], 11 );
+    TEST_EQUALITY( heap[1], 5 );
+    TEST_EQUALITY( heap[2], 8 );
+    TEST_EQUALITY( heap[3], 3 );
+    TEST_EQUALITY( heap[4], 4 );
+
+    queue.push( 15 );
+
+    TEST_EQUALITY( queue.top(), 15 );
+    TEST_EQUALITY( heap[0], 15 );
+    TEST_EQUALITY( heap[1], 5 );
+    TEST_EQUALITY( heap[2], 11 );
+    TEST_EQUALITY( heap[3], 3 );
+    TEST_EQUALITY( heap[4], 4 );
+    TEST_EQUALITY( heap[5], 8 );
+}
+
+TEUCHOS_UNIT_TEST( LinearBVH, pop_heap )
+{
+    // See https://en.wikipedia.org/wiki/Binary_heap#Extract
+    DataTransferKit::Details::PriorityQueue<int> queue;
+    auto heap = reinterpret_cast<int *>( &queue );
+
+    queue.push( 11 );
+    queue.push( 5 );
+    queue.push( 8 );
+    queue.push( 3 );
+    queue.push( 4 );
+    TEST_EQUALITY( queue.top(), 11 );
+    TEST_EQUALITY( heap[0], 11 );
+    TEST_EQUALITY( heap[1], 5 );
+    TEST_EQUALITY( heap[2], 8 );
+    TEST_EQUALITY( heap[3], 3 );
+    TEST_EQUALITY( heap[4], 4 );
+
+    queue.pop();
+
+    TEST_EQUALITY( queue.top(), 8 );
+    TEST_EQUALITY( heap[0], 8 );
+    TEST_EQUALITY( heap[1], 5 );
+    TEST_EQUALITY( heap[2], 4 );
+    TEST_EQUALITY( heap[3], 3 );
+}

--- a/packages/Search/test/tstDetailsTreeTraversal.cpp
+++ b/packages/Search/test/tstDetailsTreeTraversal.cpp
@@ -189,3 +189,135 @@ TEUCHOS_UNIT_TEST( LinearBVH, heap )
     TEST_EQUALITY( heap[5], 3 );
     TEST_EQUALITY( heap[6], 5 );
 }
+
+TEUCHOS_UNIT_TEST( LinearBVH, min_heap )
+{
+    // Here reproducing the example of a binary min heap from Wikipedia and then
+    // popping all elements one by one.
+    // This helped resolving an issue with ProprityQueue::pop() that was not
+    // exposed by other unit tests in this file, partly because they were too
+    // trivial.  The bug was only showing with real kNN search problems when
+    // comparing results from BoundaryVolumeHierarchy with boost::rtree.
+    struct Greater
+    {
+      public:
+        KOKKOS_FUNCTION bool operator()( int x, int y ) const { return x > y; }
+    };
+    DataTransferKit::Details::PriorityQueue<int, Greater> queue;
+    auto heap = reinterpret_cast<int const *>( &queue );
+
+    queue.push( 1 );
+    TEST_EQUALITY( heap[0], 1 );
+
+    queue.push( 2 );
+    TEST_EQUALITY( heap[0], 1 );
+    TEST_EQUALITY( heap[1], 2 );
+
+    queue.push( 3 );
+    TEST_EQUALITY( heap[0], 1 );
+    TEST_EQUALITY( heap[1], 2 );
+    TEST_EQUALITY( heap[2], 3 );
+
+    queue.push( 17 );
+    TEST_EQUALITY( heap[0], 1 );
+    TEST_EQUALITY( heap[1], 2 );
+    TEST_EQUALITY( heap[2], 3 );
+    TEST_EQUALITY( heap[3], 17 );
+
+    queue.push( 19 );
+    TEST_EQUALITY( heap[0], 1 );
+    TEST_EQUALITY( heap[1], 2 );
+    TEST_EQUALITY( heap[2], 3 );
+    TEST_EQUALITY( heap[3], 17 );
+    TEST_EQUALITY( heap[4], 19 );
+
+    queue.push( 36 );
+    TEST_EQUALITY( heap[0], 1 );
+    TEST_EQUALITY( heap[1], 2 );
+    TEST_EQUALITY( heap[2], 3 );
+    TEST_EQUALITY( heap[3], 17 );
+    TEST_EQUALITY( heap[4], 19 );
+    TEST_EQUALITY( heap[5], 36 );
+
+    queue.push( 7 );
+    TEST_EQUALITY( heap[0], 1 );
+    TEST_EQUALITY( heap[1], 2 );
+    TEST_EQUALITY( heap[2], 3 );
+    TEST_EQUALITY( heap[3], 17 );
+    TEST_EQUALITY( heap[4], 19 );
+    TEST_EQUALITY( heap[5], 36 );
+    TEST_EQUALITY( heap[6], 7 );
+
+    queue.push( 25 );
+    TEST_EQUALITY( heap[0], 1 );
+    TEST_EQUALITY( heap[1], 2 );
+    TEST_EQUALITY( heap[2], 3 );
+    TEST_EQUALITY( heap[3], 17 );
+    TEST_EQUALITY( heap[4], 19 );
+    TEST_EQUALITY( heap[5], 36 );
+    TEST_EQUALITY( heap[6], 7 );
+    TEST_EQUALITY( heap[7], 25 );
+
+    queue.push( 100 );
+    TEST_EQUALITY( heap[0], 1 );
+    TEST_EQUALITY( heap[1], 2 );
+    TEST_EQUALITY( heap[2], 3 );
+    TEST_EQUALITY( heap[3], 17 );
+    TEST_EQUALITY( heap[4], 19 );
+    TEST_EQUALITY( heap[5], 36 );
+    TEST_EQUALITY( heap[6], 7 );
+    TEST_EQUALITY( heap[7], 25 );
+    TEST_EQUALITY( heap[8], 100 );
+
+    queue.pop();
+    TEST_EQUALITY( heap[0], 2 );
+    TEST_EQUALITY( heap[1], 17 );
+    TEST_EQUALITY( heap[2], 3 );
+    TEST_EQUALITY( heap[3], 25 );
+    TEST_EQUALITY( heap[4], 19 );
+    TEST_EQUALITY( heap[5], 36 );
+    TEST_EQUALITY( heap[6], 7 );
+    TEST_EQUALITY( heap[7], 100 );
+
+    queue.pop();
+    TEST_EQUALITY( heap[0], 3 );
+    TEST_EQUALITY( heap[1], 17 );
+    TEST_EQUALITY( heap[2], 7 );
+    TEST_EQUALITY( heap[3], 25 );
+    TEST_EQUALITY( heap[4], 19 );
+    TEST_EQUALITY( heap[5], 36 );
+    TEST_EQUALITY( heap[6], 100 );
+
+    queue.pop();
+    TEST_EQUALITY( heap[0], 7 );
+    TEST_EQUALITY( heap[1], 17 );
+    TEST_EQUALITY( heap[2], 36 );
+    TEST_EQUALITY( heap[3], 25 );
+    TEST_EQUALITY( heap[4], 19 );
+    TEST_EQUALITY( heap[5], 100 );
+
+    queue.pop();
+    TEST_EQUALITY( heap[0], 17 );
+    TEST_EQUALITY( heap[1], 19 );
+    TEST_EQUALITY( heap[2], 36 );
+    TEST_EQUALITY( heap[3], 25 );
+    TEST_EQUALITY( heap[4], 100 );
+
+    queue.pop();
+    TEST_EQUALITY( heap[0], 19 );
+    TEST_EQUALITY( heap[1], 25 );
+    TEST_EQUALITY( heap[2], 36 );
+    TEST_EQUALITY( heap[3], 100 );
+
+    queue.pop();
+    TEST_EQUALITY( heap[0], 25 );
+    TEST_EQUALITY( heap[1], 100 );
+    TEST_EQUALITY( heap[2], 36 );
+
+    queue.pop();
+    TEST_EQUALITY( heap[0], 36 );
+    TEST_EQUALITY( heap[1], 100 );
+
+    queue.pop();
+    TEST_EQUALITY( heap[0], 100 );
+}

--- a/packages/Search/test/tstDetailsTreeTraversal.cpp
+++ b/packages/Search/test/tstDetailsTreeTraversal.cpp
@@ -67,13 +67,13 @@ void check_heap( PriorityQueue const &queue,
                  bool &success, Teuchos::FancyOStream &out )
 {
     auto const size = queue.size();
-    TEST_EQUALITY( size, heap_ref.size() );
+    TEST_EQUALITY( size, static_cast<decltype( size )>( heap_ref.size() ) );
 
     // NOTE Shameless hack to inspect the private data of the priority queue.
     // Will break if data is reordered in the PriorityQueue class declaration.
     auto heap =
         reinterpret_cast<typename PriorityQueue::ValueType const *>( &queue );
-    for ( typename PriorityQueue::SizeType i = 0; i < size; ++i )
+    for ( typename PriorityQueue::IndexType i = 0; i < size; ++i )
         TEST_EQUALITY( heap[i], heap_ref[i] );
 }
 

--- a/packages/Search/test/tstDetailsTreeTraversal.cpp
+++ b/packages/Search/test/tstDetailsTreeTraversal.cpp
@@ -59,63 +59,61 @@ TEUCHOS_UNIT_TEST( LinearBVH, priority_queue )
     TEST_ASSERT( queue.empty() );
 }
 
+template <typename PriorityQueue>
+void check_heap( PriorityQueue const &queue,
+                 std::vector<typename PriorityQueue::ValueType> const &heap_ref,
+                 bool &success, Teuchos::FancyOStream &out )
+{
+    auto const size = queue.size();
+    TEST_EQUALITY( size, heap_ref.size() );
+
+    // NOTE Shameless hack to inspect the private data of the priority queue.
+    // Will break if data is reordered in the PriorityQueue class declaration.
+    auto heap =
+        reinterpret_cast<typename PriorityQueue::ValueType const *>( &queue );
+    for ( typename PriorityQueue::SizeType i = 0; i < size; ++i )
+        TEST_EQUALITY( heap[i], heap_ref[i] );
+}
+
 TEUCHOS_UNIT_TEST( LinearBVH, push_heap )
 {
     // Here checking against the example of binary heap insertion from
     // https://en.wikipedia.org/wiki/Binary_heap#Insert
     DataTransferKit::Details::PriorityQueue<int> queue;
-    // NOTE Shameless hack to inspect the private data of the priority queue.
-    // Will break if data is reordered in the class.
-    auto heap = reinterpret_cast<int const *>( &queue );
 
     queue.push( 11 );
     queue.push( 5 );
     queue.push( 8 );
     queue.push( 3 );
     queue.push( 4 );
+
     TEST_EQUALITY( queue.top(), 11 );
-    TEST_EQUALITY( heap[0], 11 );
-    TEST_EQUALITY( heap[1], 5 );
-    TEST_EQUALITY( heap[2], 8 );
-    TEST_EQUALITY( heap[3], 3 );
-    TEST_EQUALITY( heap[4], 4 );
+    check_heap( queue, {11, 5, 8, 3, 4}, success, out );
 
     queue.push( 15 );
 
     TEST_EQUALITY( queue.top(), 15 );
-    TEST_EQUALITY( heap[0], 15 );
-    TEST_EQUALITY( heap[1], 5 );
-    TEST_EQUALITY( heap[2], 11 );
-    TEST_EQUALITY( heap[3], 3 );
-    TEST_EQUALITY( heap[4], 4 );
-    TEST_EQUALITY( heap[5], 8 );
+    check_heap( queue, {15, 5, 11, 3, 4, 8}, success, out );
 }
 
 TEUCHOS_UNIT_TEST( LinearBVH, pop_heap )
 {
     // See https://en.wikipedia.org/wiki/Binary_heap#Extract
     DataTransferKit::Details::PriorityQueue<int> queue;
-    auto heap = reinterpret_cast<int const *>( &queue );
 
     queue.push( 11 );
     queue.push( 5 );
     queue.push( 8 );
     queue.push( 3 );
     queue.push( 4 );
+
     TEST_EQUALITY( queue.top(), 11 );
-    TEST_EQUALITY( heap[0], 11 );
-    TEST_EQUALITY( heap[1], 5 );
-    TEST_EQUALITY( heap[2], 8 );
-    TEST_EQUALITY( heap[3], 3 );
-    TEST_EQUALITY( heap[4], 4 );
+    check_heap( queue, {11, 5, 8, 3, 4}, success, out );
 
     queue.pop();
 
     TEST_EQUALITY( queue.top(), 8 );
-    TEST_EQUALITY( heap[0], 8 );
-    TEST_EQUALITY( heap[1], 5 );
-    TEST_EQUALITY( heap[2], 4 );
-    TEST_EQUALITY( heap[3], 3 );
+    check_heap( queue, {8, 5, 4, 3}, success, out );
 }
 
 TEUCHOS_UNIT_TEST( LinearBVH, heap )
@@ -130,64 +128,33 @@ TEUCHOS_UNIT_TEST( LinearBVH, heap )
     // Nevertheless, I thought it helps understanding how the algorithm works so
     // I decided to keep it as a unit test.
     DataTransferKit::Details::PriorityQueue<int> queue;
-    auto heap = reinterpret_cast<int const *>( &queue );
 
     queue.push( 3 );
-    TEST_EQUALITY( heap[0], 3 );
+    check_heap( queue, {3}, success, out );
 
     queue.push( 1 );
-    TEST_EQUALITY( heap[0], 3 );
-    TEST_EQUALITY( heap[1], 1 );
+    check_heap( queue, {3, 1}, success, out );
 
     queue.push( 4 );
-    TEST_EQUALITY( heap[0], 4 );
-    TEST_EQUALITY( heap[1], 1 );
-    TEST_EQUALITY( heap[2], 3 );
+    check_heap( queue, {4, 1, 3}, success, out );
 
     queue.push( 1 );
-    TEST_EQUALITY( heap[0], 4 );
-    TEST_EQUALITY( heap[1], 1 );
-    TEST_EQUALITY( heap[2], 3 );
-    TEST_EQUALITY( heap[3], 1 );
+    check_heap( queue, {4, 1, 3, 1}, success, out );
 
     queue.push( 5 );
-    TEST_EQUALITY( heap[0], 5 );
-    TEST_EQUALITY( heap[1], 4 );
-    TEST_EQUALITY( heap[2], 3 );
-    TEST_EQUALITY( heap[3], 1 );
-    TEST_EQUALITY( heap[4], 1 );
+    check_heap( queue, {5, 4, 3, 1, 1}, success, out );
 
     queue.push( 9 );
-    TEST_EQUALITY( heap[0], 9 );
-    TEST_EQUALITY( heap[1], 4 );
-    TEST_EQUALITY( heap[2], 5 );
-    TEST_EQUALITY( heap[3], 1 );
-    TEST_EQUALITY( heap[4], 1 );
-    TEST_EQUALITY( heap[5], 3 );
+    check_heap( queue, {9, 4, 5, 1, 1, 3}, success, out );
 
     queue.pop();
-    TEST_EQUALITY( heap[0], 5 );
-    TEST_EQUALITY( heap[1], 4 );
-    TEST_EQUALITY( heap[2], 3 );
-    TEST_EQUALITY( heap[3], 1 );
-    TEST_EQUALITY( heap[4], 1 );
+    check_heap( queue, {5, 4, 3, 1, 1}, success, out );
 
     queue.push( 9 );
-    TEST_EQUALITY( heap[0], 9 );
-    TEST_EQUALITY( heap[1], 4 );
-    TEST_EQUALITY( heap[2], 5 );
-    TEST_EQUALITY( heap[3], 1 );
-    TEST_EQUALITY( heap[4], 1 );
-    TEST_EQUALITY( heap[5], 3 );
+    check_heap( queue, {9, 4, 5, 1, 1, 3}, success, out );
 
     queue.push( 6 );
-    TEST_EQUALITY( heap[0], 9 );
-    TEST_EQUALITY( heap[1], 4 );
-    TEST_EQUALITY( heap[2], 6 );
-    TEST_EQUALITY( heap[3], 1 );
-    TEST_EQUALITY( heap[4], 1 );
-    TEST_EQUALITY( heap[5], 3 );
-    TEST_EQUALITY( heap[6], 5 );
+    check_heap( queue, {9, 4, 6, 1, 1, 3, 5}, success, out );
 }
 
 TEUCHOS_UNIT_TEST( LinearBVH, min_heap )
@@ -204,120 +171,55 @@ TEUCHOS_UNIT_TEST( LinearBVH, min_heap )
         KOKKOS_FUNCTION bool operator()( int x, int y ) const { return x > y; }
     };
     DataTransferKit::Details::PriorityQueue<int, Greater> queue;
-    auto heap = reinterpret_cast<int const *>( &queue );
 
     queue.push( 1 );
-    TEST_EQUALITY( heap[0], 1 );
+    check_heap( queue, {1}, success, out );
 
     queue.push( 2 );
-    TEST_EQUALITY( heap[0], 1 );
-    TEST_EQUALITY( heap[1], 2 );
+    check_heap( queue, {1, 2}, success, out );
 
     queue.push( 3 );
-    TEST_EQUALITY( heap[0], 1 );
-    TEST_EQUALITY( heap[1], 2 );
-    TEST_EQUALITY( heap[2], 3 );
+    check_heap( queue, {1, 2, 3}, success, out );
 
     queue.push( 17 );
-    TEST_EQUALITY( heap[0], 1 );
-    TEST_EQUALITY( heap[1], 2 );
-    TEST_EQUALITY( heap[2], 3 );
-    TEST_EQUALITY( heap[3], 17 );
+    check_heap( queue, {1, 2, 3, 17}, success, out );
 
     queue.push( 19 );
-    TEST_EQUALITY( heap[0], 1 );
-    TEST_EQUALITY( heap[1], 2 );
-    TEST_EQUALITY( heap[2], 3 );
-    TEST_EQUALITY( heap[3], 17 );
-    TEST_EQUALITY( heap[4], 19 );
+    check_heap( queue, {1, 2, 3, 17, 19}, success, out );
 
     queue.push( 36 );
-    TEST_EQUALITY( heap[0], 1 );
-    TEST_EQUALITY( heap[1], 2 );
-    TEST_EQUALITY( heap[2], 3 );
-    TEST_EQUALITY( heap[3], 17 );
-    TEST_EQUALITY( heap[4], 19 );
-    TEST_EQUALITY( heap[5], 36 );
+    check_heap( queue, {1, 2, 3, 17, 19, 36}, success, out );
 
     queue.push( 7 );
-    TEST_EQUALITY( heap[0], 1 );
-    TEST_EQUALITY( heap[1], 2 );
-    TEST_EQUALITY( heap[2], 3 );
-    TEST_EQUALITY( heap[3], 17 );
-    TEST_EQUALITY( heap[4], 19 );
-    TEST_EQUALITY( heap[5], 36 );
-    TEST_EQUALITY( heap[6], 7 );
+    check_heap( queue, {1, 2, 3, 17, 19, 36, 7}, success, out );
 
     queue.push( 25 );
-    TEST_EQUALITY( heap[0], 1 );
-    TEST_EQUALITY( heap[1], 2 );
-    TEST_EQUALITY( heap[2], 3 );
-    TEST_EQUALITY( heap[3], 17 );
-    TEST_EQUALITY( heap[4], 19 );
-    TEST_EQUALITY( heap[5], 36 );
-    TEST_EQUALITY( heap[6], 7 );
-    TEST_EQUALITY( heap[7], 25 );
+    check_heap( queue, {1, 2, 3, 17, 19, 36, 7, 25}, success, out );
 
     queue.push( 100 );
-    TEST_EQUALITY( heap[0], 1 );
-    TEST_EQUALITY( heap[1], 2 );
-    TEST_EQUALITY( heap[2], 3 );
-    TEST_EQUALITY( heap[3], 17 );
-    TEST_EQUALITY( heap[4], 19 );
-    TEST_EQUALITY( heap[5], 36 );
-    TEST_EQUALITY( heap[6], 7 );
-    TEST_EQUALITY( heap[7], 25 );
-    TEST_EQUALITY( heap[8], 100 );
+    check_heap( queue, {1, 2, 3, 17, 19, 36, 7, 25, 100}, success, out );
 
     queue.pop();
-    TEST_EQUALITY( heap[0], 2 );
-    TEST_EQUALITY( heap[1], 17 );
-    TEST_EQUALITY( heap[2], 3 );
-    TEST_EQUALITY( heap[3], 25 );
-    TEST_EQUALITY( heap[4], 19 );
-    TEST_EQUALITY( heap[5], 36 );
-    TEST_EQUALITY( heap[6], 7 );
-    TEST_EQUALITY( heap[7], 100 );
+    check_heap( queue, {2, 17, 3, 25, 19, 36, 7, 100}, success, out );
 
     queue.pop();
-    TEST_EQUALITY( heap[0], 3 );
-    TEST_EQUALITY( heap[1], 17 );
-    TEST_EQUALITY( heap[2], 7 );
-    TEST_EQUALITY( heap[3], 25 );
-    TEST_EQUALITY( heap[4], 19 );
-    TEST_EQUALITY( heap[5], 36 );
-    TEST_EQUALITY( heap[6], 100 );
+    check_heap( queue, {3, 17, 7, 25, 19, 36, 100}, success, out );
 
     queue.pop();
-    TEST_EQUALITY( heap[0], 7 );
-    TEST_EQUALITY( heap[1], 17 );
-    TEST_EQUALITY( heap[2], 36 );
-    TEST_EQUALITY( heap[3], 25 );
-    TEST_EQUALITY( heap[4], 19 );
-    TEST_EQUALITY( heap[5], 100 );
+    check_heap( queue, {7, 17, 36, 25, 19, 100}, success, out );
 
     queue.pop();
-    TEST_EQUALITY( heap[0], 17 );
-    TEST_EQUALITY( heap[1], 19 );
-    TEST_EQUALITY( heap[2], 36 );
-    TEST_EQUALITY( heap[3], 25 );
-    TEST_EQUALITY( heap[4], 100 );
+    check_heap( queue, {17, 19, 36, 25, 100}, success, out );
 
     queue.pop();
-    TEST_EQUALITY( heap[0], 19 );
-    TEST_EQUALITY( heap[1], 25 );
-    TEST_EQUALITY( heap[2], 36 );
-    TEST_EQUALITY( heap[3], 100 );
+    check_heap( queue, {19, 25, 36, 100}, success, out );
 
     queue.pop();
-    TEST_EQUALITY( heap[0], 25 );
-    TEST_EQUALITY( heap[1], 100 );
-    TEST_EQUALITY( heap[2], 36 );
+    check_heap( queue, {25, 100, 36}, success, out );
 
     queue.pop();
-    TEST_EQUALITY( heap[0], 36 );
-    TEST_EQUALITY( heap[1], 100 );
+    check_heap( queue, {36, 100}, success, out );
 
     queue.pop();
-    TEST_EQUALITY( heap[0], 100 );
+    check_heap( queue, {100}, success, out );
 }

--- a/packages/Search/test/tstDetailsTreeTraversal.cpp
+++ b/packages/Search/test/tstDetailsTreeTraversal.cpp
@@ -223,3 +223,30 @@ TEUCHOS_UNIT_TEST( LinearBVH, min_heap )
     queue.pop();
     check_heap( queue, {100}, success, out );
 }
+
+TEUCHOS_UNIT_TEST( LinearBVH, pop_push )
+{
+    // note that calling pop_push(x) does not necessarily yield the same heap
+    // than calling consecutively pop() and push(x)
+    // below is a max heap example to illustate this interesting property
+    DataTransferKit::Details::PriorityQueue<int> queue;
+
+    std::vector<int> ref = {100, 19, 36, 17, 3, 25, 1, 2, 7};
+    for ( auto x : ref )
+        queue.push( x );
+    check_heap( queue, ref, success, out );
+
+    queue.pop();
+    check_heap( queue, {36, 19, 25, 17, 3, 7, 1, 2}, success, out );
+
+    queue.push( 9 );
+    check_heap( queue, {36, 19, 25, 17, 3, 7, 1, 2, 9}, success, out );
+
+    queue.clear();
+    for ( auto x : ref )
+        queue.push( x );
+    check_heap( queue, ref, success, out );
+
+    queue.pop_push( 9 );
+    check_heap( queue, {36, 19, 25, 17, 3, 9, 1, 2, 7}, success, out );
+}


### PR DESCRIPTION


~NOTE: If `swap()` turn out to be a hot spot, consider replacing with simple copy assignment and directly copy inserted element at the end when position is known.~