### PR TITLE
Improve installation documentation when using a tarball

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -65,6 +65,15 @@ Another way to achieve this is to pass the ``--recursive`` option to the ``git
 clone`` command which will automatically initialize and update DTKData in the
 DataTransferKit repository.
 
+You can also download the DTKData
+`repository <https://github.com/ORNL-CEES/DTKData>`_ yourself and then, link
+it into DTK directory:
+
+.. code::
+
+  $ cd $DTK_DIR
+  $ ln -s $DTKDATA_DIR DTKData
+
 Building DTK
 ------------
 
@@ -75,7 +84,7 @@ Trilinos main directory:
 .. code::
 
     $ cd $TRILINOS_DIR
-    $ ln -s $DTK_DIR
+    $ ln -s $DTK_DIR DataTransferKit
 
 Create a ``do-configure`` script such as:
 


### PR DESCRIPTION
The current instructions to install DTK do not work if we are downloading a tarball. 

I will cherry-pick this commit.