### PR TITLE
Define our own arithmetic traits in Search

### DIFF
--- a/packages/Meshfree/src/DTK_DetailsMovingLeastSquaresOperatorImpl.hpp
+++ b/packages/Meshfree/src/DTK_DetailsMovingLeastSquaresOperatorImpl.hpp
@@ -14,12 +14,11 @@
 
 #include <DTK_Box.hpp>
 #include <DTK_CompactlySupportedRadialBasisFunctions.hpp>
+#include <DTK_DetailsKokkosExt.hpp> // ArithmeticTraits
 #include <DTK_DetailsSVDImpl.hpp>
 #include <DTK_DetailsUtils.hpp> // lastElement
 #include <DTK_Point.hpp>
 #include <DTK_Predicates.hpp>
-
-#include <Kokkos_ArithTraits.hpp>
 
 namespace DataTransferKit
 {
@@ -120,7 +119,8 @@ struct MovingLeastSquaresOperatorImpl
                 // divide by the radius in the calculation of the radial basis
                 // function. To avoid this problem, the radius has a minimal
                 // positive value.
-                double distance = 10. * Kokkos::ArithTraits<double>::epsilon();
+                double distance =
+                    10. * KokkosExt::ArithmeticTraits::epsilon<double>::value;
                 for ( int j = offset( i ); j < offset( i + 1 ); ++j )
                 {
                     double new_distance = Details::distance(

--- a/packages/Meshfree/src/DTK_DetailsSVDImpl.hpp
+++ b/packages/Meshfree/src/DTK_DetailsSVDImpl.hpp
@@ -12,9 +12,8 @@
 #ifndef DTK_DETAILS_SVD_IMPL_HPP
 #define DTK_DETAILS_SVD_IMPL_HPP
 
-#include <DTK_DetailsKokkosExt.hpp> // sgn
+#include <DTK_DetailsKokkosExt.hpp> // sgn, ArithmeticTraits
 
-#include <Kokkos_ArithTraits.hpp>
 #include <Kokkos_Core.hpp>
 
 #include <cassert>
@@ -227,7 +226,7 @@ struct SVDFunctor
             }
 
         auto norm = norm_F_wo_diag( E );
-        auto tol = Kokkos::ArithTraits<double>::epsilon();
+        auto tol = KokkosExt::ArithmeticTraits::epsilon<double>::value;
 
         while ( norm > tol )
         {

--- a/packages/Search/src/details/DTK_Box.hpp
+++ b/packages/Search/src/details/DTK_Box.hpp
@@ -11,8 +11,8 @@
 #ifndef DTK_BOX_HPP
 #define DTK_BOX_HPP
 
+#include <DTK_DetailsKokkosExt.hpp> // ArithmeticTraits
 #include <DTK_Point.hpp>
-#include <Kokkos_ArithTraits.hpp>
 #include <Kokkos_Macros.hpp>
 
 namespace DataTransferKit
@@ -58,12 +58,12 @@ struct Box
     KOKKOS_INLINE_FUNCTION
     Point volatile const &maxCorner() volatile const { return _max_corner; }
 
-    Point _min_corner = {{Kokkos::ArithTraits<double>::max(),
-                          Kokkos::ArithTraits<double>::max(),
-                          Kokkos::ArithTraits<double>::max()}};
-    Point _max_corner = {{-Kokkos::ArithTraits<double>::max(),
-                          -Kokkos::ArithTraits<double>::max(),
-                          -Kokkos::ArithTraits<double>::max()}};
+    Point _min_corner = {{KokkosExt::ArithmeticTraits::max<double>::value,
+                          KokkosExt::ArithmeticTraits::max<double>::value,
+                          KokkosExt::ArithmeticTraits::max<double>::value}};
+    Point _max_corner = {{-KokkosExt::ArithmeticTraits::max<double>::value,
+                          -KokkosExt::ArithmeticTraits::max<double>::value,
+                          -KokkosExt::ArithmeticTraits::max<double>::value}};
 };
 } // namespace DataTransferKit
 

--- a/packages/Search/src/details/DTK_DetailsBoundingVolumeHierarchyImpl.hpp
+++ b/packages/Search/src/details/DTK_DetailsBoundingVolumeHierarchyImpl.hpp
@@ -13,11 +13,11 @@
 #define DTK_DETAILS_BOUNDING_VOLUME_HIERARCHY_IMPL_HPP
 
 #include <DTK_DetailsBatchedQueries.hpp>
+#include <DTK_DetailsKokkosExt.hpp> // ArithmeticTraits
 #include <DTK_DetailsTreeTraversal.hpp>
 #include <DTK_DetailsUtils.hpp>
 #include <DTK_Predicates.hpp>
 
-#include <Kokkos_ArithTraits.hpp>
 #include <Kokkos_View.hpp>
 
 namespace DataTransferKit
@@ -119,7 +119,8 @@ void BoundingVolumeHierarchyImpl<DeviceType>::queryDispatch(
     {
         Kokkos::View<double *, DeviceType> &distances = *distances_ptr;
         reallocWithoutInitializing( distances, n_results );
-        double const invalid_distance = -Kokkos::ArithTraits<double>::max();
+        double const invalid_distance =
+            -KokkosExt::ArithmeticTraits::max<double>::value;
         Kokkos::deep_copy( distances, invalid_distance );
 
         if ( use_deprecated_nearest_query_algorithm )

--- a/packages/Search/src/details/DTK_DetailsKokkosExt.hpp
+++ b/packages/Search/src/details/DTK_DetailsKokkosExt.hpp
@@ -79,14 +79,14 @@ int clz( uint32_t x )
 }
 
 //! Compute the maximum of two values.
-template <typename T, typename = std::enable_if_t<std::is_arithmetic<T>::value>>
+template <typename T>
 KOKKOS_INLINE_FUNCTION T max( T a, T b )
 {
     return ( a > b ) ? a : b;
 }
 
 //! Compute the minimum of two values.
-template <typename T, typename = std::enable_if_t<std::is_arithmetic<T>::value>>
+template <typename T>
 KOKKOS_INLINE_FUNCTION T min( T a, T b )
 {
     return ( a < b ) ? a : b;

--- a/packages/Search/src/details/DTK_DetailsKokkosExt.hpp
+++ b/packages/Search/src/details/DTK_DetailsKokkosExt.hpp
@@ -13,6 +13,7 @@
 
 #include <Kokkos_View.hpp>
 
+#include <cfloat>  // DBL_MAX
 #include <cmath>   // isfinite, HUGE_VAL
 #include <cstdint> // uint32_t
 #include <type_traits>
@@ -131,6 +132,18 @@ struct infinity<double>
 {
     static constexpr double value = HUGE_VAL;
 };
+
+template <typename T>
+struct max
+{
+};
+
+template <>
+struct max<double>
+{
+    static constexpr double value = DBL_MAX;
+};
+
 } // namespace ArithmeticTraits
 
 } // namespace KokkosExt

--- a/packages/Search/src/details/DTK_DetailsKokkosExt.hpp
+++ b/packages/Search/src/details/DTK_DetailsKokkosExt.hpp
@@ -80,14 +80,14 @@ int clz( uint32_t x )
 
 //! Compute the maximum of two values.
 template <typename T>
-KOKKOS_INLINE_FUNCTION T max( T a, T b )
+KOKKOS_INLINE_FUNCTION T const &max( T const &a, T const &b )
 {
     return ( a > b ) ? a : b;
 }
 
 //! Compute the minimum of two values.
 template <typename T>
-KOKKOS_INLINE_FUNCTION T min( T a, T b )
+KOKKOS_INLINE_FUNCTION T const &min( T const &a, T const &b )
 {
     return ( a < b ) ? a : b;
 }

--- a/packages/Search/src/details/DTK_DetailsKokkosExt.hpp
+++ b/packages/Search/src/details/DTK_DetailsKokkosExt.hpp
@@ -123,9 +123,7 @@ namespace ArithmeticTraits
 {
 
 template <typename T>
-struct infinity
-{
-};
+struct infinity;
 
 template <>
 struct infinity<double>
@@ -134,9 +132,7 @@ struct infinity<double>
 };
 
 template <typename T>
-struct max
-{
-};
+struct max;
 
 template <>
 struct max<double>
@@ -145,9 +141,7 @@ struct max<double>
 };
 
 template <typename T>
-struct epsilon
-{
-};
+struct epsilon;
 
 template <>
 struct epsilon<double>

--- a/packages/Search/src/details/DTK_DetailsKokkosExt.hpp
+++ b/packages/Search/src/details/DTK_DetailsKokkosExt.hpp
@@ -13,7 +13,7 @@
 
 #include <Kokkos_View.hpp>
 
-#include <cfloat>  // DBL_MAX
+#include <cfloat>  // DBL_MAX, DBL_EPSILON
 #include <cmath>   // isfinite, HUGE_VAL
 #include <cstdint> // uint32_t
 #include <type_traits>
@@ -142,6 +142,17 @@ template <>
 struct max<double>
 {
     static constexpr double value = DBL_MAX;
+};
+
+template <typename T>
+struct epsilon
+{
+};
+
+template <>
+struct epsilon<double>
+{
+    static constexpr double value = DBL_EPSILON;
 };
 
 } // namespace ArithmeticTraits

--- a/packages/Search/src/details/DTK_DetailsKokkosExt.hpp
+++ b/packages/Search/src/details/DTK_DetailsKokkosExt.hpp
@@ -109,8 +109,8 @@ KOKKOS_INLINE_FUNCTION int sgn( T x )
  * complains about calling a __host__ function from a __host__ __device__
  * function when it is present.
  */
-template <typename FloatingPoint>
-KOKKOS_INLINE_FUNCTION bool isFinite( FloatingPoint x )
+template <typename T>
+KOKKOS_INLINE_FUNCTION bool isFinite( T x )
 {
 #ifdef __CUDA_ARCH__
     return isfinite( x );

--- a/packages/Search/test/tstDetailsTreeConstruction.cpp
+++ b/packages/Search/test/tstDetailsTreeConstruction.cpp
@@ -15,13 +15,13 @@
 #include <DTK_DetailsTreeConstruction.hpp>
 #include <DTK_DetailsUtils.hpp> // iota
 
-#include <Kokkos_ArithTraits.hpp>
 #include <Teuchos_UnitTestHarness.hpp>
 
 #include <algorithm>
 #include <array>
 #include <bitset>
 #include <functional>
+#include <limits>
 #include <sstream>
 #include <vector>
 
@@ -47,7 +47,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DetailsBVH, morton_codes, DeviceType )
                dtk::expandBits( k );
     };
     std::vector<unsigned int> ref( n,
-                                   Kokkos::ArithTraits<unsigned int>::max() );
+                                   std::numeric_limits<unsigned int>::max() );
     for ( int i = 0; i < n; ++i )
         ref[i] = fun( anchors[i] );
     // using points rather than boxes for convenience here but still have to


### PR DESCRIPTION
Motivation: Remove Search package dependency on KokkosKernels

Also removing the constraints on the overload set of `KokkosExt::{min, max}` (see https://github.com/ORNL-CEES/DataTransferKit/pull/540#discussion_r268805417)