### PR TITLE
Cleanup distributed search tree

### DIFF
--- a/packages/Search/src/DTK_DistributedSearchTree_decl.hpp
+++ b/packages/Search/src/DTK_DistributedSearchTree_decl.hpp
@@ -12,14 +12,14 @@
 #ifndef DTK_DISTRIBUTED_SEARCH_TREE_DECL_HPP
 #define DTK_DISTRIBUTED_SEARCH_TREE_DECL_HPP
 
-#include <Kokkos_View.hpp>
+#include <DTK_DBC.hpp>
+#include <DTK_DetailsDistributedSearchTreeImpl.hpp>
+#include <DTK_LinearBVH.hpp>
 
 #include <Teuchos_Comm.hpp>
 #include <Teuchos_RCP.hpp>
 
-#include <DTK_DBC.hpp>
-#include <DTK_DetailsDistributedSearchTreeImpl.hpp>
-#include <DTK_LinearBVH.hpp>
+#include <Kokkos_View.hpp>
 
 namespace DataTransferKit
 {

--- a/packages/Search/src/DTK_DistributedSearchTree_decl.hpp
+++ b/packages/Search/src/DTK_DistributedSearchTree_decl.hpp
@@ -90,7 +90,7 @@ class DistributedSearchTree
     {
         using Tag = typename Query::Tag;
         Details::DistributedSearchTreeImpl<DeviceType>::queryDispatch(
-            *this, queries, indices, offset, ranks, Tag{} );
+            Tag{}, *this, queries, indices, offset, ranks );
     }
 
     template <typename Query>
@@ -105,7 +105,7 @@ class DistributedSearchTree
     {
         using Tag = typename Query::Tag;
         Details::DistributedSearchTreeImpl<DeviceType>::queryDispatch(
-            *this, queries, indices, offset, ranks, Tag{}, &distances );
+            Tag{}, *this, queries, indices, offset, ranks, &distances );
     }
 
   private:

--- a/packages/Search/src/DTK_DistributedSearchTree_decl.hpp
+++ b/packages/Search/src/DTK_DistributedSearchTree_decl.hpp
@@ -46,15 +46,15 @@ class DistributedSearchTree
     /** Returns the smallest axis-aligned box able to contain all the objects
      *  stored in the tree or an invalid box if the tree is empty.
      */
-    inline bounding_volume_type bounds() const { return _top_tree.bounds(); }
+    bounding_volume_type bounds() const { return _top_tree.bounds(); }
 
     /** Returns the global number of objects stored in the tree.
      */
-    inline size_type size() const { return _top_tree_size; }
+    size_type size() const { return _top_tree_size; }
 
     /** Indicates whether the tree is empty on all processes.
      */
-    inline bool empty() const { return size() == 0; }
+    bool empty() const { return size() == 0; }
 
     /** \brief Finds object satisfying the passed predicates (e.g. nearest to
      *  some point or overlaping with some box)

--- a/packages/Search/src/DTK_DistributedSearchTree_decl.hpp
+++ b/packages/Search/src/DTK_DistributedSearchTree_decl.hpp
@@ -21,8 +21,6 @@
 #include <DTK_DetailsDistributedSearchTreeImpl.hpp>
 #include <DTK_LinearBVH.hpp>
 
-#include "DTK_ConfigDefs.hpp"
-
 namespace DataTransferKit
 {
 

--- a/packages/Search/src/DTK_DistributedSearchTree_decl.hpp
+++ b/packages/Search/src/DTK_DistributedSearchTree_decl.hpp
@@ -75,12 +75,15 @@ class DistributedSearchTree
      *  \note The views \c indices, \c offset, and \c ranks are passed by
      *  reference because \c Kokkos::realloc() calls the assignment operator.
      *
-     *  \param[in] queries Collection of predicates of the same type.  These
+     *  \param[in] predicates Collection of predicates of the same type.  These
      *  may be spatial predicates or nearest predicates.
-     *  \param[out] indices Object local indices that satisfy the predicates.
-     *  \param[out] offset Array of predicate offsets for one-dimensional
-     *  storage.
-     *  \param[out] ranks Process ranks that own objects.
+     *  \param[out] args
+     *     - \c indices Object local indices that satisfy the predicates.
+     *     - \c offset Array of predicate offsets for one-dimensional
+     *       storage.
+     *     - \c ranks Process ranks that own objects.
+     *     - \c distances Computed distances (optional and only for nearest
+     *       predicates).
      */
     template <typename Predicates, typename... Args>
     void query( Predicates const &predicates, Args &&... args ) const

--- a/packages/Search/src/DTK_DistributedSearchTree_decl.hpp
+++ b/packages/Search/src/DTK_DistributedSearchTree_decl.hpp
@@ -82,30 +82,14 @@ class DistributedSearchTree
      *  storage.
      *  \param[out] ranks Process ranks that own objects.
      */
-    template <typename Query>
-    inline void query( Kokkos::View<Query *, DeviceType> queries,
-                       Kokkos::View<int *, DeviceType> &indices,
-                       Kokkos::View<int *, DeviceType> &offset,
-                       Kokkos::View<int *, DeviceType> &ranks ) const
+    template <typename Predicates, typename... Args>
+    void query( Predicates const &predicates, Args &&... args ) const
     {
-        using Tag = typename Query::Tag;
+        // FIXME lame placeholder for concept check
+        static_assert( Kokkos::is_view<Predicates>::value, "must pass a view" );
+        using Tag = typename Predicates::value_type::Tag;
         Details::DistributedSearchTreeImpl<DeviceType>::queryDispatch(
-            Tag{}, *this, queries, indices, offset, ranks );
-    }
-
-    template <typename Query>
-    inline typename std::enable_if<
-        std::is_same<typename Query::Tag, Details::NearestPredicateTag>::value,
-        void>::type
-    query( Kokkos::View<Query *, DeviceType> queries,
-           Kokkos::View<int *, DeviceType> &indices,
-           Kokkos::View<int *, DeviceType> &offset,
-           Kokkos::View<int *, DeviceType> &ranks,
-           Kokkos::View<double *, DeviceType> &distances ) const
-    {
-        using Tag = typename Query::Tag;
-        Details::DistributedSearchTreeImpl<DeviceType>::queryDispatch(
-            Tag{}, *this, queries, indices, offset, ranks, &distances );
+            Tag{}, *this, predicates, std::forward<Args>( args )... );
     }
 
   private:

--- a/packages/Search/src/DTK_DistributedSearchTree_def.hpp
+++ b/packages/Search/src/DTK_DistributedSearchTree_def.hpp
@@ -12,55 +12,10 @@
 #ifndef DTK_DISTRIBUTED_SEARCH_TREE_DEF_HPP
 #define DTK_DISTRIBUTED_SEARCH_TREE_DEF_HPP
 
-#include <DTK_Box.hpp>
-#include <DTK_DetailsUtils.hpp> // accumulate
-
-#include <Teuchos_Array.hpp>
-#include <Teuchos_CommHelpers.hpp>
-
 namespace DataTransferKit
 {
 
-template <typename DeviceType>
-DistributedSearchTree<DeviceType>::DistributedSearchTree(
-    Teuchos::RCP<Teuchos::Comm<int> const> comm,
-    Kokkos::View<Box const *, DeviceType> bounding_boxes )
-    : _comm( comm )
-    , _bottom_tree( bounding_boxes )
-{
-    int const comm_rank = _comm->getRank();
-    int const comm_size = _comm->getSize();
-
-    Kokkos::View<Box *, DeviceType> boxes(
-        Kokkos::ViewAllocateWithoutInitializing( "rank_bounding_boxes" ),
-        comm_size );
-    // FIXME: I am not sure how to do the MPI allgather with Teuchos for data
-    // living on the device so I copied to the host.
-    auto boxes_host = Kokkos::create_mirror_view( boxes );
-    boxes_host( comm_rank ) = _bottom_tree.bounds();
-
-    Teuchos::Array<double> bounds( 6 * comm_size );
-    Teuchos::gatherAll( *_comm, 6,
-                        reinterpret_cast<double *>( &boxes_host( comm_rank ) ),
-                        6 * comm_size, bounds.getRawPtr() );
-    for ( int i = 0; i < comm_size; ++i )
-        boxes_host( i ) = reinterpret_cast<Box const &>( bounds[6 * i] );
-    Kokkos::deep_copy( boxes, boxes_host );
-
-    _top_tree = BVH<DeviceType>( boxes );
-
-    _bottom_tree_sizes = Kokkos::View<size_type *, DeviceType>(
-        Kokkos::ViewAllocateWithoutInitializing( "leave_count_in_local_trees" ),
-        comm_size );
-    auto bottom_tree_sizes_host =
-        Kokkos::create_mirror_view( _bottom_tree_sizes );
-    auto const bottom_tree_size = _bottom_tree.size();
-    Teuchos::gatherAll( *comm, 1, &bottom_tree_size, comm_size,
-                        bottom_tree_sizes_host.data() );
-    Kokkos::deep_copy( _bottom_tree_sizes, bottom_tree_sizes_host );
-
-    _top_tree_size = accumulate( _bottom_tree_sizes, 0 );
-}
+// FIXME nothing here...
 
 } // namespace DataTransferKit
 

--- a/packages/Search/src/DTK_LinearBVH_decl.hpp
+++ b/packages/Search/src/DTK_LinearBVH_decl.hpp
@@ -53,7 +53,7 @@ class BoundingVolumeHierarchy
     }
 
     template <typename Predicates, typename... Args>
-    inline void query( Predicates const &predicates, Args &&... args ) const
+    void query( Predicates const &predicates, Args &&... args ) const
     {
         // FIXME lame placeholder for concept check
         static_assert( Kokkos::is_view<Predicates>::value, "must pass a view" );

--- a/packages/Search/src/details/DTK_DetailsBoundingVolumeHierarchyImpl.hpp
+++ b/packages/Search/src/details/DTK_DetailsBoundingVolumeHierarchyImpl.hpp
@@ -35,6 +35,14 @@ struct BoundingVolumeHierarchyImpl
     // Views are passed by reference here because internally Kokkos::realloc()
     // is called.
     template <typename Query>
+    static void queryDispatch( Details::SpatialPredicateTag,
+                               BoundingVolumeHierarchy<DeviceType> const bvh,
+                               Kokkos::View<Query *, DeviceType> queries,
+                               Kokkos::View<int *, DeviceType> &indices,
+                               Kokkos::View<int *, DeviceType> &offset,
+                               int buffer_size = 0 );
+
+    template <typename Query>
     static void queryDispatch(
         Details::NearestPredicateTag,
         BoundingVolumeHierarchy<DeviceType> const bvh,
@@ -44,20 +52,15 @@ struct BoundingVolumeHierarchyImpl
         Kokkos::View<double *, DeviceType> *distances_ptr = nullptr );
 
     template <typename Query>
-    static void queryDispatch( Details::SpatialPredicateTag,
-                               BoundingVolumeHierarchy<DeviceType> const bvh,
-                               Kokkos::View<Query *, DeviceType> queries,
-                               Kokkos::View<int *, DeviceType> &indices,
-                               Kokkos::View<int *, DeviceType> &offset,
-                               int buffer_size = 0 );
-
-    template <typename Query>
     static void queryDispatch( Details::NearestPredicateTag tag,
                                BoundingVolumeHierarchy<DeviceType> const bvh,
                                Kokkos::View<Query *, DeviceType> queries,
                                Kokkos::View<int *, DeviceType> &indices,
                                Kokkos::View<int *, DeviceType> &offset,
-                               Kokkos::View<double *, DeviceType> &distances );
+                               Kokkos::View<double *, DeviceType> &distances )
+    {
+        queryDispatch( tag, bvh, queries, indices, offset, &distances );
+    }
 };
 
 template <typename DeviceType>
@@ -372,19 +375,6 @@ void BoundingVolumeHierarchyImpl<DeviceType>::queryDispatch(
         Kokkos::fence();
         indices = tmp_indices;
     }
-}
-
-template <typename DeviceType>
-template <typename Query>
-void BoundingVolumeHierarchyImpl<DeviceType>::queryDispatch(
-    Details::NearestPredicateTag tag,
-    BoundingVolumeHierarchy<DeviceType> const bvh,
-    Kokkos::View<Query *, DeviceType> queries,
-    Kokkos::View<int *, DeviceType> &indices,
-    Kokkos::View<int *, DeviceType> &offset,
-    Kokkos::View<double *, DeviceType> &distances )
-{
-    queryDispatch( tag, bvh, queries, indices, offset, &distances );
 }
 
 } // namespace Details

--- a/packages/Search/src/details/DTK_DetailsDistributedSearchTreeImpl.hpp
+++ b/packages/Search/src/details/DTK_DetailsDistributedSearchTreeImpl.hpp
@@ -58,6 +58,18 @@ struct DistributedSearchTreeImpl
         Kokkos::View<double *, DeviceType> *distances_ptr = nullptr );
 
     template <typename Query>
+    static void queryDispatch( Details::NearestPredicateTag tag,
+                               DistributedSearchTree<DeviceType> const &tree,
+                               Kokkos::View<Query *, DeviceType> queries,
+                               Kokkos::View<int *, DeviceType> &indices,
+                               Kokkos::View<int *, DeviceType> &offset,
+                               Kokkos::View<int *, DeviceType> &ranks,
+                               Kokkos::View<double *, DeviceType> &distances )
+    {
+        queryDispatch( tag, tree, queries, indices, offset, ranks, &distances );
+    }
+
+    template <typename Query>
     static void deviseStrategy( Kokkos::View<Query *, DeviceType> queries,
                                 DistributedSearchTree<DeviceType> const &tree,
                                 Kokkos::View<int *, DeviceType> &indices,

--- a/packages/Search/src/details/DTK_DetailsDistributedSearchTreeImpl.hpp
+++ b/packages/Search/src/details/DTK_DetailsDistributedSearchTreeImpl.hpp
@@ -39,21 +39,22 @@ struct DistributedSearchTreeImpl
 
     // spatial queries
     template <typename Query>
-    static void queryDispatch( DistributedSearchTree<DeviceType> const &tree,
+    static void queryDispatch( Details::SpatialPredicateTag,
+                               DistributedSearchTree<DeviceType> const &tree,
                                Kokkos::View<Query *, DeviceType> queries,
                                Kokkos::View<int *, DeviceType> &indices,
                                Kokkos::View<int *, DeviceType> &offset,
-                               Kokkos::View<int *, DeviceType> &ranks,
-                               Details::SpatialPredicateTag );
+                               Kokkos::View<int *, DeviceType> &ranks );
 
     // nearest neighbors queries
     template <typename Query>
     static void queryDispatch(
+        Details::NearestPredicateTag,
         DistributedSearchTree<DeviceType> const &tree,
         Kokkos::View<Query *, DeviceType> queries,
         Kokkos::View<int *, DeviceType> &indices,
         Kokkos::View<int *, DeviceType> &offset,
-        Kokkos::View<int *, DeviceType> &ranks, Details::NearestPredicateTag,
+        Kokkos::View<int *, DeviceType> &ranks,
         Kokkos::View<double *, DeviceType> *distances_ptr = nullptr );
 
     template <typename Query>
@@ -302,11 +303,11 @@ void DistributedSearchTreeImpl<DeviceType>::reassessStrategy(
 template <typename DeviceType>
 template <typename Query>
 void DistributedSearchTreeImpl<DeviceType>::queryDispatch(
-    DistributedSearchTree<DeviceType> const &tree,
+    Details::NearestPredicateTag, DistributedSearchTree<DeviceType> const &tree,
     Kokkos::View<Query *, DeviceType> queries,
     Kokkos::View<int *, DeviceType> &indices,
     Kokkos::View<int *, DeviceType> &offset,
-    Kokkos::View<int *, DeviceType> &ranks, Details::NearestPredicateTag,
+    Kokkos::View<int *, DeviceType> &ranks,
     Kokkos::View<double *, DeviceType> *distances_ptr )
 {
     auto const &bottom_tree = tree._bottom_tree;
@@ -376,11 +377,11 @@ void DistributedSearchTreeImpl<DeviceType>::queryDispatch(
 template <typename DeviceType>
 template <typename Query>
 void DistributedSearchTreeImpl<DeviceType>::queryDispatch(
-    DistributedSearchTree<DeviceType> const &tree,
+    Details::SpatialPredicateTag, DistributedSearchTree<DeviceType> const &tree,
     Kokkos::View<Query *, DeviceType> queries,
     Kokkos::View<int *, DeviceType> &indices,
     Kokkos::View<int *, DeviceType> &offset,
-    Kokkos::View<int *, DeviceType> &ranks, Details::SpatialPredicateTag )
+    Kokkos::View<int *, DeviceType> &ranks )
 {
     auto const &top_tree = tree._top_tree;
     auto const &bottom_tree = tree._bottom_tree;


### PR DESCRIPTION
Following up on #467 for more consistency between regular and distributed trees.
A necessary step to enable building a distributed tree from a point cloud whenever #508 will be merged.