### PR TITLE
Fix a bug with gcc-8.2

### DIFF
--- a/packages/Interface/src/DTK_View.hpp
+++ b/packages/Interface/src/DTK_View.hpp
@@ -109,16 +109,8 @@ class View
     KOKKOS_INLINE_FUNCTION
     const Scalar *data() const { return _data; }
 
-    // Access an element in the view.
-    KOKKOS_FORCEINLINE_FUNCTION
-    Scalar &operator[]( const size_t i )
-    {
-        assert( _data );
-        assert( i < _size );
-        return _data[i];
-    }
-
     // Access a const element in the view.
+    // FIXME const-correctness
     KOKKOS_FORCEINLINE_FUNCTION
     Scalar &operator[]( const size_t i ) const
     {


### PR DESCRIPTION
gcc was choosing the wrong overload. So removed a function that is not
needed.

closes #519 