### PR TITLE
Sort queries to reduce data divergence

### DIFF
--- a/packages/Search/src/DTK_LinearBVH_decl.hpp
+++ b/packages/Search/src/DTK_LinearBVH_decl.hpp
@@ -94,7 +94,7 @@ void queryDispatch(
 {
     using ExecutionSpace = typename DeviceType::execution_space;
 
-    int const n_queries = queries.extent( 0 );
+    auto const n_queries = queries.extent( 0 );
 
     Kokkos::realloc( offset, n_queries + 1 );
     Kokkos::deep_copy( offset, 0 );
@@ -227,7 +227,7 @@ void queryDispatch( BoundingVolumeHierarchy<DeviceType> const bvh,
 {
     using ExecutionSpace = typename DeviceType::execution_space;
 
-    int const n_queries = queries.extent( 0 );
+    auto const n_queries = queries.extent( 0 );
 
     // Initialize view
     // [ 0 0 0 .... 0 0 ]

--- a/packages/Search/src/DTK_LinearBVH_decl.hpp
+++ b/packages/Search/src/DTK_LinearBVH_decl.hpp
@@ -110,7 +110,7 @@ void queryDispatch(
     Kokkos::parallel_for(
         DTK_MARK_REGION( "scan_queries_for_numbers_of_nearest_neighbors" ),
         Kokkos::RangePolicy<ExecutionSpace>( 0, n_queries ),
-        KOKKOS_LAMBDA( int i ) { offset( i ) = queries( i )._k; } );
+        KOKKOS_LAMBDA( int i ) { offset( permute( i ) ) = queries( i )._k; } );
     Kokkos::fence();
 
     exclusivePrefixSum( offset );
@@ -133,10 +133,10 @@ void queryDispatch(
                 int count = 0;
                 Details::TreeTraversal<DeviceType>::query(
                     bvh, queries( i ),
-                    [indices, offset, distances, i, &count]( int index,
-                                                             double distance ) {
-                        indices( offset( i ) + count ) = index;
-                        distances( offset( i ) + count ) = distance;
+                    [indices, offset, distances, permute, i,
+                     &count]( int index, double distance ) {
+                        indices( offset( permute( i ) ) + count ) = index;
+                        distances( offset( permute( i ) ) + count ) = distance;
                         count++;
                     } );
             } );
@@ -151,8 +151,8 @@ void queryDispatch(
                 int count = 0;
                 Details::TreeTraversal<DeviceType>::query(
                     bvh, queries( i ),
-                    [indices, offset, i, &count]( int index, double ) {
-                        indices( offset( i ) + count++ ) = index;
+                    [indices, offset, permute, i, &count]( int index, double ) {
+                        indices( offset( permute( i ) ) + count++ ) = index;
                     } );
             } );
         Kokkos::fence();
@@ -224,21 +224,6 @@ void queryDispatch(
         }
         offset = tmp_offset;
     }
-
-    if ( distances_ptr )
-    {
-        Kokkos::View<double *, DeviceType> &distances = *distances_ptr;
-
-        std::tie( offset, indices, distances ) =
-            Details::BatchedQueries<DeviceType>::reversePermutation(
-                permute, offset, indices, distances );
-    }
-    else
-    {
-        std::tie( offset, indices ) =
-            Details::BatchedQueries<DeviceType>::reversePermutation(
-                permute, offset, indices );
-    }
 }
 
 template <typename DeviceType, typename Query>
@@ -275,7 +260,7 @@ void queryDispatch( BoundingVolumeHierarchy<DeviceType> const bvh,
             "first_pass_at_the_search_count_the_number_of_indices" ),
         Kokkos::RangePolicy<ExecutionSpace>( 0, n_queries ),
         KOKKOS_LAMBDA( int i ) {
-            offset( i ) = Details::TreeTraversal<DeviceType>::query(
+            offset( permute( i ) ) = Details::TreeTraversal<DeviceType>::query(
                 bvh, queries( i ), []( int ) {} );
         } );
     Kokkos::fence();
@@ -297,21 +282,18 @@ void queryDispatch( BoundingVolumeHierarchy<DeviceType> const bvh,
     //   ^     ^     ^         ^     ^
     //   0     2     4         2N-2  2N
     Kokkos::realloc( indices, n_results );
-    Kokkos::parallel_for( DTK_MARK_REGION( "second_pass" ),
-                          Kokkos::RangePolicy<ExecutionSpace>( 0, n_queries ),
-                          KOKKOS_LAMBDA( int i ) {
-                              int count = 0;
-                              Details::TreeTraversal<DeviceType>::query(
-                                  bvh, queries( i ),
-                                  [indices, offset, i, &count]( int index ) {
-                                      indices( offset( i ) + count++ ) = index;
-                                  } );
-                          } );
+    Kokkos::parallel_for(
+        DTK_MARK_REGION( "second_pass" ),
+        Kokkos::RangePolicy<ExecutionSpace>( 0, n_queries ),
+        KOKKOS_LAMBDA( int i ) {
+            int count = 0;
+            Details::TreeTraversal<DeviceType>::query(
+                bvh, queries( i ),
+                [indices, offset, permute, i, &count]( int index ) {
+                    indices( offset( permute( i ) ) + count++ ) = index;
+                } );
+        } );
     Kokkos::fence();
-
-    std::tie( offset, indices ) =
-        Details::BatchedQueries<DeviceType>::reversePermutation(
-            permute, offset, indices );
 }
 
 template <typename DeviceType>

--- a/packages/Search/src/details/DTK_DetailsAlgorithms.hpp
+++ b/packages/Search/src/details/DTK_DetailsAlgorithms.hpp
@@ -177,6 +177,21 @@ void centroid( Box const &box, Point &c )
         c[d] = 0.5 * ( box.minCorner()[d] + box.maxCorner()[d] );
 }
 
+KOKKOS_INLINE_FUNCTION
+Point return_centroid( Point const &point ) { return point; }
+
+KOKKOS_INLINE_FUNCTION
+Point return_centroid( Box const &box )
+{
+    Point c;
+    for ( int d = 0; d < 3; ++d )
+        c[d] = 0.5 * ( box.minCorner()[d] + box.maxCorner()[d] );
+    return c;
+}
+
+KOKKOS_INLINE_FUNCTION
+Point return_centroid( Sphere const &sphere ) { return sphere.centroid(); }
+
 } // namespace Details
 } // namespace DataTransferKit
 

--- a/packages/Search/src/details/DTK_DetailsBatchedQueries.hpp
+++ b/packages/Search/src/details/DTK_DetailsBatchedQueries.hpp
@@ -1,0 +1,188 @@
+/****************************************************************************
+ * Copyright (c) 2012-2018 by the DataTransferKit authors                   *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the DataTransferKit library. DataTransferKit is     *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#ifndef DTK_DETAILS_BATCHED_QUERIES_HPP
+#define DTK_DETAILS_BATCHED_QUERIES_HPP
+
+#include <DTK_Box.hpp>
+#include <DTK_DetailsAlgorithms.hpp>       // return_centroid
+#include <DTK_DetailsTreeConstruction.hpp> // morton3D
+#include <DTK_DetailsUtils.hpp> // iota, exclusivePrefixSum, lastElement
+
+#include <Kokkos_Core.hpp>
+#include <Kokkos_Parallel.hpp>
+#include <Kokkos_View.hpp>
+
+#include <tuple>
+
+namespace DataTransferKit
+{
+
+namespace Details
+{
+template <typename DeviceType>
+struct BatchedQueries
+{
+  public:
+    using ExecutionSpace = typename DeviceType::execution_space;
+
+    // BatchedQueries defines functions for sorting queries along the Z-order
+    // space-filling curve in order to minimize data divergence.  The goal is
+    // to increase correlation between traversal decisions made by nearby
+    // threads and thereby increase performance.
+    //
+    // NOTE: sortQueriesAlongZOrderCurve() does not actually apply the sorting
+    // order, it returns the permutation indices.  applyPermutation() was added
+    // in that purpose.  reversePermutation() is able to restore the initial
+    // order on the results that are in "compressed row storage" format.  You
+    // may notice it is not used any more in the code that performs the batched
+    // queries.  We found that it was slighly more performant to add a level of
+    // indirection when recording results rather than using that function at
+    // the end.  We decided to keep reversePermutation around for now.
+
+    template <typename Query>
+    static Kokkos::View<int *, DeviceType>
+    sortQueriesAlongZOrderCurve( Box const &scene_bounding_box,
+                                 Kokkos::View<Query *, DeviceType> queries )
+    {
+        auto const n_queries = queries.extent( 0 );
+
+        Kokkos::View<unsigned int *, DeviceType> morton_codes( "morton",
+                                                               n_queries );
+        Kokkos::parallel_for(
+            DTK_MARK_REGION( "assign_morton_codes_to_queries" ),
+            Kokkos::RangePolicy<ExecutionSpace>( 0, n_queries ),
+            KOKKOS_LAMBDA( int i ) {
+                Point xyz = Details::return_centroid( queries( i )._geometry );
+                for ( int d = 0; d < 3; ++d )
+                {
+                    double const a = scene_bounding_box.minCorner()[d];
+                    double const b = scene_bounding_box.maxCorner()[d];
+                    xyz[d] = ( a != b ? ( xyz[d] - a ) / ( b - a ) : 0 );
+                }
+                morton_codes( i ) = TreeConstruction<DeviceType>::morton3D(
+                    xyz[0], xyz[1], xyz[2] );
+            } );
+        Kokkos::fence();
+
+        Kokkos::View<int *, DeviceType> permute( "permute", n_queries );
+        iota( permute );
+        TreeConstruction<DeviceType>::sortObjects( morton_codes, permute );
+
+        return permute;
+    }
+
+    template <typename T>
+    static Kokkos::View<T *, DeviceType>
+    applyPermutation( Kokkos::View<int const *, DeviceType> permute,
+                      Kokkos::View<T *, DeviceType> v )
+    {
+        auto const n = permute.extent( 0 );
+        DTK_REQUIRE( v.extent( 0 ) == n );
+
+        decltype( v ) w( v.label(), n );
+        Kokkos::parallel_for(
+            DTK_MARK_REGION( "permute_entries" ),
+            Kokkos::RangePolicy<ExecutionSpace>( 0, n ),
+            KOKKOS_LAMBDA( int i ) { w( i ) = v( permute( i ) ); } );
+        Kokkos::fence();
+
+        return w;
+    }
+
+    static Kokkos::View<int *, DeviceType>
+    permuteOffset( Kokkos::View<int const *, DeviceType> permute,
+                   Kokkos::View<int const *, DeviceType> offset )
+    {
+        auto const n = permute.extent( 0 );
+        DTK_REQUIRE( offset.extent( 0 ) == n + 1 );
+
+        Kokkos::View<int *, DeviceType> tmp_offset( offset.label(), n + 1 );
+        Kokkos::parallel_for(
+            DTK_MARK_REGION( "adjacent_difference_and_permutation" ),
+            Kokkos::RangePolicy<ExecutionSpace>( 0, n ),
+            KOKKOS_LAMBDA( int i ) {
+                tmp_offset( permute( i ) ) = offset( i + 1 ) - offset( i );
+            } );
+        Kokkos::fence();
+
+        exclusivePrefixSum( tmp_offset );
+
+        return tmp_offset;
+    }
+
+    template <typename T>
+    static Kokkos::View<T *, DeviceType>
+    permuteIndices( Kokkos::View<int const *, DeviceType> permute,
+                    Kokkos::View<T const *, DeviceType> indices,
+                    Kokkos::View<int const *, DeviceType> offset,
+                    Kokkos::View<int const *, DeviceType> tmp_offset )
+    {
+        auto const n = permute.extent( 0 );
+
+        DTK_REQUIRE( offset.extent( 0 ) == n + 1 );
+        DTK_REQUIRE( tmp_offset.extent( 0 ) == n + 1 );
+        DTK_REQUIRE( lastElement( offset ) == indices.extent_int( 0 ) );
+        DTK_REQUIRE( lastElement( tmp_offset ) == indices.extent_int( 0 ) );
+
+        Kokkos::View<T *, DeviceType> tmp_indices( indices.label(),
+                                                   indices.extent( 0 ) );
+        Kokkos::parallel_for(
+            DTK_MARK_REGION( "permute_indices" ),
+            Kokkos::RangePolicy<ExecutionSpace>( 0, n ),
+            KOKKOS_LAMBDA( int q ) {
+                for ( int i = 0; i < offset( q + 1 ) - offset( q ); ++i )
+                {
+                    tmp_indices( tmp_offset( permute( q ) ) + i ) =
+                        indices( offset( q ) + i );
+                }
+            } );
+        Kokkos::fence();
+        return tmp_indices;
+    }
+
+    static std::tuple<Kokkos::View<int *, DeviceType>,
+                      Kokkos::View<int *, DeviceType>>
+    reversePermutation( Kokkos::View<int const *, DeviceType> permute,
+                        Kokkos::View<int const *, DeviceType> offset,
+                        Kokkos::View<int const *, DeviceType> indices )
+    {
+        auto const tmp_offset = permuteOffset( permute, offset );
+
+        auto const tmp_indices =
+            permuteIndices( permute, indices, offset, tmp_offset );
+        return std::make_tuple( tmp_offset, tmp_indices );
+    }
+
+    static std::tuple<Kokkos::View<int *, DeviceType>,
+                      Kokkos::View<int *, DeviceType>,
+                      Kokkos::View<double *, DeviceType>>
+    reversePermutation( Kokkos::View<int const *, DeviceType> permute,
+                        Kokkos::View<int const *, DeviceType> offset,
+                        Kokkos::View<int const *, DeviceType> indices,
+                        Kokkos::View<double const *, DeviceType> distances )
+    {
+        auto const tmp_offset = permuteOffset( permute, offset );
+
+        auto const tmp_indices =
+            permuteIndices( permute, indices, offset, tmp_offset );
+
+        auto const tmp_distances =
+            permuteIndices( permute, distances, offset, tmp_offset );
+
+        return std::make_tuple( tmp_offset, tmp_indices, tmp_distances );
+    }
+};
+
+} // namespace Details
+} // namespace DataTransferKit
+
+#endif

--- a/packages/Search/test/CMakeLists.txt
+++ b/packages/Search/test/CMakeLists.txt
@@ -42,7 +42,14 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   STANDARD_PASS_OUTPUT
   FAIL_REGULAR_EXPRESSION "data race;leak;runtime error"
   )
-
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  DetailsBatchedQueries
+  SOURCES tstDetailsBatchedQueries.cpp unit_test_main.cpp
+  COMM serial mpi
+  NUM_MPI_PROCS 1
+  STANDARD_PASS_OUTPUT
+  FAIL_REGULAR_EXPRESSION "data race;leak;runtime error"
+  )
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   DistributedSearchTree
   SOURCES tstDistributedSearchTree.cpp Search_UnitTestHelpers.hpp unit_test_main.cpp

--- a/packages/Search/test/tstDetailsBatchedQueries.cpp
+++ b/packages/Search/test/tstDetailsBatchedQueries.cpp
@@ -1,0 +1,70 @@
+/****************************************************************************
+ * Copyright (c) 2012-2018 by the DataTransferKit authors                   *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the DataTransferKit library. DataTransferKit is     *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#include <DTK_DetailsBatchedQueries.hpp>
+
+#include <Teuchos_UnitTestHarness.hpp>
+
+template <typename DeviceType, typename ValueType>
+Kokkos::View<ValueType *, DeviceType> toView( std::vector<ValueType> const &v )
+{
+    Kokkos::View<ValueType *, DeviceType> w( "whocares", v.size() );
+    auto w_host = Kokkos::create_mirror_view( w );
+    for ( int i = 0; i < w.extent_int( 0 ); ++i )
+        w_host( i ) = v[i];
+    Kokkos::deep_copy( w, w_host );
+    return w;
+}
+
+TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( BatchedQueries, permute_offset_and_indices,
+                                   DeviceType )
+{
+    Kokkos::View<int *, DeviceType> offset( "offset" );
+    Kokkos::View<int *, DeviceType> indices( "indices" );
+
+    Kokkos::View<int *, DeviceType> permute( "permute" );
+
+    TEST_THROW( DataTransferKit::Details::BatchedQueries<
+                    DeviceType>::reversePermutation( permute, offset, indices ),
+                DataTransferKit::DataTransferKitException );
+
+    Kokkos::resize( offset, 1 );
+    TEST_NOTHROW( DataTransferKit::Details::BatchedQueries<
+                  DeviceType>::reversePermutation( permute, offset, indices ) );
+
+    std::vector<int> offset_ = {0, 0, 1, 3, 6, 10};
+    std::vector<int> indices_ = {1, 2, 2, 3, 3, 3, 4, 4, 4, 4};
+    std::vector<int> permute_ = {4, 3, 2, 1, 0};
+    std::vector<int> offset_ref = {0, 4, 7, 9, 10, 10};
+    std::vector<int> indices_ref = {4, 4, 4, 4, 3, 3, 3, 2, 2, 1};
+
+    std::tie( offset, indices ) = DataTransferKit::Details::BatchedQueries<
+        DeviceType>::reversePermutation( toView<DeviceType>( permute_ ),
+                                         toView<DeviceType>( offset_ ),
+                                         toView<DeviceType>( indices_ ) );
+    TEST_COMPARE_ARRAYS( offset, offset_ref );
+    TEST_COMPARE_ARRAYS( indices, indices_ref );
+}
+
+// Include the test macros.
+#include "DataTransferKitSearch_ETIHelperMacros.h"
+
+// Create the test group
+#define UNIT_TEST_GROUP( NODE )                                                \
+    using DeviceType##NODE = typename NODE::device_type;                       \
+    TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT(                                      \
+        BatchedQueries, permute_offset_and_indices, DeviceType##NODE )
+
+// Demangle the types
+DTK_ETI_MANGLING_TYPEDEFS()
+
+// Instantiate the tests
+DTK_INSTANTIATE_N( UNIT_TEST_GROUP )


### PR DESCRIPTION
An attempt to take advantage of the fact that if objects are nearby, chances are that they will yield almost the same traversals.