### PR TITLE
Partial fix for warnings coming from Boost during the build

### DIFF
--- a/PackagesList.cmake
+++ b/PackagesList.cmake
@@ -4,7 +4,7 @@
 
 
 SET( DataTransferKit_PACKAGES_AND_DIRS_AND_CLASSIFICATIONS
-  DataTransferKit         .     SS
+  DataTransferKit         .     ST
   )
 
 TRIBITS_DISABLE_PACKAGE_ON_PLATFORMS(DataTransferKit Windows)

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -9,4 +9,8 @@ TRIBITS_PACKAGE_DEFINE_DEPENDENCIES(
   LIB_OPTIONAL_TPLS
     BoostOrg
     Netcdf
+  TEST_OPTIONAL_TPLS
+    # BoostOrg is listed twice to have -isystem added to the include directories for the TPL when compiling the tests.
+    # This is a known limitation of TriBITS (c.f. https://tribits.org/doc/TribitsDevelopersGuide.html#project-name-tpl-system-include-dirs)
+    BoostOrg
   )


### PR DESCRIPTION
I did not manage to understand why all libraries but the one from the `Utils` package compile with `-I <BOOST_DIR>` instead of `-isystem <BOOST_DIR>` but at least now Boost headers are treated as a system headers and do not emit warnings when building tests...
