### PR TITLE
Add --output-on-failure option to Jenkins ctest

### DIFF
--- a/docker/jenkins/build.sh
+++ b/docker/jenkins/build.sh
@@ -39,7 +39,7 @@ fi
 # build
 make -j${NPROC}
 # run the unit tests
-ctest -j${NPROC} --no-compress-output -T Test
+ctest -j${NPROC} --no-compress-output --output-on-failure -T Test
 # upload code coverage only once
 if [ "${BUILD_TYPE}" == "gcc54"  ]
 then


### PR DESCRIPTION
Tests often fail but we cannot see why. This would automatically dump
all output but only in case it failed.