### PR TITLE
Remove pointer to parent node and merge internal and leaf arrays

### DIFF
--- a/packages/Search/src/details/DTK_DetailsNode.hpp
+++ b/packages/Search/src/details/DTK_DetailsNode.hpp
@@ -22,7 +22,6 @@ struct Node
     KOKKOS_INLINE_FUNCTION
     Node() = default;
 
-    Node *parent = nullptr;
     Kokkos::pair<Node *, Node *> children = {nullptr, nullptr};
     Box bounding_box;
 };

--- a/packages/Search/src/details/DTK_DetailsTreeConstruction_decl.hpp
+++ b/packages/Search/src/details/DTK_DetailsTreeConstruction_decl.hpp
@@ -56,11 +56,13 @@ struct TreeConstruction
     static Node *generateHierarchy(
         Kokkos::View<unsigned int *, DeviceType> sorted_morton_codes,
         Kokkos::View<Node *, DeviceType> leaf_nodes,
-        Kokkos::View<Node *, DeviceType> internal_nodes );
+        Kokkos::View<Node *, DeviceType> internal_nodes,
+        Kokkos::View<int *, DeviceType> parents );
 
-    static void
-    calculateBoundingBoxes( Kokkos::View<Node *, DeviceType> leaf_nodes,
-                            Kokkos::View<Node *, DeviceType> internal_nodes );
+    static void calculateInternalNodesBoundingVolumes(
+        Kokkos::View<Node const *, DeviceType> leaf_nodes,
+        Kokkos::View<Node *, DeviceType> internal_nodes,
+        Kokkos::View<int const *, DeviceType> parents );
 
     KOKKOS_INLINE_FUNCTION
     static int

--- a/packages/Search/src/details/DTK_DetailsTreeTraversal.hpp
+++ b/packages/Search/src/details/DTK_DetailsTreeTraversal.hpp
@@ -42,242 +42,208 @@ struct TreeTraversal
         return queryDispatch( Tag{}, bvh, pred, std::forward<Args>( args )... );
     }
 
-    /**
-     * Return true if the node is a leaf.
-     */
-    KOKKOS_INLINE_FUNCTION
-    static bool isLeaf( Node const *node )
-    {
-        return ( node->children.first == nullptr );
-    }
-
-    /**
-     * Return the index of the leaf node.
-     */
-    KOKKOS_INLINE_FUNCTION
-    static size_t getIndex( Node const *leaf )
-    {
-        static_assert( sizeof( size_t ) == sizeof( Node * ),
-                       "Conversion is a bad idea if these sizes do not match" );
-        return reinterpret_cast<size_t>( leaf->children.second );
-    }
-
-    /**
-     * Return the root node of the BVH.
-     */
-    KOKKOS_INLINE_FUNCTION
-    static Node const *getRoot( BoundingVolumeHierarchy<DeviceType> const &bvh )
+    // There are two (related) families of search: one using a spatial predicate
+    // and one using nearest neighbours query (see boost::geometry::queries
+    // documentation).
+    template <typename Predicate, typename Insert>
+    KOKKOS_FUNCTION static int
+    spatialQuery( BoundingVolumeHierarchy<DeviceType> const &bvh,
+                  Predicate const &predicate, Insert const &insert )
     {
         if ( bvh.empty() )
-            return nullptr;
-        return ( bvh.size() > 1 ? bvh._internal_nodes : bvh._leaf_nodes )
-            .data();
-    }
-};
-
-// There are two (related) families of search: one using a spatial predicate and
-// one using nearest neighbours query (see boost::geometry::queries
-// documentation).
-template <typename DeviceType, typename Predicate, typename Insert>
-KOKKOS_FUNCTION int
-spatialQuery( BoundingVolumeHierarchy<DeviceType> const &bvh,
-              Predicate const &predicate, Insert const &insert )
-{
-    if ( bvh.empty() )
-        return 0;
-
-    if ( bvh.size() == 1 )
-    {
-        Node const *leaf = TreeTraversal<DeviceType>::getRoot( bvh );
-        if ( predicate( leaf ) )
-        {
-            int const leaf_index = TreeTraversal<DeviceType>::getIndex( leaf );
-            insert( leaf_index );
-            return 1;
-        }
-        else
             return 0;
-    }
 
-    Stack<Node const *> stack;
-
-    stack.emplace( TreeTraversal<DeviceType>::getRoot( bvh ) );
-    int count = 0;
-
-    while ( !stack.empty() )
-    {
-        Node const *node = stack.top();
-        stack.pop();
-
-        if ( TreeTraversal<DeviceType>::isLeaf( node ) )
+        if ( bvh.size() == 1 )
         {
-            insert( TreeTraversal<DeviceType>::getIndex( node ) );
-            count++;
-        }
-        else
-        {
-            for ( Node const *child :
-                  {node->children.first, node->children.second} )
+            if ( predicate( bvh.getBoundingVolume( bvh.getRoot() ) ) )
             {
-                if ( predicate( child ) )
-                {
-                    stack.push( child );
-                }
+                insert( 0 );
+                return 1;
             }
+            else
+                return 0;
         }
-    }
-    return count;
-}
 
-// query k nearest neighbours
-template <typename DeviceType, typename Distance, typename Insert,
-          typename Buffer>
-KOKKOS_FUNCTION int
-nearestQuery( BoundingVolumeHierarchy<DeviceType> const &bvh,
-              Distance const &distance, std::size_t k, Insert const &insert,
-              Buffer const &buffer )
-{
-    if ( bvh.empty() || k < 1 )
-        return 0;
+        Stack<Node const *> stack;
 
-    if ( bvh.size() == 1 )
-    {
-        Node const *leaf = TreeTraversal<DeviceType>::getRoot( bvh );
-        int const leaf_index = TreeTraversal<DeviceType>::getIndex( leaf );
-        double const leaf_distance = distance( leaf );
-        insert( leaf_index, leaf_distance );
-        return 1;
-    }
+        stack.emplace( bvh.getRoot() );
+        int count = 0;
 
-    // Nodes with a distance that exceed that radius can safely be discarded.
-    // Initialize the radius to infinity and tighten it once k neighbors have
-    // been found.
-    double radius = KokkosHelpers::ArithTraits<double>::infinity();
-
-    using PairIndexDistance = Kokkos::pair<int, double>;
-    static_assert(
-        std::is_same<typename Buffer::value_type, PairIndexDistance>::value,
-        "Type of the elements stored in the buffer passed as argument to "
-        "TreeTraversal::nearestQuery is not right" );
-    struct CompareDistance
-    {
-        KOKKOS_INLINE_FUNCTION bool
-        operator()( PairIndexDistance const &lhs,
-                    PairIndexDistance const &rhs ) const
+        while ( !stack.empty() )
         {
-            return lhs.second < rhs.second;
-        }
-    };
-    // Use a priority queue for convenience to store the results and preserve
-    // the heap structure internally at all time.  There is no memory
-    // allocation, elements are stored in the buffer passed as an argument.
-    // The farthest leaf node is on top.
-    assert( k == buffer.size() );
-    PriorityQueue<PairIndexDistance, CompareDistance,
-                  UnmanagedStaticVector<PairIndexDistance>>
-        heap( UnmanagedStaticVector<PairIndexDistance>( buffer.data(),
-                                                        buffer.size() ) );
+            Node const *node = stack.top();
+            stack.pop();
 
-    using PairNodePtrDistance = Kokkos::pair<Node const *, double>;
-    Stack<PairNodePtrDistance> stack;
-    // Do not bother computing the distance to the root node since it is
-    // immediately popped out of the stack and processed.
-    stack.emplace( TreeTraversal<DeviceType>::getRoot( bvh ), 0. );
-
-    while ( !stack.empty() )
-    {
-        Node const *node = stack.top().first;
-        double const node_distance = stack.top().second;
-        stack.pop();
-
-        if ( node_distance < radius )
-        {
-            if ( TreeTraversal<DeviceType>::isLeaf( node ) )
+            if ( bvh.isLeaf( node ) )
             {
-                int const leaf_index =
-                    TreeTraversal<DeviceType>::getIndex( node );
-                double const leaf_distance = node_distance;
-                if ( heap.size() < k )
-                {
-                    // Insert leaf node and update radius if it was the kth one.
-                    heap.push( Kokkos::make_pair( leaf_index, leaf_distance ) );
-                    if ( heap.size() == k )
-                        radius = heap.top().second;
-                }
-                else
-                {
-                    // Replace top element in the heap and update radius.
-                    heap.popPush(
-                        Kokkos::make_pair( leaf_index, leaf_distance ) );
-                    radius = heap.top().second;
-                }
+                insert( bvh.getLeafPermutationIndex( node ) );
+                count++;
             }
             else
             {
-                // Insert children into the stack and make sure that the
-                // closest one ends on top.
-                Node const *left_child = node->children.first;
-                double const left_child_distance = distance( left_child );
-                Node const *right_child = node->children.second;
-                double const right_child_distance = distance( right_child );
-                if ( left_child_distance < right_child_distance )
+                for ( Node const *child :
+                      {node->children.first, node->children.second} )
                 {
-                    // NOTE not really sure why but it performed better with
-                    // the conditional insertion on the device and without it
-                    // on the host (~5% improvement for both)
-#if defined( __CUDA_ARCH__ )
-                    if ( right_child_distance < radius )
-#endif
-                        stack.emplace( right_child, right_child_distance );
-                    stack.emplace( left_child, left_child_distance );
-                }
-                else
-                {
-#if defined( __CUDA_ARCH__ )
-                    if ( left_child_distance < radius )
-#endif
-                        stack.emplace( left_child, left_child_distance );
-                    stack.emplace( right_child, right_child_distance );
+                    if ( predicate( bvh.getBoundingVolume( child ) ) )
+                    {
+                        stack.push( child );
+                    }
                 }
             }
         }
+        return count;
     }
-    // Sort the leaf nodes and output the results.
-    // NOTE: Do not try this at home.  Messing with the underlying container
-    // invalidates the state of the PriorityQueue.
-    sortHeap( heap.data(), heap.data() + heap.size(), heap.valueComp() );
-    for ( decltype( heap.size() ) i = 0; i < heap.size(); ++i )
+
+    // query k nearest neighbours
+    template <typename Distance, typename Insert, typename Buffer>
+    KOKKOS_FUNCTION static int
+    nearestQuery( BoundingVolumeHierarchy<DeviceType> const &bvh,
+                  Distance const &distance, std::size_t k, Insert const &insert,
+                  Buffer const &buffer )
     {
-        int const leaf_index = ( heap.data() + i )->first;
-        double const leaf_distance = ( heap.data() + i )->second;
-        insert( leaf_index, leaf_distance );
+        if ( bvh.empty() || k < 1 )
+            return 0;
+
+        if ( bvh.size() == 1 )
+        {
+            insert( 0, distance( bvh.getBoundingVolume( bvh.getRoot() ) ) );
+            return 1;
+        }
+
+        // Nodes with a distance that exceed that radius can safely be
+        // discarded. Initialize the radius to infinity and tighten it once k
+        // neighbors have been found.
+        double radius = KokkosHelpers::ArithTraits<double>::infinity();
+
+        using PairIndexDistance = Kokkos::pair<int, double>;
+        static_assert(
+            std::is_same<typename Buffer::value_type, PairIndexDistance>::value,
+            "Type of the elements stored in the buffer passed as argument to "
+            "TreeTraversal::nearestQuery is not right" );
+        struct CompareDistance
+        {
+            KOKKOS_INLINE_FUNCTION bool
+            operator()( PairIndexDistance const &lhs,
+                        PairIndexDistance const &rhs ) const
+            {
+                return lhs.second < rhs.second;
+            }
+        };
+        // Use a priority queue for convenience to store the results and
+        // preserve the heap structure internally at all time.  There is no
+        // memory allocation, elements are stored in the buffer passed as an
+        // argument. The farthest leaf node is on top.
+        assert( k == buffer.size() );
+        PriorityQueue<PairIndexDistance, CompareDistance,
+                      UnmanagedStaticVector<PairIndexDistance>>
+            heap( UnmanagedStaticVector<PairIndexDistance>( buffer.data(),
+                                                            buffer.size() ) );
+
+        using PairNodePtrDistance = Kokkos::pair<Node const *, double>;
+        Stack<PairNodePtrDistance> stack;
+        // Do not bother computing the distance to the root node since it is
+        // immediately popped out of the stack and processed.
+        stack.emplace( bvh.getRoot(), 0. );
+
+        while ( !stack.empty() )
+        {
+            Node const *node = stack.top().first;
+            double const node_distance = stack.top().second;
+            stack.pop();
+
+            if ( node_distance < radius )
+            {
+                if ( bvh.isLeaf( node ) )
+                {
+                    int const leaf_index = bvh.getLeafPermutationIndex( node );
+                    double const leaf_distance = node_distance;
+                    if ( heap.size() < k )
+                    {
+                        // Insert leaf node and update radius if it was the kth
+                        // one.
+                        heap.push(
+                            Kokkos::make_pair( leaf_index, leaf_distance ) );
+                        if ( heap.size() == k )
+                            radius = heap.top().second;
+                    }
+                    else
+                    {
+                        // Replace top element in the heap and update radius.
+                        heap.popPush(
+                            Kokkos::make_pair( leaf_index, leaf_distance ) );
+                        radius = heap.top().second;
+                    }
+                }
+                else
+                {
+                    // Insert children into the stack and make sure that the
+                    // closest one ends on top.
+                    Node const *left_child = node->children.first;
+                    double const left_child_distance =
+                        distance( bvh.getBoundingVolume( left_child ) );
+                    Node const *right_child = node->children.second;
+                    double const right_child_distance =
+                        distance( bvh.getBoundingVolume( right_child ) );
+                    if ( left_child_distance < right_child_distance )
+                    {
+                        // NOTE not really sure why but it performed better with
+                        // the conditional insertion on the device and without
+                        // it on the host (~5% improvement for both)
+#if defined( __CUDA_ARCH__ )
+                        if ( right_child_distance < radius )
+#endif
+                            stack.emplace( right_child, right_child_distance );
+                        stack.emplace( left_child, left_child_distance );
+                    }
+                    else
+                    {
+#if defined( __CUDA_ARCH__ )
+                        if ( left_child_distance < radius )
+#endif
+                            stack.emplace( left_child, left_child_distance );
+                        stack.emplace( right_child, right_child_distance );
+                    }
+                }
+            }
+        }
+        // Sort the leaf nodes and output the results.
+        // NOTE: Do not try this at home.  Messing with the underlying container
+        // invalidates the state of the PriorityQueue.
+        sortHeap( heap.data(), heap.data() + heap.size(), heap.valueComp() );
+        for ( decltype( heap.size() ) i = 0; i < heap.size(); ++i )
+        {
+            int const leaf_index = ( heap.data() + i )->first;
+            double const leaf_distance = ( heap.data() + i )->second;
+            insert( leaf_index, leaf_distance );
+        }
+        return heap.size();
     }
-    return heap.size();
-}
 
-template <typename DeviceType, typename Predicate, typename Insert>
-KOKKOS_INLINE_FUNCTION int
-queryDispatch( SpatialPredicateTag,
-               BoundingVolumeHierarchy<DeviceType> const &bvh,
-               Predicate const &pred, Insert const &insert )
-{
-    return spatialQuery( bvh, pred, insert );
-}
+    template <typename Predicate, typename Insert>
+    KOKKOS_INLINE_FUNCTION static int
+    queryDispatch( SpatialPredicateTag,
+                   BoundingVolumeHierarchy<DeviceType> const &bvh,
+                   Predicate const &pred, Insert const &insert )
+    {
+        return spatialQuery( bvh, pred, insert );
+    }
 
-template <typename DeviceType, typename Predicate, typename Insert,
-          typename Buffer>
-KOKKOS_INLINE_FUNCTION int queryDispatch(
-    NearestPredicateTag, BoundingVolumeHierarchy<DeviceType> const &bvh,
-    Predicate const &pred, Insert const &insert, Buffer const &buffer )
-{
-    auto const geometry = pred._geometry;
-    auto const k = pred._k;
-    return nearestQuery( bvh,
-                         [geometry]( Node const *node ) {
-                             return distance( geometry, node->bounding_box );
-                         },
-                         k, insert, buffer );
-}
+    template <typename Predicate, typename Insert, typename Buffer>
+    KOKKOS_INLINE_FUNCTION static int queryDispatch(
+        NearestPredicateTag, BoundingVolumeHierarchy<DeviceType> const &bvh,
+        Predicate const &pred, Insert const &insert, Buffer const &buffer )
+    {
+        auto const geometry = pred._geometry;
+        auto const k = pred._k;
+        return nearestQuery(
+            bvh,
+            [geometry]( typename BoundingVolumeHierarchy<
+                        DeviceType>::bounding_volume_type const &other ) {
+                return distance( geometry, other );
+            },
+            k, insert, buffer );
+    }
+};
 
 } // namespace Details
 } // namespace DataTransferKit

--- a/packages/Search/src/details/DTK_Predicates.hpp
+++ b/packages/Search/src/details/DTK_Predicates.hpp
@@ -57,10 +57,10 @@ struct Intersects
     {
     }
 
-    KOKKOS_INLINE_FUNCTION
-    bool operator()( Node const *node ) const
+    template <typename Other>
+    KOKKOS_INLINE_FUNCTION bool operator()( Other const &other ) const
     {
-        return Details::intersects( _geometry, node->bounding_box );
+        return Details::intersects( _geometry, other );
     }
 
     Geometry _geometry;

--- a/packages/Search/test/tstDetailsTreeConstruction.cpp
+++ b/packages/Search/test/tstDetailsTreeConstruction.cpp
@@ -307,11 +307,15 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DetailsBVH, example_tree_construction,
         }
     };
 
+    Kokkos::View<int *, DeviceType> parents( "parents", 2 * n + 1 );
+    Kokkos::deep_copy( parents, -1 );
+
     dtk::TreeConstruction<DeviceType>::generateHierarchy(
-        sorted_morton_codes, leaf_nodes, internal_nodes );
+        sorted_morton_codes, leaf_nodes, internal_nodes, parents );
+
+    TEST_EQUALITY( parents( 0 ), -1 );
 
     DataTransferKit::Node *root = internal_nodes.data();
-    TEST_ASSERT( root->parent == nullptr );
 
     std::ostringstream sol;
     traverseRecursive( root, sol );

--- a/packages/Search/test/tstLinearBVH.cpp
+++ b/packages/Search/test/tstLinearBVH.cpp
@@ -339,12 +339,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( LinearBVH, miscellaneous, DeviceType )
     } );
     auto const empty_bvh = makeBvh<DeviceType>( {} );
 
-    TEST_ASSERT(
-        DataTransferKit::Details::TreeTraversal<DeviceType>::getRoot( bvh ) );
-    // getRoot() returns nullptr when the tree is empty
-    TEST_ASSERT( !DataTransferKit::Details::TreeTraversal<DeviceType>::getRoot(
-        empty_bvh ) );
-
     // Batched queries BVH::query( Kokkos::View<Query *, ...>, ... ) returns
     // early if the tree is empty.  Below we ensure that a direct call to the
     // single query TreeTraversal::query() actually handles empty trees


### PR DESCRIPTION
* Moved bounding volume hierarchy introspection functions (such as `getRoot()`, `isLeaf()`, etc.) out of `TreeTraversal` and turned them into private members of `BoundingVolumeHierarchy` to avoid having too many places taking advantage of the knowledge of the underlying data structure.  `CalculateInternalNodesBoundingVolumesFunctor` and `initializeLeafNodes()` in `TreeConstruction` headers are the last offenders (direct access to the node `bounding_box` data member).
* Appended leaf to internal nodes to form a single array.  If *n* denotes the number of primitives passed to the `BoundingVolumeHierarchy` constructor, then *{0, ..., n-1}* are internal nodes and *{n, ..., 2n-1}* are leaves (unless *n* was zero in which case the array is empty).
* Got rid of the pointer to the parent node.  It was unnecessary since all tree traversals in `BoundingVolumeHierarchy::query()` are top-down.  Instead, temporarily store parent information when calling `generateHierarchy()` and pass it to `calculateInternalNodesBoundingVolumes()` but let it get out of scope after construction.