### PR TITLE
remove unnecessary bracket

### DIFF
--- a/packages/Search/test/Search_UnitTestHelpers.hpp
+++ b/packages/Search/test/Search_UnitTestHelpers.hpp
@@ -212,7 +212,7 @@ std::vector<Value> extractAndSort( View const &v, int begin, int end )
     std::vector<Value> r( v.data() + begin, v.data() + end );
     std::sort( r.begin(), r.end() );
     return r;
-};
+}
 
 template <typename InputView1, typename InputView2>
 void validateResults( std::tuple<InputView1, InputView1> const &reference,


### PR DESCRIPTION
Removes a compiler warning (GCC 7.3).