### PR TITLE
Update README for building on CADES SHPC Condo

### DIFF
--- a/scripts/README_CADES.md
+++ b/scripts/README_CADES.md
@@ -7,7 +7,7 @@ From the available modules, below are the ones that need to be loaded:
 ```bash
 module load git cmake
 module load PE-gnu/2.0
-module load cuda/8.0
+module load cuda/9.2
 module load boost
 module load ATLAS
 ```

--- a/scripts/README_CADES.md
+++ b/scripts/README_CADES.md
@@ -30,7 +30,7 @@ make -j4
 ```
 
 ## Execute a job on your SHPC Condo allocation to run the tests/examples
-Please refer to the [CADES user guide](http://support.cades.ornl.gov/user-documentation/_book/condos/condo-mpi-hello-world.html)
+Please refer to the [CADES user guide](http://support.cades.ornl.gov/user-documentation/_book/condos/how-to-use/execute-a-job.html)
 for more details on how to create a portable batch system (PBS) script and execute a job on SHPC Condo.
 Below is how you may start an interactive session on a node that has GPUs:
 ```bash

--- a/scripts/README_CADES.md
+++ b/scripts/README_CADES.md
@@ -6,7 +6,7 @@ The CADES SHPC Condo user guide in available [here](http://support.cades.ornl.go
 From the available modules, below are the ones that need to be loaded:
 ```bash
 module load git cmake
-module load PE-gnu
+module load PE-gnu/2.0
 module load cuda/8.0
 module load boost
 module load ATLAS

--- a/scripts/cades_shpc_condo_cmake
+++ b/scripts/cades_shpc_condo_cmake
@@ -6,7 +6,7 @@ rm -f  CMakeCache.txt
 rm -rf CMakeFiles/
 EXTRA_ARGS=("$@")
 ARGS=(
-    -D CMAKE_BUILD_TYPE=Debug
+    -D CMAKE_BUILD_TYPE=Release
     -D BUILD_SHARED_LIBS=ON
     ### COMPILERS AND FLAGS ###
     -D CMAKE_CXX_FLAGS="-g -lineinfo \

--- a/scripts/cades_shpc_condo_cmake
+++ b/scripts/cades_shpc_condo_cmake
@@ -9,13 +9,14 @@ ARGS=(
     -D CMAKE_BUILD_TYPE=Debug
     -D BUILD_SHARED_LIBS=ON
     ### COMPILERS AND FLAGS ###
-    -D CMAKE_CXX_FLAGS="-g -arch=sm_60 -lineinfo \
+    -D CMAKE_CXX_FLAGS="-g -lineinfo \
         -Xcudafe --diag_suppress=conversion_function_not_usable \
         -Xcudafe --diag_suppress=cc_clobber_ignored \
         -Xcudafe --diag_suppress=code_is_unreachable"
     -D DataTransferKit_CXX_FLAGS="-Wall -Wno-shadow -Wpedantic"
     -D Trilinos_CXX11_FLAGS="-std=c++11 --expt-extended-lambda"
     -D Trilinos_TPL_SYSTEM_INCLUDE_DIRS=ON
+    -D KOKKOS_ARCH="BDW;Pascal60"
     ### TPLs ###
     -D TPL_ENABLE_MPI=ON
     -D TPL_ENABLE_BLAS=ON

--- a/scripts/cades_shpc_condo_cmake
+++ b/scripts/cades_shpc_condo_cmake
@@ -23,11 +23,11 @@ ARGS=(
         -D BLAS_LIBRARY_DIRS="${ATLAS_DIR}/lib;${GCC_LIB}"
         -D BLAS_LIBRARY_NAMES="f77blas;cblas;atlas;gfortran"
     -D TPL_ENABLE_LAPACK=ON
-        -D LAPACK_LIBRARY_DIRS=${ATLAS_DIR}/lib
+        -D LAPACK_LIBRARY_DIRS="${ATLAS_DIR}/lib"
         -D LAPACK_LIBRARY_NAMES="lapack"
     -D TPL_ENABLE_Boost=ON
-        -D Boost_INCLUDE_DIRS=${BOOST_DIR}/include
-        -D Boost_LIBRARY_DIRS=${BOOST_DIR}/lib
+        -D Boost_INCLUDE_DIRS="${BOOST_DIR}/include"
+        -D Boost_LIBRARY_DIRS="${BOOST_DIR}/lib"
     -D TPL_ENABLE_CUDA=ON
     ### ETI ###
     -D Trilinos_ENABLE_EXPLICIT_INSTANTIATION=ON

--- a/scripts/cades_shpc_condo_cmake
+++ b/scripts/cades_shpc_condo_cmake
@@ -56,4 +56,4 @@ ARGS=(
         -D DataTransferKit_ENABLE_TESTS=ON
         -D DataTransferKit_ENABLE_EXAMPLES=ON
     )
-cmake "${ARGS[@]}" "${EXTRA_ARGS[@]}" $TRILINOS_DIR
+cmake "${ARGS[@]}" "${EXTRA_ARGS[@]}" "${TRILINOS_DIR}"

--- a/scripts/cades_shpc_condo_cmake
+++ b/scripts/cades_shpc_condo_cmake
@@ -29,6 +29,7 @@ ARGS=(
         -D Boost_INCLUDE_DIRS="${BOOST_DIR}/include"
         -D Boost_LIBRARY_DIRS="${BOOST_DIR}/lib"
     -D TPL_ENABLE_CUDA=ON
+    -D CMAKE_PREFIX_PATH="${HOME}/opt/local/benchmark"
     ### ETI ###
     -D Trilinos_ENABLE_EXPLICIT_INSTANTIATION=ON
     ### PACKAGES CONFIGURATION ###


### PR DESCRIPTION
Main change is using `KOKKOS_ARCH` instead of adding `-arch` flag

`CMAKE_PREFIX_PATH` is in my home directory but it shouldn't prevent anyone else to configure.
You should be able to point to it if you don;'t want to install Benchmark on your own.