### PR TITLE
Fix for AddressSanitizer reports

### DIFF
--- a/scripts/docker_clang60_env.sh
+++ b/scripts/docker_clang60_env.sh
@@ -15,7 +15,7 @@ if [ "$SANITIZER" == "undefined_sanitizer" ]
   # Set the ASAN_SYMBOLIZER_PATH environment variable to point to the
   # llvm-symbolizer to make AddressSanitizer symbolize its output.  This makes
   # the reports more human-readable.
-  export ASAN_SYMBOLIZER_PATH=/usr/lib/llvm-5.0/bin/llvm-symbolizer
+  export ASAN_SYMBOLIZER_PATH=/usr/lib/llvm-6.0/bin/llvm-symbolizer
 elif [ "$SANITIZER" == "thread_sanitizer" ]
   then FLAGS="-fsanitize=thread"
 fi


### PR DESCRIPTION
Had forgotten to update the `ASAN_SYMBOLIZER_PATH` environment variable that points to the llvm-symbolizer binary in e3121ba