### PR TITLE
Alternate nearest query traversal using a stack instead of priority queue

### DIFF
--- a/packages/Search/src/DTK_LinearBVH_decl.hpp
+++ b/packages/Search/src/DTK_LinearBVH_decl.hpp
@@ -312,7 +312,7 @@ void queryDispatch( Details::SpatialPredicateTag,
             KOKKOS_LAMBDA( int i ) {
                 offset( permute( i ) ) =
                     Details::TreeTraversal<DeviceType>::query(
-                        bvh, queries( i ), []( int index ) {} );
+                        bvh, queries( i ), []( int ) {} );
             } );
     Kokkos::fence();
 

--- a/packages/Search/src/details/DTK_DetailsContainers.hpp
+++ b/packages/Search/src/details/DTK_DetailsContainers.hpp
@@ -61,6 +61,45 @@ class Vector
     // clang-format on
 };
 
+template <typename T>
+class UnmanagedVector
+{
+    // clang-format off
+  public:
+    using value_type = T;
+    using size_type = std::size_t;
+    using difference_type = std::ptrdiff_t;
+    using reference = value_type &;
+    using const_reference = value_type const &;
+    using pointer = value_type *;
+    using const_pointer = value_type const *;
+    KOKKOS_FUNCTION UnmanagedVector( pointer ptr, size_type max_size ) : _ptr(ptr) , _max_size(max_size) { assert(ptr != nullptr); }
+    KOKKOS_INLINE_FUNCTION bool empty() const { return _size == 0; }
+    KOKKOS_INLINE_FUNCTION size_type size() const { return _size; }
+    KOKKOS_INLINE_FUNCTION constexpr size_type maxSize() const { return _max_size; }
+    KOKKOS_INLINE_FUNCTION constexpr size_type capacity() const { return _max_size; }
+    KOKKOS_INLINE_FUNCTION reference operator[]( size_type pos ) { assert(pos < size()); return *(_ptr + pos); }
+    KOKKOS_INLINE_FUNCTION const_reference operator[]( size_type pos ) const { assert(pos < size()); return *(_ptr + pos); }
+    KOKKOS_INLINE_FUNCTION reference back() { assert(size() > 0); return *(_ptr + _size - 1); }
+    KOKKOS_INLINE_FUNCTION const_reference back() const { assert(size() > 0); return *(_ptr + _size - 1); }
+    KOKKOS_INLINE_FUNCTION void pushBack(T const &value) { assert(size() < maxSize()); *(_ptr + _size++) = value; }
+    KOKKOS_INLINE_FUNCTION void pushBack(T &&value) { assert(size() < maxSize()); *(_ptr + _size++) = std::move(value); }
+    template<class... Args>
+    KOKKOS_INLINE_FUNCTION void emplaceBack(Args&&... args) { assert(size() < maxSize()); ::new (static_cast<void*>(_ptr + _size++)) T(std::forward<Args>(args)...); }
+    KOKKOS_INLINE_FUNCTION void popBack() { assert(size() > 0); _size--; }
+    KOKKOS_INLINE_FUNCTION reference front() { assert(size() > 0); return *(_ptr + 0); }
+    KOKKOS_INLINE_FUNCTION const_reference front() const { assert(size() > 0); return *(_ptr + 0); }
+    KOKKOS_INLINE_FUNCTION void clear() { _size = 0; }
+    KOKKOS_INLINE_FUNCTION pointer data() { return _ptr; }
+    KOKKOS_INLINE_FUNCTION const_pointer data() const { return _ptr; }
+
+  private:
+    pointer _ptr = nullptr;
+    size_type const _max_size = 0;
+    size_type _size = 0;
+    // clang-format on
+};
+
 } // namespace Details
 } // namespace DataTransferKit
 

--- a/packages/Search/src/details/DTK_DetailsContainers.hpp
+++ b/packages/Search/src/details/DTK_DetailsContainers.hpp
@@ -1,0 +1,67 @@
+/****************************************************************************
+ * Copyright (c) 2012-2018 by the DataTransferKit authors                   *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the DataTransferKit library. DataTransferKit is     *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+#ifndef DTK_DETAILS_CONTAINERS_HPP
+#define DTK_DETAILS_CONTAINERS_HPP
+
+#include <Kokkos_Macros.hpp>
+
+#include <cassert> // assert
+#include <cstddef> // size_t, ptrdiff_t
+#include <utility> // move, forward
+
+namespace DataTransferKit
+{
+namespace Details
+{
+
+// dynamic vector with fixed maximum size
+template <typename T, std::size_t N>
+class Vector
+{
+    // clang-format off
+  public:
+    using value_type = T;
+    using size_type = std::size_t;
+    using difference_type = std::ptrdiff_t;
+    using reference = value_type &;
+    using const_reference = value_type const &;
+    using pointer = value_type *;
+    using const_pointer = value_type const *;
+    KOKKOS_FUNCTION Vector() = default;
+    KOKKOS_INLINE_FUNCTION bool empty() const { return _size == 0; }
+    KOKKOS_INLINE_FUNCTION size_type size() const { return _size; }
+    KOKKOS_INLINE_FUNCTION constexpr size_type maxSize() const { return N; }
+    KOKKOS_INLINE_FUNCTION constexpr size_type capacity() const { return N; }
+    KOKKOS_INLINE_FUNCTION reference operator[]( size_type pos ) { assert(pos < size()); return _data[pos]; }
+    KOKKOS_INLINE_FUNCTION const_reference operator[]( size_type pos ) const { assert(pos < size()); return _data[pos]; }
+    KOKKOS_INLINE_FUNCTION reference back() { assert(size() > 0 ); return _data[_size - 1]; }
+    KOKKOS_INLINE_FUNCTION const_reference back() const { assert(size() > 0); return _data[_size - 1]; }
+    KOKKOS_INLINE_FUNCTION void pushBack(T const &value) { assert(size() < maxSize()); _data[_size++] = value; }
+    KOKKOS_INLINE_FUNCTION void pushBack(T &&value) { assert(size() < maxSize()); _data[_size++] = std::move(value); }
+    template<class... Args>
+    KOKKOS_INLINE_FUNCTION void emplaceBack(Args&&... args) { assert(size() < maxSize()); ::new (static_cast<void*>(_data + _size++)) T(std::forward<Args>(args)...); }
+    KOKKOS_INLINE_FUNCTION void popBack() { assert(size() > 0); _size--; }
+    KOKKOS_INLINE_FUNCTION reference front() { assert(size() > 0); return _data[0]; }
+    KOKKOS_INLINE_FUNCTION const_reference front() const { assert(size() > 0); return _data[0]; }
+    KOKKOS_INLINE_FUNCTION void clear() { _size = 0; }
+    KOKKOS_INLINE_FUNCTION pointer data() { return _data; }
+    KOKKOS_INLINE_FUNCTION constexpr const_pointer data() const { return _data; }
+
+  private:
+    value_type _data[N];
+    size_type _size = 0;
+    // clang-format on
+};
+
+} // namespace Details
+} // namespace DataTransferKit
+
+#endif

--- a/packages/Search/src/details/DTK_DetailsDistributedSearchTreeImpl.hpp
+++ b/packages/Search/src/details/DTK_DetailsDistributedSearchTreeImpl.hpp
@@ -667,8 +667,9 @@ void DistributedSearchTreeImpl<DeviceType>::filterResults(
         KOKKOS_LAMBDA( int q ) {
             PriorityQueue queue;
             for ( int i = offset( q ); i < offset( q + 1 ); ++i )
-                queue.push( Kokkos::Array<int, 2>{{indices( i ), ranks( i )}},
-                            distances( i ) );
+                queue.emplace(
+                    Kokkos::Array<int, 2>{{indices( i ), ranks( i )}},
+                    distances( i ) );
 
             int count = 0;
             while ( !queue.empty() && count < queries( q )._k )

--- a/packages/Search/src/details/DTK_DetailsHeap.hpp
+++ b/packages/Search/src/details/DTK_DetailsHeap.hpp
@@ -21,6 +21,22 @@ namespace DataTransferKit
 namespace Details
 {
 
+template <typename RandomIterator, typename Compare>
+KOKKOS_INLINE_FUNCTION bool isHeap( RandomIterator first, RandomIterator last,
+                                    Compare comp )
+{
+    using DistanceType =
+        typename std::iterator_traits<RandomIterator>::difference_type;
+    DistanceType len = last - first;
+    for ( DistanceType pos = 0; pos < len; ++pos )
+    {
+        for ( DistanceType child : {2 * pos + 1, 2 * pos + 2} )
+            if ( child < len && comp( *( first + pos ), *( first + child ) ) )
+                return false;
+    }
+    return true;
+}
+
 template <typename RandomIterator, typename DistanceType, typename ValueType,
           typename Compare>
 KOKKOS_INLINE_FUNCTION void __bubbleUp( RandomIterator first, DistanceType pos,

--- a/packages/Search/src/details/DTK_DetailsHeap.hpp
+++ b/packages/Search/src/details/DTK_DetailsHeap.hpp
@@ -1,0 +1,98 @@
+/****************************************************************************
+ * Copyright (c) 2012-2018 by the DataTransferKit authors                   *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the DataTransferKit library. DataTransferKit is     *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+#ifndef DTK_DETAILS_HEAP_HPP
+#define DTK_DETAILS_HEAP_HPP
+
+#include <Kokkos_Macros.hpp>
+
+#include <iterator> // iterator_traits
+#include <utility>  // move
+
+namespace DataTransferKit
+{
+namespace Details
+{
+
+template <typename RandomIterator, typename DistanceType, typename ValueType,
+          typename Compare>
+KOKKOS_INLINE_FUNCTION void __bubbleUp( RandomIterator first, DistanceType pos,
+                                        DistanceType top, ValueType val,
+                                        Compare comp )
+{
+    DistanceType parent = ( pos - 1 ) / 2;
+    while ( pos > top && comp( *( first + parent ), val ) )
+    {
+        *( first + pos ) = std::move( *( first + parent ) );
+        pos = parent;
+        parent = ( pos - 1 ) / 2;
+    }
+    *( first + pos ) = std::move( val );
+}
+
+template <typename RandomIterator, typename Compare>
+KOKKOS_INLINE_FUNCTION void pushHeap( RandomIterator first, RandomIterator last,
+                                      Compare comp )
+{
+    using DistanceType =
+        typename std::iterator_traits<RandomIterator>::difference_type;
+    using ValueType = typename std::iterator_traits<RandomIterator>::value_type;
+    if ( last - first > 1 )
+    {
+        ValueType value = std::move( *( last - 1 ) );
+        __bubbleUp( first, DistanceType( ( last - first ) - 1 ),
+                    DistanceType( 0 ), std::move( value ), comp );
+    }
+}
+
+template <typename RandomIterator, typename DistanceType, typename ValueType,
+          typename Compare>
+KOKKOS_INLINE_FUNCTION void __bubbleDown( RandomIterator first,
+                                          DistanceType pos, DistanceType len,
+                                          ValueType val, Compare comp )
+{
+    DistanceType child = 2 * pos + 1;
+    // if right child exists and compares greater than left child
+    if ( child + 1 < len && comp( *( first + child ), *( first + child + 1 ) ) )
+        ++child;
+
+    while ( child < len && comp( val, *( first + child ) ) )
+    {
+        *( first + pos ) = std::move( *( first + child ) );
+        pos = child;
+        child = 2 * pos + 1;
+        if ( child + 1 < len &&
+             comp( *( first + child ), *( first + child + 1 ) ) )
+            ++child;
+    }
+    *( first + pos ) = std::move( val );
+}
+
+template <typename RandomIterator, typename Compare>
+KOKKOS_INLINE_FUNCTION void popHeap( RandomIterator first, RandomIterator last,
+                                     Compare comp )
+{
+    using DistanceType =
+        typename std::iterator_traits<RandomIterator>::difference_type;
+    using ValueType = typename std::iterator_traits<RandomIterator>::value_type;
+    if ( last - first > 1 )
+    {
+        ValueType value = std::move( *first );
+        __bubbleDown( first, DistanceType( 0 ),
+                      DistanceType( ( last - first ) - 1 ),
+                      std::move( *( last - 1 ) ), comp );
+        *( last - 1 ) = std::move( value );
+    }
+}
+
+} // namespace Details
+} // namespace DataTransferKit
+
+#endif

--- a/packages/Search/src/details/DTK_DetailsHeap.hpp
+++ b/packages/Search/src/details/DTK_DetailsHeap.hpp
@@ -108,6 +108,14 @@ KOKKOS_INLINE_FUNCTION void popHeap( RandomIterator first, RandomIterator last,
     }
 }
 
+template <typename RandomIterator, typename Compare>
+KOKKOS_INLINE_FUNCTION void sortHeap( RandomIterator first, RandomIterator last,
+                                      Compare comp )
+{
+    while ( first != last )
+        popHeap( first, last--, comp );
+}
+
 } // namespace Details
 } // namespace DataTransferKit
 

--- a/packages/Search/src/details/DTK_DetailsPriorityQueue.hpp
+++ b/packages/Search/src/details/DTK_DetailsPriorityQueue.hpp
@@ -11,11 +11,14 @@
 #ifndef DTK_DETAILS_PRIORITY_QUEUE_HPP
 #define DTK_DETAILS_PRIORITY_QUEUE_HPP
 
+#include <DTK_DetailsContainers.hpp>
+#include <DTK_DetailsHeap.hpp>
+
 #include <Kokkos_Macros.hpp>
 
-#include <cassert>
-#include <cstdlib>
-#include <utility>
+#include <cstddef>     // ptrdiff_t
+#include <type_traits> // is_same
+#include <utility>     // move, forward
 
 namespace DataTransferKit
 {
@@ -26,120 +29,102 @@ template <typename T>
 struct Less
 {
   public:
-    KOKKOS_INLINE_FUNCTION bool operator()( T const &x, T const &y ) const
+    KOKKOS_INLINE_FUNCTION bool operator()( T const &lhs, T const &rhs ) const
     {
-        return x < y;
+        return lhs < rhs;
     }
 };
 
-template <typename T, typename Compare = Less<T>>
+template <typename T>
+struct Greater
+{
+  public:
+    KOKKOS_INLINE_FUNCTION bool operator()( T const &lhs, T const &rhs ) const
+    {
+        return lhs > rhs;
+    }
+};
+
+template <typename T, typename Compare = Less<T>,
+          typename Container = Vector<T, 256>>
 class PriorityQueue
 {
   public:
-    using IndexType = std::ptrdiff_t;
-    using ValueType = T;
-    using ValueCompare = Compare;
+    using container_type = Container;
+    using value_compare = Compare;
+    using value_type = typename Container::value_type;
+    using size_type = typename Container::size_type;
+    using reference = typename Container::reference;
+    using const_reference = typename Container::const_reference;
+    static_assert( std::is_same<value_type, T>::value,
+                   "Template parameter T in PriorityQueue is not the same as "
+                   "the type of the elements stored by the underlying "
+                   "container Container::value_type" );
 
     KOKKOS_FUNCTION PriorityQueue() = default;
 
-    KOKKOS_INLINE_FUNCTION bool empty() const { return _size == 0; }
-
-    KOKKOS_INLINE_FUNCTION IndexType size() const { return _size; }
-
-    KOKKOS_INLINE_FUNCTION void clear() { _size = 0; }
-
-    KOKKOS_INLINE_FUNCTION ValueCompare value_comp() const { return _compare; }
-
-    template <typename... Args>
-    KOKKOS_INLINE_FUNCTION void push( Args &&... args )
+    KOKKOS_FUNCTION PriorityQueue( Container const &c )
+        : _c( c )
     {
-        // ensure the heap is not already full
-        assert( _size < _max_size );
-
-        // add the element to the bottom level of the heap
-        IndexType pos = _size;
-        T elem{std::forward<Args>( args )...};
-
-        // perform up-heap operation
-        while ( pos > 0 )
-        {
-            // compare the added element with its parent
-            // if they are in correct order, stop
-            // if not, swap them and continue
-            IndexType const parent = ( pos - 1 ) / 2;
-            if ( !_compare( _heap[parent], elem ) )
-                break;
-            _heap[pos] = _heap[parent];
-            pos = parent;
-        }
-
-        _heap[pos] = elem;
-
-        // update the size of the heap
-        ++_size;
+        assert( _c.empty() ||
+                isHeap( _c.data(), _c.data() + _c.size(), _compare ) );
     }
 
+    // Capacity
+    KOKKOS_INLINE_FUNCTION bool empty() const { return _c.empty(); }
+    KOKKOS_INLINE_FUNCTION size_type size() const { return _c.size(); }
+
+    // Element access
+    KOKKOS_INLINE_FUNCTION reference top() { return _c.front(); }
+    KOKKOS_INLINE_FUNCTION const_reference top() const { return _c.front(); }
+
+    // Modifiers
+    KOKKOS_INLINE_FUNCTION void push( value_type const &value )
+    {
+        _c.pushBack( value );
+        pushHeap( _c.data(), _c.data() + _c.size(), _compare );
+    }
+    KOKKOS_INLINE_FUNCTION void push( value_type &&value )
+    {
+        _c.pushBack( std::move( value ) );
+        pushHeap( _c.data(), _c.data() + _c.size(), _compare );
+    }
+    template <class... Args>
+    KOKKOS_INLINE_FUNCTION void emplace( Args &&... args )
+    {
+        _c.emplaceBack( std::forward<Args>( args )... );
+        pushHeap( _c.data(), _c.data() + _c.size(), _compare );
+    }
     KOKKOS_INLINE_FUNCTION void pop()
     {
-        // ensure that the heap is not empty
-        assert( _size > 0 );
-
-        // replace the root with the last element on the last level
-        IndexType pos = 0;
-
-        // perform down-heap operation
-        while ( true )
-        {
-            // compare the new root with its children
-            // if they are in the correct order, stop
-            // if not, swap the element with one of its children and continue
-            IndexType const left_child = 2 * pos + 1;
-            IndexType const right_child = 2 * pos + 2;
-            IndexType next_pos = _size - 1;
-            for ( IndexType child : {left_child, right_child} )
-                if ( child < _size - 1 &&
-                     _compare( _heap[next_pos], _heap[child] ) )
-                    next_pos = child;
-            if ( next_pos == _size - 1 )
-                break;
-            _heap[pos] = _heap[next_pos];
-            pos = next_pos;
-        }
-
-        _heap[pos] = _heap[_size - 1];
-
-        // update the size of the heap
-        _size--;
+        popHeap( _c.data(), _c.data() + _c.size(), _compare );
+        _c.popBack();
     }
-
     // in TreeTraversal::nearestQuery, pop() is often followed by push which is
     // an opportunity for doing a single bubble-down operation instead of paying
     // for both one bubble-down and one bubble-up
     template <typename... Args>
-    KOKKOS_INLINE_FUNCTION void pop_push( Args &&... args )
+    KOKKOS_INLINE_FUNCTION void popPush( Args &&... args )
     {
-        assert( _size < _max_size );
-
-        // size will be decremented by pop()
-        _size++;
-
-        // put the new element at the bottom level
-        _heap[_size - 1] = T{std::forward<Args>( args )...};
-
-        // replace the root with that new element and bubble it down
-        pop();
+        assert( _c.size() > 0 );
+        __bubbleDown( _c.data(), std::ptrdiff_t( 0 ),
+                      std::ptrdiff_t( _c.size() ),
+                      T{std::forward<Args>( args )...}, _compare );
     }
 
-    KOKKOS_INLINE_FUNCTION T const &top() const
+    // Accessors that shouldn't be there but that are convenient in
+    // TreeTraversal::nearestQuery()
+    KOKKOS_INLINE_FUNCTION typename Container::pointer data()
     {
-        assert( _size > 0 );
-        return _heap[0];
+        return _c.data();
+    }
+    KOKKOS_INLINE_FUNCTION value_compare const &valueComp() const
+    {
+        return _compare;
     }
 
   private:
-    static IndexType constexpr _max_size = 256;
-    T _heap[_max_size];
-    IndexType _size = 0;
+    Container _c;
     Compare _compare;
 };
 

--- a/packages/Search/src/details/DTK_DetailsTreeTraversal.hpp
+++ b/packages/Search/src/details/DTK_DetailsTreeTraversal.hpp
@@ -130,10 +130,12 @@ spatialQuery( BoundingVolumeHierarchy<DeviceType> const &bvh,
 }
 
 // query k nearest neighbours
-template <typename DeviceType, typename Distance, typename Insert>
+template <typename DeviceType, typename Distance, typename Insert,
+          typename Buffer>
 KOKKOS_FUNCTION int
 nearestQuery( BoundingVolumeHierarchy<DeviceType> const &bvh,
-              Distance const &distance, int k, Insert const &insert )
+              Distance const &distance, std::size_t k, Insert const &insert,
+              Buffer const &buffer )
 {
     if ( bvh.empty() || k < 1 )
         return 0;
@@ -147,57 +149,106 @@ nearestQuery( BoundingVolumeHierarchy<DeviceType> const &bvh,
         return 1;
     }
 
-    using PairNodePtrDistance = Kokkos::pair<Node const *, double>;
+    // Nodes with a distance that exceed that radius can safely be discarded.
+    // Initialize the radius to infinity and tighten it once k neighbors have
+    // been found.
+    double radius = KokkosHelpers::ArithTraits<double>::infinity();
 
+    using PairIndexDistance = Kokkos::pair<int, double>;
+    static_assert(
+        std::is_same<typename Buffer::value_type, PairIndexDistance>::value,
+        "Type of the elements stored in the buffer passed as argument to "
+        "TreeTraversal::nearestQuery is not right" );
     struct CompareDistance
     {
         KOKKOS_INLINE_FUNCTION bool
-        operator()( PairNodePtrDistance const &lhs,
-                    PairNodePtrDistance const &rhs ) const
+        operator()( PairIndexDistance const &lhs,
+                    PairIndexDistance const &rhs ) const
         {
-            // reverse order (larger distance means lower priority)
-            return lhs.second > rhs.second;
+            return lhs.second < rhs.second;
         }
     };
+    // Use a priority queue for convenience to store the results and preserve
+    // the heap structure internally at all time.  There is no memory
+    // allocation, elements are stored in the buffer passed as an argument.
+    // The farthest leaf node is on top.
+    assert( k == buffer.size() );
+    PriorityQueue<PairIndexDistance, CompareDistance,
+                  UnmanagedVector<PairIndexDistance>>
+        heap( UnmanagedVector<PairIndexDistance>( buffer.data(),
+                                                  buffer.size() ) );
 
-    PriorityQueue<PairNodePtrDistance, CompareDistance> queue;
-    // priority does not matter for the root since the node will be
-    // processed directly and removed from the priority queue we don't even
-    // bother computing the distance to it.
-    Node const *root = TreeTraversal<DeviceType>::getRoot( bvh );
-    queue.push( root, 0. );
-    int count = 0;
+    using PairNodePtrDistance = Kokkos::pair<Node const *, double>;
+    Stack<PairNodePtrDistance> stack;
+    // Do not bother computing the distance to the root node since it is
+    // immediately popped out of the stack and processed.
+    stack.emplace( TreeTraversal<DeviceType>::getRoot( bvh ), 0. );
 
-    while ( !queue.empty() && count < k )
+    while ( !stack.empty() )
     {
-        // get the node that is on top of the priority list (i.e. is the
-        // closest to the query point)
-        Node const *node = queue.top().first;
-        double const node_distance = queue.top().second;
-        // NOTE: it would be nice to be able to do something like
-        // tie( node, node_distance = queue.top();
+        Node const *node = stack.top().first;
+        double const node_distance = stack.top().second;
+        stack.pop();
 
-        // NOTE: not calling queue.pop() here so that it can be combined with
-        // the next push in case the node is internal (thus sparing a bubble-up
-        // operation)
-        if ( TreeTraversal<DeviceType>::isLeaf( node ) )
+        if ( node_distance < radius )
         {
-            queue.pop();
-            insert( TreeTraversal<DeviceType>::getIndex( node ),
-                    node_distance );
-            count++;
-        }
-        else
-        {
-            // insert children of the node in the priority list
-
-            auto const left_child = node->children.first;
-            auto const right_child = node->children.second;
-            queue.pop_push( left_child, distance( left_child ) );
-            queue.push( right_child, distance( right_child ) );
+            if ( TreeTraversal<DeviceType>::isLeaf( node ) )
+            {
+                int const leaf_index =
+                    TreeTraversal<DeviceType>::getIndex( node );
+                double const leaf_distance = node_distance;
+                if ( heap.size() < k )
+                {
+                    // Insert leaf node and update radius if it was the kth one.
+                    heap.push( Kokkos::make_pair( leaf_index, leaf_distance ) );
+                    if ( heap.size() == k )
+                        radius = heap.top().second;
+                }
+                else
+                {
+                    // Replace top element in the heap and update radius.
+                    heap.popPush(
+                        Kokkos::make_pair( leaf_index, leaf_distance ) );
+                    radius = heap.top().second;
+                }
+            }
+            else
+            {
+                // Insert children into the stack and make sure that the
+                // closest one ends on top.
+                Node const *left_child = node->children.first;
+                double const left_child_distance = distance( left_child );
+                Node const *right_child = node->children.second;
+                double const right_child_distance = distance( right_child );
+                if ( left_child_distance < right_child_distance )
+                {
+                    // NOTE not really sure why but it performed better with
+                    // the conditional insertion on the device and without it
+                    // on the host (~5% improvement for both)
+                    if ( right_child_distance < radius )
+                        stack.emplace( right_child, right_child_distance );
+                    stack.emplace( left_child, left_child_distance );
+                }
+                else
+                {
+                    if ( left_child_distance < radius )
+                        stack.emplace( left_child, left_child_distance );
+                    stack.emplace( right_child, right_child_distance );
+                }
+            }
         }
     }
-    return count;
+    // Sort the leaf nodes and output the results.
+    // NOTE: Do not try this at home.  Messing with the underlying container
+    // invalidates the state of the PriorityQueue.
+    sortHeap( heap.data(), heap.data() + heap.size(), heap.valueComp() );
+    for ( decltype( heap.size() ) i = 0; i < heap.size(); ++i )
+    {
+        int const leaf_index = ( heap.data() + i )->first;
+        double const leaf_distance = ( heap.data() + i )->second;
+        insert( leaf_index, leaf_distance );
+    }
+    return heap.size();
 }
 
 template <typename DeviceType, typename Predicate, typename Insert>
@@ -209,10 +260,11 @@ queryDispatch( SpatialPredicateTag,
     return spatialQuery( bvh, pred, insert );
 }
 
-template <typename DeviceType, typename Predicate, typename Insert>
+template <typename DeviceType, typename Predicate, typename Insert,
+          typename Buffer>
 KOKKOS_INLINE_FUNCTION int queryDispatch(
     NearestPredicateTag, BoundingVolumeHierarchy<DeviceType> const &bvh,
-    Predicate const &pred, Insert const &insert)
+    Predicate const &pred, Insert const &insert, Buffer const &buffer )
 {
     auto const geometry = pred._geometry;
     auto const k = pred._k;
@@ -220,7 +272,7 @@ KOKKOS_INLINE_FUNCTION int queryDispatch(
                          [geometry]( Node const *node ) {
                              return distance( geometry, node->bounding_box );
                          },
-                         k, insert );
+                         k, insert, buffer );
 }
 
 } // namespace Details

--- a/packages/Search/src/details/DTK_DetailsTreeTraversal.hpp
+++ b/packages/Search/src/details/DTK_DetailsTreeTraversal.hpp
@@ -101,8 +101,7 @@ spatialQuery( BoundingVolumeHierarchy<DeviceType> const &bvh,
 
     Stack<Node const *> stack;
 
-    Node const *root = TreeTraversal<DeviceType>::getRoot( bvh );
-    stack.push( root );
+    stack.emplace( TreeTraversal<DeviceType>::getRoot( bvh ) );
     int count = 0;
 
     while ( !stack.empty() )

--- a/packages/Search/src/details/DTK_DetailsTreeTraversal.hpp
+++ b/packages/Search/src/details/DTK_DetailsTreeTraversal.hpp
@@ -225,13 +225,17 @@ nearestQuery( BoundingVolumeHierarchy<DeviceType> const &bvh,
                     // NOTE not really sure why but it performed better with
                     // the conditional insertion on the device and without it
                     // on the host (~5% improvement for both)
+#if defined( __CUDA_ARCH__ )
                     if ( right_child_distance < radius )
+#endif
                         stack.emplace( right_child, right_child_distance );
                     stack.emplace( left_child, left_child_distance );
                 }
                 else
                 {
+#if defined( __CUDA_ARCH__ )
                     if ( left_child_distance < radius )
+#endif
                         stack.emplace( left_child, left_child_distance );
                     stack.emplace( right_child, right_child_distance );
                 }

--- a/packages/Search/test/tstDetailsTreeTraversal.cpp
+++ b/packages/Search/test/tstDetailsTreeTraversal.cpp
@@ -452,3 +452,22 @@ TEUCHOS_UNIT_TEST( PriorityQueue, maintain_heap_properties )
         check_heap( queue, success, out );
     }
 }
+
+TEUCHOS_UNIT_TEST( HeapOperations, is_heap )
+{
+    for ( auto heap : {std::vector<int>{36, 19, 25, 17, 3, 7, 1, 2, 9},
+                       std::vector<int>{36, 19, 25, 17, 3, 9, 1, 2, 7},
+                       std::vector<int>{100, 19, 36, 17, 3, 25, 1, 2, 7},
+                       std::vector<int>{15, 5, 11, 3, 4, 8}} )
+    {
+        TEST_ASSERT( dtk::isHeap( heap.data(), heap.data() + heap.size(),
+                                  dtk::Less<int>() ) );
+    }
+    for ( auto not_heap : {std::vector<int>{0, 1, 2, 3, 4, 3, 2, 1, 0},
+                           std::vector<int>{2, 1, 0, 1, 2}} )
+    {
+        TEST_ASSERT( !dtk::isHeap( not_heap.data(),
+                                   not_heap.data() + not_heap.size(),
+                                   dtk::Less<int>() ) );
+    }
+}

--- a/packages/Search/test/tstDetailsTreeTraversal.cpp
+++ b/packages/Search/test/tstDetailsTreeTraversal.cpp
@@ -81,6 +81,68 @@ TEUCHOS_UNIT_TEST( Containers, dynamic_array_with_fixed_maximum_size )
     TEST_EQUALITY( a.capacity(), 4 );
 }
 
+TEUCHOS_UNIT_TEST( Containers, non_owning_view_over_dynamic_array )
+{
+    float data[6] = {255, 255, 255, 255, 255, 255};
+    //                        ^^^^ ^^^^ ^^^^
+    dtk::UnmanagedVector<float> a( data + 2, 3 );
+
+    TEST_ASSERT( !std::is_default_constructible<decltype( a )>::value );
+    TEST_EQUALITY( a.data(), data + 2 );
+
+    TEST_ASSERT( a.empty() );
+    TEST_EQUALITY( a.size(), 0 );
+    TEST_EQUALITY( a.maxSize(), 3 );
+    TEST_EQUALITY( a.capacity(), 3 );
+
+    a.pushBack( 0 );
+    TEST_ASSERT( !a.empty() );
+    TEST_EQUALITY( a.size(), 1 );
+    TEST_EQUALITY( a.maxSize(), 3 );
+    TEST_EQUALITY( a.capacity(), 3 );
+    TEST_EQUALITY( a.front(), 0 );
+    TEST_EQUALITY( a.back(), 0 );
+    TEST_EQUALITY( a[0], 0 );
+
+    a.pushBack( 1 );
+    TEST_ASSERT( !a.empty() );
+    TEST_EQUALITY( a.size(), 2 );
+    TEST_EQUALITY( a.maxSize(), 3 );
+    TEST_EQUALITY( a.capacity(), 3 );
+    TEST_EQUALITY( a.front(), 0 );
+    TEST_EQUALITY( a[0], 0 );
+    TEST_EQUALITY( a.back(), 1 );
+    TEST_EQUALITY( a[1], 1 );
+
+    a.pushBack( 2 );
+    TEST_ASSERT( !a.empty() );
+    TEST_EQUALITY( a.size(), 3 );
+    TEST_EQUALITY( a.maxSize(), 3 );
+    TEST_EQUALITY( a.capacity(), 3 );
+    TEST_EQUALITY( a.front(), 0 );
+    TEST_EQUALITY( a[0], 0 );
+    TEST_EQUALITY( a[1], 1 );
+    TEST_EQUALITY( a.back(), 2 );
+    TEST_EQUALITY( a[2], 2 );
+
+    a.popBack();
+    TEST_ASSERT( !a.empty() );
+    TEST_EQUALITY( a.size(), 2 );
+    TEST_EQUALITY( a.maxSize(), 3 );
+    TEST_EQUALITY( a.capacity(), 3 );
+    TEST_EQUALITY( a.front(), 0 );
+    TEST_EQUALITY( a[0], 0 );
+    TEST_EQUALITY( a.back(), 1 );
+    TEST_EQUALITY( a[1], 1 );
+
+    TEST_EQUALITY( data[0], 255 );
+    TEST_EQUALITY( data[1], 255 );
+    TEST_EQUALITY( data[2], 0 );
+    TEST_EQUALITY( data[3], 1 );
+    TEST_EQUALITY( data[4], 2 );
+    TEST_EQUALITY( data[5], 255 );
+}
+
 TEUCHOS_UNIT_TEST( LinearBVH, stack )
 {
     // stack is empty at construction

--- a/packages/Search/test/tstDetailsTreeTraversal.cpp
+++ b/packages/Search/test/tstDetailsTreeTraversal.cpp
@@ -172,9 +172,9 @@ TEUCHOS_UNIT_TEST( ContainerAdaptors, stack )
     TEST_EQUALITY( stack.size(), 0 );
 }
 
-TEUCHOS_UNIT_TEST( LinearBVH, priority_queue )
+TEUCHOS_UNIT_TEST( ContainerAdaptors, priority_queue )
 {
-    DataTransferKit::Details::PriorityQueue<int> queue;
+    dtk::PriorityQueue<int> queue;
     // queue is empty at construction
     TEST_ASSERT( queue.empty() );
     // insert element
@@ -197,9 +197,10 @@ TEUCHOS_UNIT_TEST( LinearBVH, priority_queue )
 }
 
 template <typename PriorityQueue>
-void check_heap( PriorityQueue const &queue,
-                 std::vector<typename PriorityQueue::ValueType> const &heap_ref,
-                 bool &success, Teuchos::FancyOStream &out )
+void check_heap(
+    PriorityQueue const &queue,
+    std::vector<typename PriorityQueue::value_type> const &heap_ref,
+    bool &success, Teuchos::FancyOStream &out )
 {
     auto const size = queue.size();
     TEST_EQUALITY( size, static_cast<decltype( size )>( heap_ref.size() ) );
@@ -207,8 +208,8 @@ void check_heap( PriorityQueue const &queue,
     // NOTE Shameless hack to inspect the private data of the priority queue.
     // Will break if data is reordered in the PriorityQueue class declaration.
     auto heap =
-        reinterpret_cast<typename PriorityQueue::ValueType const *>( &queue );
-    for ( typename PriorityQueue::IndexType i = 0; i < size; ++i )
+        reinterpret_cast<typename PriorityQueue::value_type const *>( &queue );
+    for ( typename PriorityQueue::size_type i = 0; i < size; ++i )
         TEST_EQUALITY( heap[i], heap_ref[i] );
 }
 
@@ -350,12 +351,12 @@ TEUCHOS_UNIT_TEST( HeapOperations, min_heap )
     TEST_COMPARE_ARRAYS( a, ref );
 }
 
-TEUCHOS_UNIT_TEST( LinearBVH, pop_push )
+TEUCHOS_UNIT_TEST( PriorityQueue, pop_push )
 {
     // note that calling pop_push(x) does not necessarily yield the same heap
     // than calling consecutively pop() and push(x)
     // below is a max heap example to illustate this interesting property
-    DataTransferKit::Details::PriorityQueue<int> queue;
+    dtk::PriorityQueue<int> queue;
 
     std::vector<int> ref = {100, 19, 36, 17, 3, 25, 1, 2, 7};
     for ( auto x : ref )
@@ -369,12 +370,13 @@ TEUCHOS_UNIT_TEST( LinearBVH, pop_push )
     check_heap( queue, {36, 19, 25, 17, 3, 7, 1, 2, 9}, success, out );
     //                                    ^^       ^^
 
-    queue.clear();
+    // Clear the content of the queue
+    queue = dtk::PriorityQueue<int>();
     for ( auto x : ref )
         queue.push( x );
     check_heap( queue, ref, success, out );
 
-    queue.pop_push( 9 );
+    queue.popPush( 9 );
     check_heap( queue, {36, 19, 25, 17, 3, 9, 1, 2, 7}, success, out );
     //                                    ^^       ^^
 }
@@ -383,9 +385,9 @@ template <typename PriorityQueue>
 void check_heap( PriorityQueue const &queue, bool &success,
                  Teuchos::FancyOStream &out )
 {
-    using ValueType = typename PriorityQueue::ValueType;
+    using ValueType = typename PriorityQueue::value_type;
     int const size = queue.size();
-    auto const compare = queue.value_comp();
+    auto const compare = queue.valueComp();
     auto heap = reinterpret_cast<ValueType const *>( &queue );
     for ( int i = 0; i < size; ++i )
     {
@@ -432,7 +434,7 @@ TEUCHOS_UNIT_TEST( PriorityQueue, maintain_heap_properties )
             queue.push( uniform_distribution( generator ) );
             break;
         case POP_PUSH:
-            queue.pop_push( uniform_distribution( generator ) );
+            queue.popPush( uniform_distribution( generator ) );
             break;
         default:
             throw std::runtime_error( "something went wrong" );

--- a/packages/Search/test/tstDetailsTreeTraversal.cpp
+++ b/packages/Search/test/tstDetailsTreeTraversal.cpp
@@ -145,36 +145,31 @@ TEUCHOS_UNIT_TEST( Containers, non_owning_view_over_dynamic_array )
     TEST_EQUALITY( data[5], 255 );
 }
 
-TEUCHOS_UNIT_TEST( LinearBVH, stack )
+TEUCHOS_UNIT_TEST( ContainerAdaptors, stack )
 {
     // stack is empty at construction
-    DataTransferKit::Details::Stack<int> stack;
+    dtk::Stack<int> stack;
     TEST_ASSERT( stack.empty() );
-    TEST_ASSERT( stack.size() == 0 );
+    TEST_EQUALITY( stack.size(), 0 );
     // insert element
     stack.push( 2 );
     TEST_ASSERT( !stack.empty() );
-    TEST_ASSERT( stack.size() == 1 );
-    TEST_ASSERT( stack.top() == 2 );
+    TEST_EQUALITY( stack.size(), 1 );
+    TEST_EQUALITY( stack.top(), 2 );
     // insert another element
     stack.push( 5 );
     TEST_ASSERT( !stack.empty() );
-    TEST_ASSERT( stack.size() == 2 );
-    TEST_ASSERT( stack.top() == 5 );
+    TEST_EQUALITY( stack.size(), 2 );
+    TEST_EQUALITY( stack.top(), 5 );
     // remove it
     stack.pop();
     TEST_ASSERT( !stack.empty() );
-    TEST_ASSERT( stack.size() == 1 );
-    TEST_ASSERT( stack.top() == 2 );
+    TEST_EQUALITY( stack.size(), 1 );
+    TEST_EQUALITY( stack.top(), 2 );
     // empty the stack
     stack.pop();
     TEST_ASSERT( stack.empty() );
-    TEST_ASSERT( stack.size() == 0 );
-    // add a few elements again and clear the stack
-    for ( int x : {0, 1, 1, 2, 3, 5, 8, 13, 21, 34} )
-        stack.push( x );
-    stack.clear();
-    TEST_ASSERT( stack.empty() );
+    TEST_EQUALITY( stack.size(), 0 );
 }
 
 TEUCHOS_UNIT_TEST( LinearBVH, priority_queue )

--- a/packages/Search/test/tstDetailsTreeTraversal.cpp
+++ b/packages/Search/test/tstDetailsTreeTraversal.cpp
@@ -8,12 +8,78 @@
  *                                                                          *
  * SPDX-License-Identifier: BSD-3-Clause                                    *
  ****************************************************************************/
+
+#include <DTK_DetailsContainers.hpp>
 #include <DTK_DetailsPriorityQueue.hpp>
 #include <DTK_DetailsStack.hpp>
 
 #include <Teuchos_UnitTestHarness.hpp>
 
 #include <random>
+
+namespace dtk = DataTransferKit::Details;
+
+TEUCHOS_UNIT_TEST( Containers, dynamic_array_with_fixed_maximum_size )
+{
+    dtk::Vector<int, 4> a;
+
+    TEST_ASSERT( a.empty() );
+    TEST_EQUALITY( a.size(), 0 );
+    TEST_EQUALITY( a.maxSize(), 4 );
+    TEST_EQUALITY( a.capacity(), 4 );
+
+    a.pushBack( 255 );
+    TEST_ASSERT( !a.empty() );
+    TEST_EQUALITY( a.size(), 1 );
+    TEST_EQUALITY( a.maxSize(), 4 );
+    TEST_EQUALITY( a.capacity(), 4 );
+    TEST_EQUALITY( a.front(), 255 );
+    TEST_EQUALITY( a[0], 255 );
+    TEST_EQUALITY( a.back(), 255 );
+
+    a.pushBack( -1 );
+    TEST_ASSERT( !a.empty() );
+    TEST_EQUALITY( a.size(), 2 );
+    TEST_EQUALITY( a.maxSize(), 4 );
+    TEST_EQUALITY( a.capacity(), 4 );
+    TEST_EQUALITY( a.front(), 255 );
+    TEST_EQUALITY( a[0], 255 );
+    TEST_EQUALITY( a.back(), -1 );
+    TEST_EQUALITY( a[1], -1 );
+
+    a.pushBack( 33 );
+    TEST_ASSERT( !a.empty() );
+    TEST_EQUALITY( a.size(), 3 );
+    TEST_EQUALITY( a.maxSize(), 4 );
+    TEST_EQUALITY( a.capacity(), 4 );
+    TEST_EQUALITY( a.front(), 255 );
+    TEST_EQUALITY( a[0], 255 );
+    TEST_EQUALITY( a[1], -1 );
+    TEST_EQUALITY( a.back(), 33 );
+    TEST_EQUALITY( a[2], 33 );
+
+    a.popBack();
+    TEST_ASSERT( !a.empty() );
+    TEST_EQUALITY( a.size(), 2 );
+    TEST_EQUALITY( a.maxSize(), 4 );
+    TEST_EQUALITY( a.capacity(), 4 );
+    TEST_EQUALITY( a.front(), 255 );
+    TEST_EQUALITY( a.back(), -1 );
+
+    a.popBack();
+    TEST_ASSERT( !a.empty() );
+    TEST_EQUALITY( a.size(), 1 );
+    TEST_EQUALITY( a.maxSize(), 4 );
+    TEST_EQUALITY( a.capacity(), 4 );
+    TEST_EQUALITY( a.front(), 255 );
+    TEST_EQUALITY( a.back(), 255 );
+
+    a.popBack();
+    TEST_ASSERT( a.empty() );
+    TEST_EQUALITY( a.size(), 0 );
+    TEST_EQUALITY( a.maxSize(), 4 );
+    TEST_EQUALITY( a.capacity(), 4 );
+}
 
 TEUCHOS_UNIT_TEST( LinearBVH, stack )
 {

--- a/packages/Search/test/tstDetailsTreeTraversal.cpp
+++ b/packages/Search/test/tstDetailsTreeTraversal.cpp
@@ -453,6 +453,20 @@ TEUCHOS_UNIT_TEST( PriorityQueue, maintain_heap_properties )
     }
 }
 
+TEUCHOS_UNIT_TEST( HeapOperations, sort_heap )
+{
+    for ( auto heap : {std::vector<int>{36, 19, 25, 17, 3, 7, 1, 2, 9},
+                       std::vector<int>{36, 19, 25, 17, 3, 9, 1, 2, 7},
+                       std::vector<int>{100, 19, 36, 17, 3, 25, 1, 2, 7},
+                       std::vector<int>{15, 5, 11, 3, 4, 8}} )
+    {
+        dtk::sortHeap( heap.data(), heap.data() + heap.size(),
+                       dtk::Less<int>() );
+        // std::sort_heap( heap.begin(), heap.end() );
+        TEST_ASSERT( std::is_sorted( heap.begin(), heap.end() ) );
+    }
+}
+
 TEUCHOS_UNIT_TEST( HeapOperations, is_heap )
 {
     for ( auto heap : {std::vector<int>{36, 19, 25, 17, 3, 7, 1, 2, 9},

--- a/packages/Search/test/tstLinearBVH.cpp
+++ b/packages/Search/test/tstLinearBVH.cpp
@@ -319,6 +319,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( LinearBVH, miscellaneous, DeviceType )
     using ExecutionSpace = typename DeviceType::execution_space;
     Kokkos::View<int *, DeviceType> zeros( "zeros", 3 );
     Kokkos::deep_copy( zeros, 255 );
+    Kokkos::View<Kokkos::pair<int, double> *, DeviceType> empty_buffer(
+        "empty_buffer" );
     Kokkos::parallel_for(
         "dummy", Kokkos::RangePolicy<ExecutionSpace>( 0, 1 ),
         KOKKOS_LAMBDA( int ) {
@@ -332,12 +334,12 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( LinearBVH, miscellaneous, DeviceType )
             zeros( 1 ) =
                 DataTransferKit::Details::TreeTraversal<DeviceType>::query(
                     empty_bvh, DataTransferKit::nearest( p ),
-                    []( int, double ) {} );
+                    []( int, double ) {}, empty_buffer );
             // nearest query for k < 1
             zeros( 2 ) =
                 DataTransferKit::Details::TreeTraversal<DeviceType>::query(
-                    bvh, DataTransferKit::nearest( p, 0 ),
-                    []( int, double ) {} );
+                    bvh, DataTransferKit::nearest( p, 0 ), []( int, double ) {},
+                    empty_buffer );
         } );
     Kokkos::fence();
     auto zeros_host = Kokkos::create_mirror_view( zeros );

--- a/packages/Search/test/tstLinearBVH.cpp
+++ b/packages/Search/test/tstLinearBVH.cpp
@@ -322,8 +322,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( LinearBVH, miscellaneous, DeviceType )
     Kokkos::View<Kokkos::pair<int, double> *, DeviceType> empty_buffer(
         "empty_buffer" );
     Kokkos::parallel_for(
-        "dummy", Kokkos::RangePolicy<ExecutionSpace>( 0, 1 ),
-        KOKKOS_LAMBDA( int ) {
+        Kokkos::RangePolicy<ExecutionSpace>( 0, 1 ), KOKKOS_LAMBDA( int ) {
             DataTransferKit::Point p = {{0., 0., 0.}};
             double r = 1.0;
             // spatial query on empty tree

--- a/packages/Utils/src/DTK_KokkosHelpers.hpp
+++ b/packages/Utils/src/DTK_KokkosHelpers.hpp
@@ -23,6 +23,20 @@ namespace DataTransferKit
 namespace KokkosHelpers
 {
 
+// FIXME should be able to use directly Kokkos::ArithTrais<T>::infinity() when
+// kokkos/kokkos-kernels#279 gets merged and eventually makes it into Trilinos.
+template <typename T>
+struct ArithTraits
+{
+    static KOKKOS_INLINE_FUNCTION T infinity();
+};
+
+template <>
+struct ArithTraits<double>
+{
+    static KOKKOS_INLINE_FUNCTION double infinity() { return HUGE_VAL; }
+};
+
 //! Compute the maximum of two values.
 template <typename T, typename = std::enable_if<std::is_arithmetic<T>::value>>
 KOKKOS_INLINE_FUNCTION T max( T a, T b )

--- a/packages/Utils/test/tstKokkosHelpers.cpp
+++ b/packages/Utils/test/tstKokkosHelpers.cpp
@@ -9,7 +9,7 @@
  * SPDX-License-Identifier: BSD-3-Clause                                    *
  ****************************************************************************/
 
-#include <DTK_KokkosHelpers.hpp> // isFinite
+#include <DTK_KokkosHelpers.hpp> // isFinite, infinity
 
 #include <Teuchos_UnitTestHarness.hpp>
 
@@ -24,4 +24,6 @@ TEUCHOS_UNIT_TEST( KokkosHelpers, is_finite )
     TEST_ASSERT( isFinite( DBL_MIN / 2.0 ) );
     TEST_ASSERT( isFinite( 1.0 ) );
     TEST_ASSERT( !isFinite( std::exp( 800 ) ) );
+    TEST_ASSERT( !isFinite(
+        DataTransferKit::KokkosHelpers::ArithTraits<double>::infinity() ) );
 }


### PR DESCRIPTION
Changed implementation of the traversal for nearest queries (only affects kNN search)
Benefits: improved timings but also reduced memory footprint since `PriorityQueue` had a static size relatively big as compared to `Stack` (256 vs 64)^^

^^even though we temporarily double the storage to store the results when we allocate the buffer over which we perform heap operations