### PR TITLE
Revisit logic to get the polynomial basis size at compile time

### DIFF
--- a/packages/Meshfree/src/DTK_DetailsMovingLeastSquaresOperatorImpl.hpp
+++ b/packages/Meshfree/src/DTK_DetailsMovingLeastSquaresOperatorImpl.hpp
@@ -179,7 +179,7 @@ struct MovingLeastSquaresOperatorImpl
                         PolynomialBasis const &polynomial_basis )
     {
         auto const n_points = points.extent( 0 );
-        auto constexpr size_polynomial_basis = PolynomialBasis::size();
+        auto constexpr size_polynomial_basis = PolynomialBasis::size;
         Kokkos::View<double *, DeviceType> p(
             "vandermonde", n_points * size_polynomial_basis );
         Kokkos::parallel_for(

--- a/packages/Meshfree/src/DTK_MovingLeastSquaresOperator_def.hpp
+++ b/packages/Meshfree/src/DTK_MovingLeastSquaresOperator_def.hpp
@@ -49,7 +49,7 @@ MovingLeastSquaresOperator<DeviceType, CompactlySupportedRadialBasisFunction,
     // target.
     auto queries =
         Details::MovingLeastSquaresOperatorImpl<DeviceType>::makeKNNQueries(
-            target_points, PolynomialBasis::size() );
+            target_points, PolynomialBasis::size );
 
     // Perform the actual search.
     search_tree.query( queries, _indices, _offset, _ranks );
@@ -94,7 +94,7 @@ MovingLeastSquaresOperator<DeviceType, CompactlySupportedRadialBasisFunction,
     // MxM (U*E^+*V) as it will later be just used to do MxV. We could instead
     // return the (U,E^+,V) and do the MxV multiplication. But for now, it's OK.
     auto t = Details::MovingLeastSquaresOperatorImpl<DeviceType>::invertMoments(
-        a, PolynomialBasis::size() );
+        a, PolynomialBasis::size );
     auto inv_a = std::get<0>( t );
 
     // std::get<1>(t) returns the number of undetermined system. However, this
@@ -108,7 +108,7 @@ MovingLeastSquaresOperator<DeviceType, CompactlySupportedRadialBasisFunction,
     // going to be [1, 0, 0, ..., 0]^T.
     _coeffs = Details::MovingLeastSquaresOperatorImpl<
         DeviceType>::computePolynomialCoefficients( _offset, inv_a, p, phi,
-                                                    PolynomialBasis::size() );
+                                                    PolynomialBasis::size );
 }
 
 template <typename DeviceType, typename CompactlySupportedRadialBasisFunction,

--- a/packages/Meshfree/src/DTK_MultivariatePolynomialBasis.hpp
+++ b/packages/Meshfree/src/DTK_MultivariatePolynomialBasis.hpp
@@ -86,6 +86,11 @@ struct MultivariatePolynomialBasis
     operator()( Point const &p ) const;
 };
 
+// Definition below is required (until C++17) to avoid link-time errors
+// c.f. https://en.cppreference.com/w/cpp/language/definition#ODR-use
+template <typename Basis, int DIM>
+int constexpr MultivariatePolynomialBasis<Basis, DIM>::size;
+
 // NOTE: For now relying on Point::operator[]( int i ) to access the coordinates
 // which make it possible to use various types such as DTK::Point or
 // Kokkos::Array<double, DIM>

--- a/packages/Meshfree/src/DTK_MultivariatePolynomialBasis.hpp
+++ b/packages/Meshfree/src/DTK_MultivariatePolynomialBasis.hpp
@@ -40,39 +40,38 @@ namespace Details
 {
 
 template <typename Basis, int DIM>
-struct Traits
+struct Size
 {
-    static KOKKOS_INLINE_FUNCTION int constexpr size();
 };
 
 template <int DIM>
-struct Traits<Constant, DIM>
+struct Size<Constant, DIM>
 {
-    static KOKKOS_INLINE_FUNCTION int constexpr size() { return 1; }
+    static int constexpr value = 1;
 };
 
 template <>
-struct Traits<Linear, 3>
+struct Size<Linear, 3>
 {
-    static KOKKOS_INLINE_FUNCTION int constexpr size() { return 4; }
+    static int constexpr value = 4;
 };
 
 template <>
-struct Traits<Quadratic, 3>
+struct Size<Quadratic, 3>
 {
-    static KOKKOS_INLINE_FUNCTION int constexpr size() { return 10; }
+    static int constexpr value = 10;
 };
 
 template <>
-struct Traits<Linear, 2>
+struct Size<Linear, 2>
 {
-    static KOKKOS_INLINE_FUNCTION int constexpr size() { return 3; }
+    static int constexpr value = 3;
 };
 
 template <>
-struct Traits<Quadratic, 2>
+struct Size<Quadratic, 2>
 {
-    static KOKKOS_INLINE_FUNCTION int constexpr size() { return 6; }
+    static int constexpr value = 6;
 };
 
 } // namespace Details
@@ -80,12 +79,10 @@ struct Traits<Quadratic, 2>
 template <typename Basis, int DIM>
 struct MultivariatePolynomialBasis
 {
-    static KOKKOS_INLINE_FUNCTION int constexpr size()
-    {
-        return Details::Traits<Basis, DIM>::size();
-    }
+    static int constexpr size = Details::Size<Basis, DIM>::value;
+
     template <typename Point>
-    KOKKOS_INLINE_FUNCTION Kokkos::Array<double, size()>
+    KOKKOS_INLINE_FUNCTION Kokkos::Array<double, size>
     operator()( Point const &p ) const;
 };
 

--- a/packages/Meshfree/src/DTK_MultivariatePolynomialBasis.hpp
+++ b/packages/Meshfree/src/DTK_MultivariatePolynomialBasis.hpp
@@ -98,7 +98,7 @@ int constexpr MultivariatePolynomialBasis<Basis, DIM>::size;
 template <>
 template <typename Point>
 KOKKOS_INLINE_FUNCTION
-    Kokkos::Array<double, MultivariatePolynomialBasis<Constant, 3>::size()>
+    Kokkos::Array<double, MultivariatePolynomialBasis<Constant, 3>::size>
     MultivariatePolynomialBasis<Constant, 3>::operator()( Point const & ) const
 {
     return {{1.}};
@@ -107,7 +107,7 @@ KOKKOS_INLINE_FUNCTION
 template <>
 template <typename Point>
 KOKKOS_INLINE_FUNCTION
-    Kokkos::Array<double, MultivariatePolynomialBasis<Linear, 3>::size()>
+    Kokkos::Array<double, MultivariatePolynomialBasis<Linear, 3>::size>
     MultivariatePolynomialBasis<Linear, 3>::operator()( Point const &p ) const
 {
     return {{1., p[0], p[1], p[2]}};
@@ -116,7 +116,7 @@ KOKKOS_INLINE_FUNCTION
 template <>
 template <typename Point>
 KOKKOS_INLINE_FUNCTION
-    Kokkos::Array<double, MultivariatePolynomialBasis<Quadratic, 3>::size()>
+    Kokkos::Array<double, MultivariatePolynomialBasis<Quadratic, 3>::size>
     MultivariatePolynomialBasis<Quadratic, 3>::
     operator()( Point const &p ) const
 {
@@ -127,7 +127,7 @@ KOKKOS_INLINE_FUNCTION
 template <>
 template <typename Point>
 KOKKOS_INLINE_FUNCTION
-    Kokkos::Array<double, MultivariatePolynomialBasis<Constant, 2>::size()>
+    Kokkos::Array<double, MultivariatePolynomialBasis<Constant, 2>::size>
     MultivariatePolynomialBasis<Constant, 2>::operator()( Point const & ) const
 {
     return {{1.}};
@@ -136,7 +136,7 @@ KOKKOS_INLINE_FUNCTION
 template <>
 template <typename Point>
 KOKKOS_INLINE_FUNCTION
-    Kokkos::Array<double, MultivariatePolynomialBasis<Linear, 2>::size()>
+    Kokkos::Array<double, MultivariatePolynomialBasis<Linear, 2>::size>
     MultivariatePolynomialBasis<Linear, 2>::operator()( Point const &p ) const
 {
     return {{1., p[0], p[1]}};
@@ -145,7 +145,7 @@ KOKKOS_INLINE_FUNCTION
 template <>
 template <typename Point>
 KOKKOS_INLINE_FUNCTION
-    Kokkos::Array<double, MultivariatePolynomialBasis<Quadratic, 2>::size()>
+    Kokkos::Array<double, MultivariatePolynomialBasis<Quadratic, 2>::size>
     MultivariatePolynomialBasis<Quadratic, 2>::
     operator()( Point const &p ) const
 {

--- a/packages/Meshfree/test/tstMovingLeastSquaresOperator.cpp
+++ b/packages/Meshfree/test/tstMovingLeastSquaresOperator.cpp
@@ -149,8 +149,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( MovingLeastSquaresOperator,
     const int n_target_points = 10;
     const double radius = 1.0;
 
-    const int size_polynomial_basis = PolynomialBasis::size();
-    const int n_source_points_in_radius = size_polynomial_basis;
+    const int n_source_points_in_radius = PolynomialBasis::size;
 
     const int n_source_points = n_target_points * n_source_points_in_radius;
 
@@ -167,7 +166,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( MovingLeastSquaresOperator,
 
     // Arbitrary function of the specified order
     std::function<double( std::array<double, DIM> )> f;
-    switch ( size_polynomial_basis )
+    switch ( PolynomialBasis::size )
     {
     case 1: // constant
         f = []( std::array<double, DIM> ) -> double { return 3.0; };
@@ -235,9 +234,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( MovingLeastSquaresOperator, grid, DeviceType,
     std::vector<double> target_values_ref( n_target_points );
 
     // Arbitrary function of the specified order
-    int const size_polynomial_basis = PolynomialBasis::size();
     std::function<double( std::array<double, DIM> )> f;
-    switch ( size_polynomial_basis )
+    switch ( PolynomialBasis::size )
     {
     case 1: // constant
         f = []( std::array<double, DIM> ) -> double { return 3.0; };
@@ -305,9 +303,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( MovingLeastSquaresOperator, line, DeviceType,
     std::vector<double> target_values_ref( n_target_points );
 
     // Arbitrary function of the specified order
-    int const size_polynomial_basis = PolynomialBasis::size();
     std::function<double( std::array<double, DIM> )> f;
-    switch ( size_polynomial_basis )
+    switch ( PolynomialBasis::size )
     {
     case 1: // constant
         f = []( std::array<double, DIM> ) -> double { return 3.0; };
@@ -362,7 +359,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( MovingLeastSquaresOperator,
     const int n_target_points = 10;
     const double radius = 1.0;
 
-    const int size_polynomial_basis = PolynomialBasis::size();
     const int n_source_points_in_radius = 1;
 
     const int n_source_points = n_target_points * n_source_points_in_radius;
@@ -379,7 +375,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( MovingLeastSquaresOperator,
 
     // Arbitrary function of the specified order
     std::function<double( std::array<double, DIM> )> f;
-    switch ( size_polynomial_basis )
+    switch ( PolynomialBasis::size )
     {
     case 1: // constant
         f = []( std::array<double, DIM> ) -> double { return 3.0; };

--- a/packages/Meshfree/test/tstMultivariatePolynomialBasis.cpp
+++ b/packages/Meshfree/test/tstMultivariatePolynomialBasis.cpp
@@ -26,7 +26,7 @@ void checkBasisEvaluation( PolynomialBasis const &b, Point const &x,
 }
 
 // NOTE: The extra pairs of parentheses below around
-// MultivariatePolynomialBasis::size() in TEST_EQUALITY() macro are needed.
+// MultivariatePolynomialBasis::size in TEST_EQUALITY() macro are needed.
 // Without them, the Teuchos unit testing macro yields the folowing error:
 //
 //     error: macro "TEST_EQUALITY" passed 3 arguments, but takes just 2
@@ -41,17 +41,17 @@ TEUCHOS_UNIT_TEST( MultivariatePolynomialBasis, 2D )
     using Point = Kokkos::Array<double, 2>;
 
     // (X, Y) -> [ 1 ]
-    TEST_EQUALITY( ( MultivariatePolynomialBasis<Constant, 2>::size() ), 1 );
+    TEST_EQUALITY( ( MultivariatePolynomialBasis<Constant, 2>::size ), 1 );
     checkBasisEvaluation( MultivariatePolynomialBasis<Constant, 2>(),
                           Point{{0., 0.}}, {1.}, success, out );
 
     // (X, Y) -> [ 1, X, Y ]
-    TEST_EQUALITY( ( MultivariatePolynomialBasis<Linear, 2>::size() ), 3 );
+    TEST_EQUALITY( ( MultivariatePolynomialBasis<Linear, 2>::size ), 3 );
     checkBasisEvaluation( MultivariatePolynomialBasis<Linear, 2>(),
                           Point{{0., 1.}}, {{1., 0., 1.}}, success, out );
 
     // (X, Y) -> [ 1, X, Y, X^2, XY, Y^2 ]
-    TEST_EQUALITY( ( MultivariatePolynomialBasis<Quadratic, 2>::size() ), 6 );
+    TEST_EQUALITY( ( MultivariatePolynomialBasis<Quadratic, 2>::size ), 6 );
     checkBasisEvaluation( MultivariatePolynomialBasis<Quadratic, 2>(),
                           Point{{1., 2.}}, {{1., 1., 2., 1., 2., 4.}}, success,
                           out );
@@ -66,18 +66,18 @@ TEUCHOS_UNIT_TEST( MultivariatePolynomialBasis, 3D )
     using DataTransferKit::Quadratic;
 
     // (X, Y, Z) -> [ 1 ]
-    TEST_EQUALITY( ( MultivariatePolynomialBasis<Constant, 3>::size() ), 1 );
+    TEST_EQUALITY( ( MultivariatePolynomialBasis<Constant, 3>::size ), 1 );
     checkBasisEvaluation( MultivariatePolynomialBasis<Constant, 3>(),
                           Point{{0., 0., 0.}}, {1.}, success, out );
 
     // (X, Y, Z) -> [ 1, X, Y, Z ]
-    TEST_EQUALITY( ( MultivariatePolynomialBasis<Linear, 3>::size() ), 4 );
+    TEST_EQUALITY( ( MultivariatePolynomialBasis<Linear, 3>::size ), 4 );
     checkBasisEvaluation( MultivariatePolynomialBasis<Linear, 3>(),
                           Point{{0., 1., 2.}}, {{1., 0., 1., 2.}}, success,
                           out );
 
     // (X, Y, Z) -> [ 1, X, Y, Z, X^2, XY, XZ, Y^2, YZ, Z^2 ]
-    TEST_EQUALITY( ( MultivariatePolynomialBasis<Quadratic, 3>::size() ), 10 );
+    TEST_EQUALITY( ( MultivariatePolynomialBasis<Quadratic, 3>::size ), 10 );
     checkBasisEvaluation(
         MultivariatePolynomialBasis<Quadratic, 3>(), Point{{0., 1., 2.}},
         {{1., 0., 1., 2., 0., 0., 0., 1., 2., 4.}}, success, out );


### PR DESCRIPTION
Motivation for theses changes was reclaiming the name `Traits` and use it to get access to the data from the `primitives` argument passed to the `BoundingVolumeHierarchy` constructor


