### PR TITLE
Move morton3D and sortObjects out of TreeConstruction to DetailsUtils

### DIFF
--- a/packages/Search/src/DTK_LinearBVH_decl.hpp
+++ b/packages/Search/src/DTK_LinearBVH_decl.hpp
@@ -15,6 +15,7 @@
 #include <DTK_Box.hpp>
 #include <DTK_DetailsBoundingVolumeHierarchyImpl.hpp>
 #include <DTK_DetailsNode.hpp>
+#include <DTK_DetailsSortUtils.hpp>
 #include <DTK_DetailsTreeConstruction.hpp>
 
 #include <Kokkos_Macros.hpp>
@@ -112,8 +113,7 @@ BoundingVolumeHierarchy<DeviceType>::BoundingVolumeHierarchy(
         primitives, morton_indices, _internal_nodes[0].bounding_box );
 
     // sort them along the Z-order space-filling curve
-    auto permutation_indices =
-        Details::TreeConstruction<DeviceType>::sortObjects( morton_indices );
+    auto permutation_indices = Details::sortObjects( morton_indices );
 
     Details::TreeConstruction<DeviceType>::initializeLeafNodes(
         permutation_indices, primitives, _leaf_nodes );

--- a/packages/Search/src/details/DTK_DetailsBatchedQueries.hpp
+++ b/packages/Search/src/details/DTK_DetailsBatchedQueries.hpp
@@ -13,9 +13,10 @@
 #define DTK_DETAILS_BATCHED_QUERIES_HPP
 
 #include <DTK_Box.hpp>
-#include <DTK_DetailsAlgorithms.hpp>       // return_centroid
-#include <DTK_DetailsTreeConstruction.hpp> // morton3D
-#include <DTK_DetailsUtils.hpp> // iota, exclusivePrefixSum, lastElement
+#include <DTK_DetailsAlgorithms.hpp> // return_centroid
+#include <DTK_DetailsMortonCode.hpp> // morton3D
+#include <DTK_DetailsSortUtils.hpp>  // sortObjects
+#include <DTK_DetailsUtils.hpp>      // iota, exclusivePrefixSum, lastElement
 
 #include <Kokkos_Core.hpp>
 #include <Kokkos_Parallel.hpp>
@@ -68,12 +69,11 @@ struct BatchedQueries
                     double const b = scene_bounding_box.maxCorner()[d];
                     xyz[d] = ( a != b ? ( xyz[d] - a ) / ( b - a ) : 0 );
                 }
-                morton_codes( i ) = TreeConstruction<DeviceType>::morton3D(
-                    xyz[0], xyz[1], xyz[2] );
+                morton_codes( i ) = morton3D( xyz[0], xyz[1], xyz[2] );
             } );
         Kokkos::fence();
 
-        return TreeConstruction<DeviceType>::sortObjects( morton_codes );
+        return sortObjects( morton_codes );
     }
 
     template <typename T>

--- a/packages/Search/src/details/DTK_DetailsMortonCode.hpp
+++ b/packages/Search/src/details/DTK_DetailsMortonCode.hpp
@@ -1,0 +1,64 @@
+/****************************************************************************
+ * Copyright (c) 2012-2018 by the DataTransferKit authors                   *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the DataTransferKit library. DataTransferKit is     *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#ifndef DTK_DETAILS_MORTON_CODE_UTILS_HPP
+#define DTK_DETAILS_MORTON_CODE_UTILS_HPP
+
+#include <DTK_DBC.hpp>
+
+#include <DTK_KokkosHelpers.hpp> // clz, min. max
+
+namespace DataTransferKit
+{
+
+namespace Details
+{
+
+// Expands a 10-bit integer into 30 bits
+// by inserting 2 zeros after each bit.
+KOKKOS_INLINE_FUNCTION
+static unsigned int expandBits( unsigned int v )
+{
+    v = ( v * 0x00010001u ) & 0xFF0000FFu;
+    v = ( v * 0x00000101u ) & 0x0F00F00Fu;
+    v = ( v * 0x00000011u ) & 0xC30C30C3u;
+    v = ( v * 0x00000005u ) & 0x49249249u;
+    return v;
+}
+
+// Calculates a 30-bit Morton code for the
+// given 3D point located within the unit cube [0,1].
+KOKKOS_INLINE_FUNCTION
+static unsigned int morton3D( double x, double y, double z )
+{
+    using KokkosHelpers::max;
+    using KokkosHelpers::min;
+
+    // The interval [0,1] is subdivided into 1024 bins (in each direction).
+    // If we were to use more bits to encode the Morton code, we would need
+    // to reflect these changes in expandBits() as well as in the clz()
+    // function that returns the number of leading zero bits since it
+    // currently assumes that the code can be represented by a 32 bit
+    // integer.
+    x = min( max( x * 1024.0, 0.0 ), 1023.0 );
+    y = min( max( y * 1024.0, 0.0 ), 1023.0 );
+    z = min( max( z * 1024.0, 0.0 ), 1023.0 );
+    unsigned int xx = expandBits( (unsigned int)x );
+    unsigned int yy = expandBits( (unsigned int)y );
+    unsigned int zz = expandBits( (unsigned int)z );
+    return xx * 4 + yy * 2 + zz;
+}
+
+} // namespace Details
+
+} // namespace DataTransferKit
+
+#endif

--- a/packages/Search/src/details/DTK_DetailsMortonCode.hpp
+++ b/packages/Search/src/details/DTK_DetailsMortonCode.hpp
@@ -25,7 +25,7 @@ namespace Details
 // Expands a 10-bit integer into 30 bits
 // by inserting 2 zeros after each bit.
 KOKKOS_INLINE_FUNCTION
-static unsigned int expandBits( unsigned int v )
+unsigned int expandBits( unsigned int v )
 {
     v = ( v * 0x00010001u ) & 0xFF0000FFu;
     v = ( v * 0x00000101u ) & 0x0F00F00Fu;
@@ -37,7 +37,7 @@ static unsigned int expandBits( unsigned int v )
 // Calculates a 30-bit Morton code for the
 // given 3D point located within the unit cube [0,1].
 KOKKOS_INLINE_FUNCTION
-static unsigned int morton3D( double x, double y, double z )
+unsigned int morton3D( double x, double y, double z )
 {
     using KokkosHelpers::max;
     using KokkosHelpers::min;

--- a/packages/Search/src/details/DTK_DetailsSortUtils.hpp
+++ b/packages/Search/src/details/DTK_DetailsSortUtils.hpp
@@ -1,0 +1,71 @@
+/****************************************************************************
+ * Copyright (c) 2012-2018 by the DataTransferKit authors                   *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the DataTransferKit library. DataTransferKit is     *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#ifndef DTK_DETAILS_SORT_UTILS_HPP
+#define DTK_DETAILS_SORT_UTILS_HPP
+
+#include <DTK_DBC.hpp>
+
+#include <DTK_DetailsUtils.hpp> // iota
+#include <Kokkos_Sort.hpp>      // min_max_functor
+#include <Kokkos_View.hpp>
+
+namespace DataTransferKit
+{
+
+namespace Details
+{
+
+// NOTE returns the permutation indices **and** sorts the morton codes
+template <typename DeviceType>
+Kokkos::View<size_t *, DeviceType>
+sortObjects( Kokkos::View<unsigned int *, DeviceType> view )
+{
+    int const n = view.extent( 0 );
+
+    using ViewType = decltype( view );
+    using ValueType = typename ViewType::value_type;
+    using CompType = Kokkos::BinOp1D<ViewType>;
+    using ExecutionSpace = typename DeviceType::execution_space;
+
+    Kokkos::Experimental::MinMaxScalar<ValueType> result;
+    Kokkos::Experimental::MinMax<ValueType> reducer( result );
+    parallel_reduce( DTK_MARK_REGION( "find_min_max_view" ),
+                     Kokkos::RangePolicy<ExecutionSpace>( 0, n ),
+                     Kokkos::Impl::min_max_functor<ViewType>( view ), reducer );
+    if ( result.min_val == result.max_val )
+    {
+        Kokkos::View<size_t *, DeviceType> permute(
+            Kokkos::ViewAllocateWithoutInitializing( "permute" ), n );
+        iota( permute );
+        return permute;
+    }
+
+    // Passing the SizeType template argument to Kokkos::BinSort because it
+    // defaults to the memory space size type which is different on the host and
+    // on cuda (size_t versus unsigned int respectively).  size_t feels like a
+    // better choice here because its size is guaranteed to coincide with the
+    // pointer size which is a good thing for converting with reinterpret_cast
+    // (when leaf indices are encoded into the pointer to one of their children)
+    Kokkos::BinSort<ViewType, CompType, DeviceType, size_t> bin_sort(
+        view, CompType( n / 2, result.min_val, result.max_val ), true );
+    bin_sort.create_permute_vector();
+    bin_sort.sort( view );
+    Kokkos::fence();
+
+    return bin_sort.get_permute_vector();
+}
+
+} // namespace Details
+
+} // namespace DataTransferKit
+
+#endif

--- a/packages/Search/test/tstDetailsTreeConstruction.cpp
+++ b/packages/Search/test/tstDetailsTreeConstruction.cpp
@@ -9,6 +9,8 @@
  * SPDX-License-Identifier: BSD-3-Clause                                    *
  ****************************************************************************/
 #include <DTK_DetailsAlgorithms.hpp>
+#include <DTK_DetailsMortonCode.hpp> // expandBits, morton3D
+#include <DTK_DetailsSortUtils.hpp>  // sortObjects
 #include <DTK_DetailsTreeConstruction.hpp>
 #include <DTK_DetailsUtils.hpp>  // iota
 #include <DTK_KokkosHelpers.hpp> // clz
@@ -41,9 +43,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DetailsBVH, morton_codes, DeviceType )
         unsigned int i = std::get<0>( anchor );
         unsigned int j = std::get<1>( anchor );
         unsigned int k = std::get<2>( anchor );
-        return 4 * dtk::TreeConstruction<DeviceType>::expandBits( i ) +
-               2 * dtk::TreeConstruction<DeviceType>::expandBits( j ) +
-               dtk::TreeConstruction<DeviceType>::expandBits( k );
+        return 4 * dtk::expandBits( i ) + 2 * dtk::expandBits( j ) +
+               dtk::expandBits( k );
     };
     std::vector<unsigned int> ref( n,
                                    Kokkos::ArithTraits<unsigned int>::max() );
@@ -109,7 +110,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DetailsBVH, indirect_sort, DeviceType )
 
     std::vector<size_t> ref = {3, 2, 1, 0};
     // sort morton codes and object ids
-    auto ids = dtk::TreeConstruction<DeviceType>::sortObjects( k );
+    auto ids = dtk::sortObjects( k );
 
     auto k_host = Kokkos::create_mirror_view( k );
     Kokkos::deep_copy( k_host, k );


### PR DESCRIPTION
Few questions:
1. Is `DTK_DetailsUtils.hpp` the right place for them?
2. Should they be in `DTK` or `DTK::Details` namespace?
3. Should we put generalize `sortObjects` to work with more types, and rename to `sort`?