### PR TITLE
Another day, another warning fix

### DIFF
--- a/packages/Search/src/DTK_LinearBVH_def.hpp
+++ b/packages/Search/src/DTK_LinearBVH_def.hpp
@@ -31,8 +31,6 @@ BoundingVolumeHierarchy<DeviceType>::BoundingVolumeHierarchy(
           Kokkos::ViewAllocateWithoutInitializing( "internal_nodes" ),
           bounding_boxes.extent( 0 ) > 0 ? bounding_boxes.extent( 0 ) - 1 : 0 )
 {
-    using ExecutionSpace = typename DeviceType::execution_space;
-
     if ( empty() )
     {
         return;

--- a/packages/Search/test/tstLinearBVH.cpp
+++ b/packages/Search/test/tstLinearBVH.cpp
@@ -302,7 +302,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( LinearBVH, structured_grid, DeviceType )
     Kokkos::parallel_for(
         "fill_bounding_boxes", Kokkos::RangePolicy<ExecutionSpace>( 0, nx ),
         KOKKOS_LAMBDA( int i ) {
-            double x, y, z;
+            [[gnu::unused]] double x, y, z;
             for ( int j = 0; j < ny; ++j )
                 for ( int k = 0; k < nz; ++k )
                 {


### PR DESCRIPTION
Slightly better version.

`[[gnu::unused]]` is an extension warning, and is not in C++11. However, a) it is supported by both gcc and clang, and b) if I read it right, compilers would ignore unknown attributes (though, they may issue a warning).

Given that, I think it makes the situation slightly better.