### PR TITLE
Do not require Boost.MPI and Boost.Serialization in release 3.0

### DIFF
--- a/cmake/TPLs/FindTPLBoostOrg.cmake
+++ b/cmake/TPLs/FindTPLBoostOrg.cmake
@@ -4,7 +4,6 @@ GLOBAL_SET(BoostOrg_LIBRARY_DIRS "${Boost_LIBRARY_DIRS}")
 TRIBITS_TPL_FIND_INCLUDE_DIRS_AND_LIBRARIES(
   BoostOrg
   REQUIRED_HEADERS boost/version.hpp boost/mpl/at.hpp
-  REQUIRED_LIBS_NAMES boost_mpi boost_serialization
   )
 
 # Use CMake FindBoost module to check version is sufficient


### PR DESCRIPTION
It removes the need for building Boost