### PR TITLE
Update script to setup Clang in the Docker container

### DIFF
--- a/scripts/docker_clang60_env.sh
+++ b/scripts/docker_clang60_env.sh
@@ -7,15 +7,18 @@ export CXX=mpicxx
 # Add clang OpenMP runtime library to LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 
-# Suppress leak sanitizer on functions we have no control of.
-export LSAN_OPTIONS=suppressions=/scratch/source/trilinos/release/DataTransferKit/scripts/leak_blacklist.txt
+if [ ! -z "$1" ]
+then
+  # Suppress leak sanitizer on functions we have no control of.
+  export LSAN_OPTIONS=suppressions=/scratch/source/trilinos/release/DataTransferKit/scripts/leak_blacklist.txt
 
-# Set the ASAN_SYMBOLIZER_PATH environment variable to point to the
-# llvm-symbolizer to make AddressSanitizer symbolize its output.  This makes
-# the reports more human-readable.
-export ASAN_SYMBOLIZER_PATH=/opt/llvm/6.0/bin/llvm-symbolizer
+  # Set the ASAN_SYMBOLIZER_PATH environment variable to point to the
+  # llvm-symbolizer to make AddressSanitizer symbolize its output.  This makes
+  # the reports more human-readable.
+  export ASAN_SYMBOLIZER_PATH=/opt/llvm/6.0/bin/llvm-symbolizer
 
-# Use SANITIZER_FLAGS to add Wextra flags to avoid increasing the complexity of
-# our script. We don't put Wextra directly in docker_cmake because it would
-# affect every build and the number of warnings is very large.
-export SANITIZER_FLAGS="-Wextra -fsanitize=address -fsanitize=undefined -fsanitize-blacklist=/scratch/source/trilinos/release/DataTransferKit/scripts/undefined_blacklist.txt"
+  # Use SANITIZER_FLAGS to add Wextra flags to avoid increasing the complexity
+  # of our script. We don't put Wextra directly in docker_cmake because it
+  # would affect every build and the number of warnings is very large.
+  export SANITIZER_FLAGS="-Wextra -fsanitize=address -fsanitize=undefined -fsanitize-blacklist=/scratch/source/trilinos/release/DataTransferKit/scripts/undefined_blacklist.txt"
+fi

--- a/scripts/docker_clang60_env.sh
+++ b/scripts/docker_clang60_env.sh
@@ -7,20 +7,15 @@ export CXX=mpicxx
 # Add clang OpenMP runtime library to LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 
-SANITIZER=$1
-if [ "$SANITIZER" == "undefined_sanitizer" ]
-  then FLAGS="-fsanitize=address -fsanitize=undefined -fsanitize-blacklist=/scratch/source/trilinos/release/DataTransferKit/scripts/undefined_blacklist.txt"
-  # Suppress leak sanitizer on functions we have no control of.
-  export LSAN_OPTIONS=suppressions=/scratch/source/trilinos/release/DataTransferKit/scripts/leak_blacklist.txt
-  # Set the ASAN_SYMBOLIZER_PATH environment variable to point to the
-  # llvm-symbolizer to make AddressSanitizer symbolize its output.  This makes
-  # the reports more human-readable.
-  export ASAN_SYMBOLIZER_PATH=/usr/lib/llvm-6.0/bin/llvm-symbolizer
-elif [ "$SANITIZER" == "thread_sanitizer" ]
-  then FLAGS="-fsanitize=thread"
-fi
+# Suppress leak sanitizer on functions we have no control of.
+export LSAN_OPTIONS=suppressions=/scratch/source/trilinos/release/DataTransferKit/scripts/leak_blacklist.txt
+
+# Set the ASAN_SYMBOLIZER_PATH environment variable to point to the
+# llvm-symbolizer to make AddressSanitizer symbolize its output.  This makes
+# the reports more human-readable.
+export ASAN_SYMBOLIZER_PATH=/opt/llvm/6.0/bin/llvm-symbolizer
 
 # Use SANITIZER_FLAGS to add Wextra flags to avoid increasing the complexity of
 # our script. We don't put Wextra directly in docker_cmake because it would
 # affect every build and the number of warnings is very large.
-export SANITIZER_FLAGS="-Wextra $FLAGS"
+export SANITIZER_FLAGS="-Wextra -fsanitize=address -fsanitize=undefined -fsanitize-blacklist=/scratch/source/trilinos/release/DataTransferKit/scripts/undefined_blacklist.txt"


### PR DESCRIPTION
Rational:
* there was no default-clause in the if statement that would determine what sanitizer to use
* the thread sanitizer does not work with OpenMP so the output was total garbage (it produced ~200MB of error when running one of our tests!)

I chose to setup the sanitizer all the time.  Let me know if you think that's problematic.

