### PR TITLE
Fix SVD bug

### DIFF
--- a/packages/Meshfree/src/DTK_DetailsMovingLeastSquaresOperatorImpl.hpp
+++ b/packages/Meshfree/src/DTK_DetailsMovingLeastSquaresOperatorImpl.hpp
@@ -249,6 +249,7 @@ struct MovingLeastSquaresOperatorImpl
                    const int size_polynomial_basis )
     {
         Kokkos::View<double *, DeviceType> inv_a( "inv_a", a.extent( 0 ) );
+        Kokkos::View<double *, DeviceType> aux( "aux", 3 * a.extent( 0 ) );
 
         auto num_matrices =
             a.extent( 0 ) / ( size_polynomial_basis * size_polynomial_basis );
@@ -257,7 +258,8 @@ struct MovingLeastSquaresOperatorImpl
         // available in the comments in SVDFunctor.
         const int team_size = 1;
 
-        SVDFunctor<DeviceType> svdFunctor( size_polynomial_basis, a, inv_a );
+        SVDFunctor<DeviceType> svdFunctor( size_polynomial_basis, a, inv_a,
+                                           aux );
         size_t num_underdetermined = 0;
         Kokkos::parallel_reduce(
             DTK_MARK_REGION( "compute_svd_inverse" ),

--- a/packages/Meshfree/src/DTK_DetailsMovingLeastSquaresOperatorImpl.hpp
+++ b/packages/Meshfree/src/DTK_DetailsMovingLeastSquaresOperatorImpl.hpp
@@ -254,16 +254,12 @@ struct MovingLeastSquaresOperatorImpl
         auto num_matrices =
             a.extent( 0 ) / ( size_polynomial_basis * size_polynomial_basis );
 
-        // TODO: right now, we hardcode the team size to 1. More information is
-        // available in the comments in SVDFunctor.
-        const int team_size = 1;
-
         SVDFunctor<DeviceType> svdFunctor( size_polynomial_basis, a, inv_a,
                                            aux );
         size_t num_underdetermined = 0;
         Kokkos::parallel_reduce(
             DTK_MARK_REGION( "compute_svd_inverse" ),
-            Kokkos::TeamPolicy<ExecutionSpace>( num_matrices, team_size ),
+            Kokkos::TeamPolicy<ExecutionSpace>( num_matrices, Kokkos::AUTO() ),
             svdFunctor, num_underdetermined );
 
         return std::make_tuple( inv_a, num_underdetermined );

--- a/packages/Meshfree/src/DTK_DetailsMovingLeastSquaresOperatorImpl.hpp
+++ b/packages/Meshfree/src/DTK_DetailsMovingLeastSquaresOperatorImpl.hpp
@@ -253,6 +253,12 @@ struct MovingLeastSquaresOperatorImpl
         auto num_matrices =
             a.extent( 0 ) / ( size_polynomial_basis * size_polynomial_basis );
 
+        // We request auxiliary space for matrices E, U, and V (thus, 3) that
+        // we need inside SVD. Single level parallelism does not provide access
+        // to scratch space (or, at the least, I don't know how to access it).
+        // So we preallocate it here, and pass to the functor. We use 2D array
+        // as we would like to use 2D matrices inside SVD, and there is no way
+        // to reshape.
         Kokkos::View<double **, DeviceType> aux( "aux", size_polynomial_basis,
                                                  3 * num_matrices *
                                                      size_polynomial_basis );

--- a/packages/Meshfree/src/DTK_DetailsSVDImpl.hpp
+++ b/packages/Meshfree/src/DTK_DetailsSVDImpl.hpp
@@ -38,6 +38,9 @@ struct SVDFunctor
     // We use 1D view of the matrices here to make it as generic as possible.
     // This should allow for a certain flexibility later, like using different
     // sized matrices, or using some batching.
+    // NOTE pass flat::matrix_type and matrix_type by value (or typename
+    // matrix_type::const_type) but pass matrix_2x2_type by reference (or const
+    // &)
     using flat_matrix_type = Kokkos::View<double *, DeviceType>;
     using matrix_type = Kokkos::View<double **, DeviceType>;
     using matrix_2x2_type = Kokkos::Array<Kokkos::Array<double, 2>, 2>;
@@ -81,13 +84,13 @@ struct SVDFunctor
     }
 
     KOKKOS_INLINE_FUNCTION
-    void trans_2x2( const matrix_2x2_type A, matrix_2x2_type &B ) const
+    void trans_2x2( matrix_2x2_type const &A, matrix_2x2_type &B ) const
     {
         B = {{{{A[0][0], A[1][0]}}, {{A[0][1], A[1][1]}}}};
     }
 
     KOKKOS_INLINE_FUNCTION
-    void trans_nxn( const matrix_type A, matrix_type &B ) const
+    void trans_nxn( typename matrix_type::const_type A, matrix_type &B ) const
     {
         auto n = A.extent( 0 );
 
@@ -97,7 +100,7 @@ struct SVDFunctor
     }
 
     KOKKOS_INLINE_FUNCTION
-    void mult_2x2( const matrix_2x2_type A, const matrix_2x2_type B,
+    void mult_2x2( matrix_2x2_type const &A, matrix_2x2_type const &B,
                    matrix_2x2_type &C ) const
     {
         C = {{{{A[0][0] * B[0][0] + A[0][1] * B[1][0],
@@ -107,7 +110,7 @@ struct SVDFunctor
     }
 
     KOKKOS_INLINE_FUNCTION
-    void svd_2x2( const matrix_2x2_type A, matrix_2x2_type &U,
+    void svd_2x2( matrix_2x2_type const &A, matrix_2x2_type &U,
                   matrix_2x2_type &E, matrix_2x2_type &V ) const
     {
         matrix_2x2_type At, AAt, AtA;

--- a/packages/Meshfree/src/DTK_DetailsSVDImpl.hpp
+++ b/packages/Meshfree/src/DTK_DetailsSVDImpl.hpp
@@ -193,30 +193,23 @@ struct SVDFunctor
         // approach is. It could be that instead the matrices should be
         // pre-sorted by size.
         auto A = Kokkos::subview(
-            _As, Kokkos::make_pair(
-                     static_cast<size_t>( matrix_id * _n * _n ),
-                     static_cast<size_t>( ( matrix_id + 1 ) * _n * _n ) ) );
+            _As, Kokkos::make_pair( matrix_id * _n * _n,
+                                    ( matrix_id + 1 ) * _n * _n ) );
         auto pseudoA = Kokkos::subview(
-            _pseudoAs,
-            Kokkos::make_pair(
-                static_cast<size_t>( matrix_id * _n * _n ),
-                static_cast<size_t>( ( matrix_id + 1 ) * _n * _n ) ) );
+            _pseudoAs, Kokkos::make_pair( matrix_id * _n * _n,
+                                          ( matrix_id + 1 ) * _n * _n ) );
 
         auto E = Kokkos::subview(
             _aux, Kokkos::ALL(),
-            Kokkos::make_pair(
-                static_cast<size_t>( 3 * matrix_id * _n ),
-                static_cast<size_t>( 3 * matrix_id * _n + _n ) ) );
-        auto U = Kokkos::subview(
-            _aux, Kokkos::ALL(),
-            Kokkos::make_pair(
-                static_cast<size_t>( 3 * matrix_id * _n + _n ),
-                static_cast<size_t>( 3 * matrix_id * _n + 2 * _n ) ) );
-        auto V = Kokkos::subview(
-            _aux, Kokkos::ALL(),
-            Kokkos::make_pair(
-                static_cast<size_t>( 3 * matrix_id * _n + 2 * _n ),
-                static_cast<size_t>( 3 * matrix_id * _n + 3 * _n ) ) );
+            Kokkos::make_pair( 3 * matrix_id * _n, 3 * matrix_id * _n + _n ) );
+        auto U =
+            Kokkos::subview( _aux, Kokkos::ALL(),
+                             Kokkos::make_pair( 3 * matrix_id * _n + _n,
+                                                3 * matrix_id * _n + 2 * _n ) );
+        auto V =
+            Kokkos::subview( _aux, Kokkos::ALL(),
+                             Kokkos::make_pair( 3 * matrix_id * _n + 2 * _n,
+                                                3 * matrix_id * _n + 3 * _n ) );
 
         for ( int i = 0; i < _n; i++ )
             for ( int j = 0; j < _n; j++ )

--- a/packages/Meshfree/src/DTK_DetailsSVDImpl.hpp
+++ b/packages/Meshfree/src/DTK_DetailsSVDImpl.hpp
@@ -39,14 +39,12 @@ struct SVDFunctor
     // This should allow for a certain flexibility later, like using different
     // sized matrices, or using some batching.
     using flat_matrix_type = Kokkos::View<double *, DeviceType>;
-    using aux_matrix_type = Kokkos::View<double **, DeviceType>;
-    using matrix_type =
-        Kokkos::View<double **, Kokkos::LayoutStride, DeviceType>;
+    using matrix_type = Kokkos::View<double **, DeviceType>;
     using matrix_2x2_type = Kokkos::Array<Kokkos::Array<double, 2>, 2>;
 
   public:
     SVDFunctor( int n, typename flat_matrix_type::const_type As,
-                flat_matrix_type pseudoAs, aux_matrix_type aux )
+                flat_matrix_type pseudoAs, matrix_type aux )
         : _n( n )
         , _As( As )
         , _pseudoAs( pseudoAs )
@@ -307,7 +305,7 @@ struct SVDFunctor
     int _n;
     typename flat_matrix_type::const_type _As;
     flat_matrix_type _pseudoAs;
-    aux_matrix_type _aux;
+    matrix_type _aux;
 };
 
 } // end namespace Details

--- a/packages/Meshfree/test/tstSVD.cpp
+++ b/packages/Meshfree/test/tstSVD.cpp
@@ -71,6 +71,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( SVD, full_rank, DeviceType )
     int const size = n_matrices * matrix_size * matrix_size;
     Kokkos::View<double *, DeviceType> matrices( "matrices", size );
     Kokkos::View<double *, DeviceType> inv_matrices( "inv_matrices", size );
+    Kokkos::View<double *, DeviceType> aux( "aux", 3 * size );
 
     // Fill the matrices
     auto matrices_host = Kokkos::create_mirror_view( matrices );
@@ -81,7 +82,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( SVD, full_rank, DeviceType )
     Kokkos::deep_copy( matrices, matrices_host );
 
     DataTransferKit::Details::SVDFunctor<DeviceType> svd_functor(
-        matrix_size, matrices, inv_matrices );
+        matrix_size, matrices, inv_matrices, aux );
     size_t n_underdetermined = 0;
     using ExecutionSpace = typename DeviceType::execution_space;
     Kokkos::parallel_reduce(
@@ -102,6 +103,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( SVD, rank_deficient, DeviceType )
     int const size = n_matrices * matrix_size * matrix_size;
     Kokkos::View<double *, DeviceType> matrices( "matrices", size );
     Kokkos::View<double *, DeviceType> inv_matrices( "inv_matrices", size );
+    Kokkos::View<double *, DeviceType> aux( "aux", 3 * size );
 
     // Fill the matrices
     auto matrices_host = Kokkos::create_mirror_view( matrices );
@@ -127,7 +129,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( SVD, rank_deficient, DeviceType )
     Kokkos::deep_copy( matrices, matrices_host );
 
     DataTransferKit::Details::SVDFunctor<DeviceType> svd_functor(
-        matrix_size, matrices, inv_matrices );
+        matrix_size, matrices, inv_matrices, aux );
     size_t n_underdetermined = 0;
     using ExecutionSpace = typename DeviceType::execution_space;
     Kokkos::parallel_reduce(

--- a/packages/Meshfree/test/tstSVD.cpp
+++ b/packages/Meshfree/test/tstSVD.cpp
@@ -71,7 +71,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( SVD, full_rank, DeviceType )
     int const size = n_matrices * matrix_size * matrix_size;
     Kokkos::View<double *, DeviceType> matrices( "matrices", size );
     Kokkos::View<double *, DeviceType> inv_matrices( "inv_matrices", size );
-    Kokkos::View<double *, DeviceType> aux( "aux", 3 * size );
+    Kokkos::View<double **, DeviceType> aux( "aux", matrix_size,
+                                             3 * n_matrices * matrix_size );
 
     // Fill the matrices
     auto matrices_host = Kokkos::create_mirror_view( matrices );
@@ -87,7 +88,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( SVD, full_rank, DeviceType )
     using ExecutionSpace = typename DeviceType::execution_space;
     Kokkos::parallel_reduce(
         DTK_MARK_REGION( "compute_svd_inverse" ),
-        Kokkos::TeamPolicy<ExecutionSpace>( n_matrices, 1 ), svd_functor,
+        Kokkos::RangePolicy<ExecutionSpace>( 0, n_matrices ), svd_functor,
         n_underdetermined );
 
     std::set<int> rank_deficiency;
@@ -103,7 +104,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( SVD, rank_deficient, DeviceType )
     int const size = n_matrices * matrix_size * matrix_size;
     Kokkos::View<double *, DeviceType> matrices( "matrices", size );
     Kokkos::View<double *, DeviceType> inv_matrices( "inv_matrices", size );
-    Kokkos::View<double *, DeviceType> aux( "aux", 3 * size );
+    Kokkos::View<double **, DeviceType> aux( "aux", matrix_size,
+                                             3 * n_matrices * matrix_size );
 
     // Fill the matrices
     auto matrices_host = Kokkos::create_mirror_view( matrices );
@@ -134,7 +136,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( SVD, rank_deficient, DeviceType )
     using ExecutionSpace = typename DeviceType::execution_space;
     Kokkos::parallel_reduce(
         DTK_MARK_REGION( "compute_svd_inverse" ),
-        Kokkos::TeamPolicy<ExecutionSpace>( n_matrices, 1 ), svd_functor,
+        Kokkos::RangePolicy<ExecutionSpace>( 0, n_matrices ), svd_functor,
         n_underdetermined );
 
     TEST_EQUALITY( n_underdetermined, n_matrices );

--- a/packages/Meshfree/test/tstSVD.cpp
+++ b/packages/Meshfree/test/tstSVD.cpp
@@ -71,6 +71,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( SVD, full_rank, DeviceType )
     int const size = n_matrices * matrix_size * matrix_size;
     Kokkos::View<double *, DeviceType> matrices( "matrices", size );
     Kokkos::View<double *, DeviceType> inv_matrices( "inv_matrices", size );
+    // For magic number 3, see comment in
+    // DTK_DetailsMovingLeastSquaresOperatorImpl.hpp
     Kokkos::View<double **, DeviceType> aux( "aux", matrix_size,
                                              3 * n_matrices * matrix_size );
 
@@ -104,6 +106,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( SVD, rank_deficient, DeviceType )
     int const size = n_matrices * matrix_size * matrix_size;
     Kokkos::View<double *, DeviceType> matrices( "matrices", size );
     Kokkos::View<double *, DeviceType> inv_matrices( "inv_matrices", size );
+    // For magic number 3, see comment in
+    // DTK_DetailsMovingLeastSquaresOperatorImpl.hpp
     Kokkos::View<double **, DeviceType> aux( "aux", matrix_size,
                                              3 * n_matrices * matrix_size );
 


### PR DESCRIPTION
Closes #502 

The original problem with running SVD on GPUs was too much memory used by a single thread, and thus by a thread team. This commit works around the problem by requiring an extra temporary view to work with. I played around with using `scratch(1)` but was not able to quickly figure it out. I also found some references in other code about using `MemoryPool` and `UniqueToken` together (Mark mentioned Aria). I think this could be a longer term solution, but we have not started working on the performance on this code yet, so I think it's fine for now.