### PR TITLE
Adding size arguments to field evaluation in C API

### DIFF
--- a/packages/Interface/src/DTK_C_API.cpp
+++ b/packages/Interface/src/DTK_C_API.cpp
@@ -249,8 +249,12 @@ void EvaluateFieldFunctionWrapper<double>(
     const View<Coordinate> evaluation_points,
     const View<LocalOrdinal> object_ids, View<double> values )
 {
+    size_t num_point = object_ids.size();
+    unsigned space_dim = evaluation_points.size() / num_point;
     auto u = get_function<DTK_EvaluateFieldFunction>( user_data );
-    u.first( u.second, field_name.c_str(), evaluation_points.data(),
+    u.first( u.second, field_name.c_str(),
+             num_point, space_dim,
+             evaluation_points.data(),
              object_ids.data(), values.data() );
 }
 

--- a/packages/Interface/src/DTK_C_API.cpp
+++ b/packages/Interface/src/DTK_C_API.cpp
@@ -250,11 +250,9 @@ void EvaluateFieldFunctionWrapper<double>(
     const View<LocalOrdinal> object_ids, View<double> values )
 {
     size_t num_point = object_ids.size();
-    unsigned space_dim = evaluation_points.size() / num_point;
     auto u = get_function<DTK_EvaluateFieldFunction>( user_data );
     u.first( u.second, field_name.c_str(),
-             num_point, space_dim,
-             evaluation_points.data(),
+             num_point, evaluation_points.data(),
              object_ids.data(), values.data() );
 }
 

--- a/packages/Interface/src/DTK_C_API.h
+++ b/packages/Interface/src/DTK_C_API.h
@@ -612,22 +612,41 @@ typedef void ( *DTK_PushFieldDataFunction )( void *user_data,
 /** \brief Prototype function to evaluate a field at a given set of points in a
  *         given set of objects.
  *
- *  Register with a user application using DTK_setUserFunction() by passing
- *  DTK_EVALUATE_FIELD_FUNCTION as the \p type argument.
+ *  This function gives users the ability to use their own interpolant with a
+ *  DTK transfer operator. This function provides a set of coordinates at
+ *  which the function should be evaluated and for each point the local id of
+ *  the object in which the field is located or to which it is nearest. The
+ *  user then interpolates the field onto this point and returns the result.
+ *
+ *  \note Register with a user application using DTK_setUserFunction() by
+ *  passing DTK_EVALUATE_FIELD_FUNCTION as the \p type argument.
  *
  *  \param[in] user_data Custom user data.
- *  \param[in] field_name Name of the field to evaluate.
+ *
+ *  \param[in] field_name Name of the field to evaluate. The user
+ *             implementation of this function should evaluate the field
+ *             associated with this name.
+ *
+ *  \param[in] num_points The number of points at which to evaluate the field.
+ *
+ *  \param[in] space_dim The spatial dimension of the evaluation points.
+ *
  *  \param[in] evaluate_points Coordinates of the points at which to evaluate
- *             the field.
- *  \param[in] objects_ids ID of the cell/face with repect of which the
- *             coordinates are expressed.
- *  \param[out] values Field values.
- *  <!--
- *  FIXME: changed Scalar to double, which other do we need to provide?
- *  -->
+ *             the field. The length of this array is num_points *
+ *             space_dim. As with other coordinate arrays, these values are
+ *             blocked by spatial dimension.
+ *
+ *  \param[in] objects_ids ID of the cell/face with respect of which the
+ *             coordinates are expressed. The length of this array is
+ *             num_points.
+ *
+ *  \param[out] values Evaluated field values. The length of this array is
+ *              num_points * field_dimension. Values are blocked by field
+ *              dimension.
  */
 typedef void ( *DTK_EvaluateFieldFunction )(
     void *user_data, const char *field_name,
+    const size_t num_points, const unsigned space_dim,
     const Coordinate *evaluation_points, const LocalOrdinal *object_ids,
     double *values );
 

--- a/packages/Interface/src/DTK_C_API.h
+++ b/packages/Interface/src/DTK_C_API.h
@@ -629,12 +629,12 @@ typedef void ( *DTK_PushFieldDataFunction )( void *user_data,
  *
  *  \param[in] num_points The number of points at which to evaluate the field.
  *
- *  \param[in] space_dim The spatial dimension of the evaluation points.
- *
  *  \param[in] evaluate_points Coordinates of the points at which to evaluate
  *             the field. The length of this array is num_points *
  *             space_dim. As with other coordinate arrays, these values are
- *             blocked by spatial dimension.
+ *             blocked by spatial dimension. The spatial dimension of the
+ *             points is defined by the geometry of the problem (e.g. 3D
+ *             problems have points with 3 dimensions).
  *
  *  \param[in] objects_ids ID of the cell/face with respect of which the
  *             coordinates are expressed. The length of this array is
@@ -646,9 +646,8 @@ typedef void ( *DTK_PushFieldDataFunction )( void *user_data,
  */
 typedef void ( *DTK_EvaluateFieldFunction )(
     void *user_data, const char *field_name,
-    const size_t num_points, const unsigned space_dim,
-    const Coordinate *evaluation_points, const LocalOrdinal *object_ids,
-    double *values );
+    const size_t num_points, const Coordinate *evaluation_points,
+    const LocalOrdinal *object_ids, double *values );
 
 /**@}*/
 

--- a/packages/Interface/test/tstC_API.c
+++ b/packages/Interface/test/tstC_API.c
@@ -275,7 +275,7 @@ void field_size( void *user_data, const char *field_name,
 {
     UserTestClass *u = (UserTestClass *)user_data;
 
-    // Here one could do actions depening on the name, but in the tests we
+    // Here one could do actions depending on the name, but in the tests we
     // simply ignore it
     (void)field_name;
 
@@ -291,7 +291,7 @@ void pull_field_data( void *user_data, const char *field_name,
 {
     UserTestClass *u = (UserTestClass *)user_data;
 
-    // Here one could do actions depening on the name, but in the tests we
+    // Here one could do actions depending on the name, but in the tests we
     // simply ignore it
     (void)field_name;
 
@@ -310,7 +310,7 @@ void push_field_data( void *user_data, const char *field_name,
 {
     UserTestClass *u = (UserTestClass *)user_data;
 
-    // Here one could do actions depening on the name, but in the tests we
+    // Here one could do actions depending on the name, but in the tests we
     // simply ignore it
     (void)field_name;
 
@@ -324,20 +324,19 @@ void push_field_data( void *user_data, const char *field_name,
 //---------------------------------------------------------------------------//
 // Evaluate a field at a given set of points in a given set of objects.
 void evaluate_field( void *user_data, const char *field_name,
+                     const size_t num_points, const unsigned space_dim,
                      const Coordinate *evaluation_points,
                      const LocalOrdinal *object_ids, double *values )
 {
-    UserTestClass *u = (UserTestClass *)user_data;
-
-    // Here one could do actions depening on the name, but in the tests we
+    // Here one could do actions depending on the name, but in the tests we
     // simply ignore it
     (void)field_name;
 
-    for ( size_t n = 0; n < u->_size_1; n++ )
+    for ( size_t n = 0; n < num_points; n++ )
     {
-        for ( unsigned d = 0; d < u->_space_dim; ++d )
-            values[d * u->_size_1 + n] =
-                evaluation_points[d * u->_size_1 + n] + object_ids[n];
+        for ( unsigned d = 0; d < space_dim; ++d )
+            values[d * num_points + n] =
+                evaluation_points[d * num_points + n] + object_ids[n];
     }
 }
 

--- a/packages/Interface/test/tstC_API.c
+++ b/packages/Interface/test/tstC_API.c
@@ -324,17 +324,19 @@ void push_field_data( void *user_data, const char *field_name,
 //---------------------------------------------------------------------------//
 // Evaluate a field at a given set of points in a given set of objects.
 void evaluate_field( void *user_data, const char *field_name,
-                     const size_t num_points, const unsigned space_dim,
+                     const size_t num_points,
                      const Coordinate *evaluation_points,
                      const LocalOrdinal *object_ids, double *values )
 {
+    UserTestClass *u = (UserTestClass *)user_data;
+
     // Here one could do actions depending on the name, but in the tests we
     // simply ignore it
     (void)field_name;
 
     for ( size_t n = 0; n < num_points; n++ )
     {
-        for ( unsigned d = 0; d < space_dim; ++d )
+        for ( unsigned d = 0; d < u->_space_dim; ++d )
             values[d * num_points + n] =
                 evaluation_points[d * num_points + n] + object_ids[n];
     }

--- a/packages/Interface/test/tstFortran_API.f90
+++ b/packages/Interface/test/tstFortran_API.f90
@@ -512,28 +512,31 @@ contains
   !---------------------------------------------------------------------------//
   ! Evaluate a field at a given set of points in a given set of objects.
   subroutine evaluate_field(user_data, field_name, &
+      num_points, space_dim, &
       evaluation_points, object_ids, values) BIND(C)
     use, intrinsic :: ISO_C_BINDING
     type(c_ptr), value :: user_data
     type(c_ptr), value, intent(in) :: field_name
+    integer(c_size_t), value, intent(in) :: num_points
+    integer(c_int), value, intent(in) :: space_dim
     real(c_double), dimension(*), intent(in) :: evaluation_points
     integer(c_int), dimension(*), intent(in) :: object_ids
     real(c_double), dimension(*), intent(out) :: values
 
     integer :: i, j
-    character(kind=c_char,len=:), pointer :: f_field_name
-    type(UserTestClass), pointer :: u
+    ! character(kind=c_char,len=:), pointer :: f_field_name
+    ! type(UserTestClass), pointer :: u
 
-    call c_f_pointer(user_data, u)
+    ! call c_f_pointer(user_data, u)
 
-    f_field_name => c_f_string(field_name)
+    ! f_field_name => c_f_string(field_name)
     ! Here one could do actions depening on the name, but in the tests we
     ! simply ignore it
 
-    do i = 1, u%size_1
-      do j = 1, u%space_dim
-        values((j-1) * u%size_1 + i) = &
-          evaluation_points((j-1) * u%size_1 + i) + object_ids(i)
+    do i = 1, num_points
+      do j = 1, space_dim
+        values((j-1) * num_points + i) = &
+          evaluation_points((j-1) * num_points + i) + object_ids(i)
       end do
     end do
   end subroutine

--- a/packages/Interface/test/tstFortran_API.f90
+++ b/packages/Interface/test/tstFortran_API.f90
@@ -512,29 +512,28 @@ contains
   !---------------------------------------------------------------------------//
   ! Evaluate a field at a given set of points in a given set of objects.
   subroutine evaluate_field(user_data, field_name, &
-      num_points, space_dim, &
+      num_points, &
       evaluation_points, object_ids, values) BIND(C)
     use, intrinsic :: ISO_C_BINDING
     type(c_ptr), value :: user_data
     type(c_ptr), value, intent(in) :: field_name
     integer(c_size_t), value, intent(in) :: num_points
-    integer(c_int), value, intent(in) :: space_dim
     real(c_double), dimension(*), intent(in) :: evaluation_points
     integer(c_int), dimension(*), intent(in) :: object_ids
     real(c_double), dimension(*), intent(out) :: values
 
     integer :: i, j
     ! character(kind=c_char,len=:), pointer :: f_field_name
-    ! type(UserTestClass), pointer :: u
+    type(UserTestClass), pointer :: u
 
-    ! call c_f_pointer(user_data, u)
+    call c_f_pointer(user_data, u)
 
     ! f_field_name => c_f_string(field_name)
     ! Here one could do actions depening on the name, but in the tests we
     ! simply ignore it
 
     do i = 1, num_points
-      do j = 1, space_dim
+      do j = 1, u%space_dim
         values((j-1) * num_points + i) = &
           evaluation_points((j-1) * num_points + i) + object_ids(i)
       end do


### PR DESCRIPTION
Through reviewing the C API for documentation I realized that `DTK_EvaluateFieldDataFunction` had no size arguments and therefore there was no way for a user to know how many points they were evaluating the field at and what spatial dimension the points were. I have updated the C interface to reflect this.