### PR TITLE
Do not let Jenkins build fail if performance benchmark regression fails

### DIFF
--- a/docker/jenkins/build.sh
+++ b/docker/jenkins/build.sh
@@ -54,5 +54,6 @@ fi
 if [ "${BUILD_TYPE}" == "gcc54-cuda8" ]
 then
   ./DataTransferKit/packages/Search/examples/bvh_driver/DataTransferKit_bvh.exe --benchmark_out=test.json --values=1000000 --queries=100000 --benchmark_repetitions=5 --benchmark_report_aggregates_only=true
-  python ../scripts/compare.py -c $GIT_COMMIT -b $BUILD_NUMBER -r ../scripts/ref_gcc54_cuda8.json -n test.json -o ../performance_history.csv
+  # FIXME Making exit code be zero regardless of the outcome of the performance benchmarking comparison.
+  python ../scripts/compare.py -c $GIT_COMMIT -b $BUILD_NUMBER -r ../scripts/ref_gcc54_cuda8.json -n test.json -o ../performance_history.csv || true
 fi


### PR DESCRIPTION
The logging will still happen.  We will need to revisit our performance benchmarking but this way we won't be "randomly" prevented to merge...
Just being pragmatic, this is just not working at the moment.