### PR TITLE
Create self-contained Search asserts

### DIFF
--- a/packages/Meshfree/src/DTK_DetailsNearestNeighborOperatorImpl.hpp
+++ b/packages/Meshfree/src/DTK_DetailsNearestNeighborOperatorImpl.hpp
@@ -12,6 +12,7 @@
 #ifndef DTK_DETAILS_NEAREST_NEIGHBOR_OPERATOR_IMPL_HPP
 #define DTK_DETAILS_NEAREST_NEIGHBOR_OPERATOR_IMPL_HPP
 
+#include <DTK_DBC.hpp>
 #include <DTK_DetailsDistributedSearchTreeImpl.hpp> // sendAcrossNetwork()
 #include <DTK_DistributedSearchTree.hpp>
 

--- a/packages/Meshfree/src/DTK_NearestNeighborOperator_def.hpp
+++ b/packages/Meshfree/src/DTK_NearestNeighborOperator_def.hpp
@@ -12,6 +12,7 @@
 #ifndef DTK_NEAREST_NEIGHBOR_OPERATOR_DEF_HPP
 #define DTK_NEAREST_NEIGHBOR_OPERATOR_DEF_HPP
 
+#include <DTK_DBC.hpp>
 #include <DTK_DetailsNearestNeighborOperatorImpl.hpp>
 #include <DTK_DistributedSearchTree.hpp>
 

--- a/packages/Search/examples/point_clouds/point_clouds.hpp
+++ b/packages/Search/examples/point_clouds/point_clouds.hpp
@@ -9,7 +9,7 @@
  * SPDX-License-Identifier: BSD-3-Clause                                    *
  ****************************************************************************/
 
-#include <DTK_DBC.hpp>
+#include <DTK_Search_Exception.hpp>
 
 #include <Kokkos_View.hpp>
 
@@ -213,7 +213,7 @@ void generatePointCloud(
     }
     else
     {
-        throw DataTransferKit::DataTransferKitNotImplementedException();
+        throw DataTransferKit::SearchException( "not implemented" );
     }
     Kokkos::deep_copy( random_points, random_points_host );
 }
@@ -228,7 +228,7 @@ void loadPointCloud(
     {
         int size = -1;
         file >> size;
-        DTK_REQUIRE( size > 0 );
+        DTK_SEARCH_ASSERT( size > 0 );
         Kokkos::realloc( random_points, size );
         auto random_points_host = Kokkos::create_mirror_view( random_points );
         for ( int i = 0; i < size; ++i )

--- a/packages/Search/src/details/DTK_DetailsBatchedQueries.hpp
+++ b/packages/Search/src/details/DTK_DetailsBatchedQueries.hpp
@@ -77,7 +77,7 @@ struct BatchedQueries
                       Kokkos::View<T *, DeviceType> v )
     {
         auto const n = permute.extent( 0 );
-        DTK_REQUIRE( v.extent( 0 ) == n );
+        DTK_SEARCH_ASSERT( v.extent( 0 ) == n );
 
         auto w = cloneWithoutInitializingNorCopying( v );
         Kokkos::parallel_for(
@@ -94,7 +94,7 @@ struct BatchedQueries
                    Kokkos::View<int const *, DeviceType> offset )
     {
         auto const n = permute.extent( 0 );
-        DTK_REQUIRE( offset.extent( 0 ) == n + 1 );
+        DTK_SEARCH_ASSERT( offset.extent( 0 ) == n + 1 );
 
         auto tmp_offset = cloneWithoutInitializingNorCopying( offset );
         Kokkos::parallel_for(
@@ -119,10 +119,11 @@ struct BatchedQueries
     {
         auto const n = permute.extent( 0 );
 
-        DTK_REQUIRE( offset.extent( 0 ) == n + 1 );
-        DTK_REQUIRE( tmp_offset.extent( 0 ) == n + 1 );
-        DTK_REQUIRE( lastElement( offset ) == indices.extent_int( 0 ) );
-        DTK_REQUIRE( lastElement( tmp_offset ) == indices.extent_int( 0 ) );
+        DTK_SEARCH_ASSERT( offset.extent( 0 ) == n + 1 );
+        DTK_SEARCH_ASSERT( tmp_offset.extent( 0 ) == n + 1 );
+        DTK_SEARCH_ASSERT( lastElement( offset ) == indices.extent_int( 0 ) );
+        DTK_SEARCH_ASSERT( lastElement( tmp_offset ) ==
+                           indices.extent_int( 0 ) );
 
         auto tmp_indices = cloneWithoutInitializingNorCopying( indices );
         Kokkos::parallel_for(

--- a/packages/Search/src/details/DTK_DetailsBoundingVolumeHierarchyImpl.hpp
+++ b/packages/Search/src/details/DTK_DetailsBoundingVolumeHierarchyImpl.hpp
@@ -399,7 +399,7 @@ void BoundingVolumeHierarchyImpl<DeviceType>::queryDispatch(
     if ( max_results_per_query > buffer_size )
     {
         // FIXME can definitely do better about error message
-        DTK_INSIST( !throw_if_buffer_optimization_fails );
+        DTK_SEARCH_ASSERT( !throw_if_buffer_optimization_fails );
 
         // We allocate the memory and fill
         //

--- a/packages/Search/src/details/DTK_DetailsDistributedSearchTreeImpl.hpp
+++ b/packages/Search/src/details/DTK_DetailsDistributedSearchTreeImpl.hpp
@@ -172,7 +172,7 @@ DistributedSearchTreeImpl<DeviceType>::sendAcrossNetwork(
     Distributor const &distributor, View exports,
     typename View::non_const_type imports )
 {
-    DTK_REQUIRE(
+    DTK_SEARCH_ASSERT(
         ( exports.dimension_0() == distributor.getTotalSendLength() ) &&
         ( imports.dimension_0() == distributor.getTotalReceiveLength() ) &&
         ( exports.dimension_1() == imports.dimension_1() ) &&
@@ -447,8 +447,8 @@ template <typename BinSort, typename View, typename... OtherViews>
 void applyPermutations( BinSort &bin_sort, View view,
                         OtherViews... other_views )
 {
-    DTK_REQUIRE( bin_sort.get_permute_vector().extent( 0 ) ==
-                 view.extent( 0 ) );
+    DTK_SEARCH_ASSERT( bin_sort.get_permute_vector().extent( 0 ) ==
+                       view.extent( 0 ) );
     bin_sort.sort( view );
     applyPermutations( bin_sort, other_views... );
 }

--- a/packages/Search/src/details/DTK_DetailsDistributor.hpp
+++ b/packages/Search/src/details/DTK_DetailsDistributor.hpp
@@ -11,7 +11,7 @@
 #ifndef DTK_DETAILS_DISTRIBUTOR_HPP
 #define DTK_DETAILS_DISTRIBUTOR_HPP
 
-#include <DTK_DBC.hpp>
+#include <DTK_Search_Exception.hpp>
 
 #include <Kokkos_Core.hpp> // FIXME
 
@@ -37,10 +37,10 @@ static void sortAndDetermineBufferLayout( InputView ranks,
                                           std::vector<int> &counts,
                                           std::vector<int> &offsets )
 {
-    DTK_REQUIRE( unique_ranks.empty() );
-    DTK_REQUIRE( offsets.empty() );
-    DTK_REQUIRE( counts.empty() );
-    DTK_REQUIRE( permutation_indices.extent( 0 ) == ranks.extent( 0 ) );
+    DTK_SEARCH_ASSERT( unique_ranks.empty() );
+    DTK_SEARCH_ASSERT( offsets.empty() );
+    DTK_SEARCH_ASSERT( counts.empty() );
+    DTK_SEARCH_ASSERT( permutation_indices.extent( 0 ) == ranks.extent( 0 ) );
     static_assert(
         std::is_same<typename InputView::non_const_value_type, int>::value,
         "" );
@@ -155,8 +155,10 @@ class Distributor
     void doPostsAndWaits( typename View::const_type const &exports,
                           size_t num_packets, View const &imports ) const
     {
-        DTK_REQUIRE( num_packets * _src_offsets.back() == imports.size() );
-        DTK_REQUIRE( num_packets * _dest_offsets.back() == exports.size() );
+        DTK_SEARCH_ASSERT( num_packets * _src_offsets.back() ==
+                           imports.size() );
+        DTK_SEARCH_ASSERT( num_packets * _dest_offsets.back() ==
+                           exports.size() );
 
         using ValueType = typename View::value_type;
         static_assert( View::rank == 1, "" );

--- a/packages/Search/src/details/DTK_DetailsMortonCode.hpp
+++ b/packages/Search/src/details/DTK_DetailsMortonCode.hpp
@@ -12,7 +12,7 @@
 #ifndef DTK_DETAILS_MORTON_CODE_UTILS_HPP
 #define DTK_DETAILS_MORTON_CODE_UTILS_HPP
 
-#include <DTK_DBC.hpp>
+#include <DTK_Search_Exception.hpp>
 
 #include <DTK_DetailsKokkosExt.hpp> // min. max
 

--- a/packages/Search/src/details/DTK_DetailsSortUtils.hpp
+++ b/packages/Search/src/details/DTK_DetailsSortUtils.hpp
@@ -12,7 +12,7 @@
 #ifndef DTK_DETAILS_SORT_UTILS_HPP
 #define DTK_DETAILS_SORT_UTILS_HPP
 
-#include <DTK_DBC.hpp>
+#include <DTK_Search_Exception.hpp>
 
 #include <DTK_DetailsUtils.hpp> // iota
 #include <Kokkos_Sort.hpp>      // min_max_functor

--- a/packages/Search/src/details/DTK_DetailsTreeConstruction.hpp
+++ b/packages/Search/src/details/DTK_DetailsTreeConstruction.hpp
@@ -272,7 +272,7 @@ inline void TreeConstruction<DeviceType>::assignMortonCodes(
     using Access = typename Traits::Access<Primitives>;
 
     auto const n = Access::size( primitives );
-    DTK_REQUIRE( morton_codes.extent( 0 ) == n );
+    DTK_SEARCH_ASSERT( morton_codes.extent( 0 ) == n );
 
     using Tag = typename Access::Tag;
     assignMortonCodesDispatch( Tag{}, primitives, morton_codes,
@@ -326,8 +326,8 @@ inline void TreeConstruction<DeviceType>::initializeLeafNodes(
     using Access = typename Traits::Access<Primitives>;
 
     auto const n = Access::size( primitives );
-    DTK_REQUIRE( permutation_indices.extent( 0 ) == n );
-    DTK_REQUIRE( leaf_nodes.extent( 0 ) == n );
+    DTK_SEARCH_ASSERT( permutation_indices.extent( 0 ) == n );
+    DTK_SEARCH_ASSERT( leaf_nodes.extent( 0 ) == n );
 
     static_assert( sizeof( typename decltype(
                        permutation_indices )::value_type ) == sizeof( Node * ),

--- a/packages/Search/src/details/DTK_DetailsTreeTraversal.hpp
+++ b/packages/Search/src/details/DTK_DetailsTreeTraversal.hpp
@@ -11,7 +11,7 @@
 #ifndef DTK_DETAILS_TREE_TRAVERSAL_HPP
 #define DTK_DETAILS_TREE_TRAVERSAL_HPP
 
-#include <DTK_DBC.hpp>
+#include <DTK_Search_Exception.hpp>
 
 #include <DTK_DetailsAlgorithms.hpp>
 #include <DTK_DetailsNode.hpp>

--- a/packages/Search/src/details/DTK_DetailsUtils.hpp
+++ b/packages/Search/src/details/DTK_DetailsUtils.hpp
@@ -12,7 +12,7 @@
 #ifndef DTK_DETAILS_UTILS_HPP
 #define DTK_DETAILS_UTILS_HPP
 
-#include <DTK_DBC.hpp>
+#include <DTK_Search_Exception.hpp>
 
 #include <Kokkos_Parallel.hpp>
 #include <Kokkos_Sort.hpp> // min_max_functor
@@ -82,7 +82,7 @@ void exclusivePrefixSum( Kokkos::View<ST, SP...> const &src,
     using ValueType = typename Kokkos::ViewTraits<DT, DP...>::value_type;
 
     auto const n = src.extent( 0 );
-    DTK_REQUIRE( n == dst.extent( 0 ) );
+    DTK_SEARCH_ASSERT( n == dst.extent( 0 ) );
     Kokkos::parallel_scan(
         "exclusive_scan", Kokkos::RangePolicy<ExecutionSpace>( 0, n ),
         Details::ExclusiveScanFunctor<ValueType, ExecutionSpace>( src, dst ) );
@@ -117,7 +117,7 @@ lastElement( Kokkos::View<T, P...> const &v )
         ( unsigned( Kokkos::ViewTraits<T, P...>::rank ) == unsigned( 1 ) ),
         "lastElement requires Views of rank 1" );
     auto const n = v.extent( 0 );
-    DTK_REQUIRE( n > 0 );
+    DTK_SEARCH_ASSERT( n > 0 );
     auto v_subview = Kokkos::subview( v, n - 1 );
     auto v_host = Kokkos::create_mirror_view( v_subview );
     Kokkos::deep_copy( v_host, v_subview );
@@ -172,7 +172,7 @@ minMax( ViewType const &v )
     static_assert( ViewType::rank == 1, "minMax requires a View of rank 1" );
     using ExecutionSpace = typename ViewType::execution_space;
     auto const n = v.extent( 0 );
-    DTK_REQUIRE( n > 0 );
+    DTK_SEARCH_ASSERT( n > 0 );
     Kokkos::Experimental::MinMaxScalar<typename ViewType::non_const_value_type>
         result;
     Kokkos::Experimental::MinMax<typename ViewType::non_const_value_type>
@@ -193,7 +193,7 @@ typename ViewType::non_const_value_type min( ViewType const &v )
     static_assert( ViewType::rank == 1, "min requires a View of rank 1" );
     using ExecutionSpace = typename ViewType::execution_space;
     auto const n = v.extent( 0 );
-    DTK_REQUIRE( n > 0 );
+    DTK_SEARCH_ASSERT( n > 0 );
     typename ViewType::non_const_value_type result;
     Kokkos::Experimental::Min<typename ViewType::non_const_value_type> reducer(
         result );
@@ -216,7 +216,7 @@ typename ViewType::non_const_value_type max( ViewType const &v )
     static_assert( ViewType::rank == 1, "max requires a View of rank 1" );
     using ExecutionSpace = typename ViewType::execution_space;
     auto const n = v.extent( 0 );
-    DTK_REQUIRE( n > 0 );
+    DTK_SEARCH_ASSERT( n > 0 );
     typename ViewType::non_const_value_type result;
     Kokkos::Experimental::Max<typename ViewType::non_const_value_type> reducer(
         result );
@@ -294,8 +294,8 @@ void adjacentDifference( SrcViewType const &src, DstViewType const &dst )
     using ExecutionSpace = typename DstViewType::execution_space;
     // QUESTION Should we assert anything about the memory spaces?
     auto const n = src.extent( 0 );
-    DTK_REQUIRE( n == dst.extent( 0 ) );
-    DTK_REQUIRE( src != dst );
+    DTK_SEARCH_ASSERT( n == dst.extent( 0 ) );
+    DTK_SEARCH_ASSERT( src != dst );
     Kokkos::parallel_for( "adjacentDifference",
                           Kokkos::RangePolicy<ExecutionSpace>( 0, n ),
                           KOKKOS_LAMBDA( int i ) {

--- a/packages/Search/src/details/DTK_Search_Exception.hpp
+++ b/packages/Search/src/details/DTK_Search_Exception.hpp
@@ -1,0 +1,49 @@
+/****************************************************************************
+ * Copyright (c) 2012-2019 by the DataTransferKit authors                   *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the DataTransferKit library. DataTransferKit is     *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+#ifndef DTK_SEARCH_EXCEPTION_HPP
+#define DTK_SEARCH_EXCEPTION_HPP
+
+#include <stdexcept>
+#include <string>
+
+// FIXME
+// This dependency on DTK will have to be resolved later.
+// Particularly, HAVE_DTK_DBC macros and DTK_MARK_REGION
+#include <DTK_ConfigDefs.hpp>
+
+namespace DataTransferKit
+{
+class SearchException : public std::logic_error
+{
+  public:
+    SearchException( std::string const &msg )
+        : std::logic_error( std::string( "DTK Search exception: " ) + msg )
+    {
+    }
+
+    virtual ~SearchException() throw() {}
+};
+
+} // namespace DataTransferKit
+
+#define DTK_SEARCH_STRINGIZE_DETAIL( x ) #x
+#define DTK_SEARCH_STRINGIZE( x ) DTK_SEARCH_STRINGIZE_DETAIL( x )
+
+#if HAVE_DTK_DBC
+#define DTK_SEARCH_ASSERT( c )                                                 \
+    if ( !( c ) )                                                              \
+    throw DataTransferKit::SearchException(                                    \
+        #c ", failed at " __FILE__ ":" DTK_SEARCH_STRINGIZE( __LINE__ ) "." )
+#else
+#define DTK_SEARCH_ASSERT( c )
+#endif
+
+#endif

--- a/packages/Search/test/CMakeLists.txt
+++ b/packages/Search/test/CMakeLists.txt
@@ -10,6 +10,13 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   FAIL_REGULAR_EXPRESSION "data race;leak;runtime error"
   )
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  Exception
+  SOURCES tstException.cpp unit_test_main.cpp
+  COMM serial mpi
+  STANDARD_PASS_OUTPUT
+  FAIL_REGULAR_EXPRESSION "data race;leak;runtime error"
+  )
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
   DetailsTreeConstruction
   SOURCES tstDetailsTreeConstruction.cpp unit_test_main.cpp
   COMM serial mpi

--- a/packages/Search/test/DTK_BoostRangeAdapters.hpp
+++ b/packages/Search/test/DTK_BoostRangeAdapters.hpp
@@ -12,7 +12,7 @@
 #ifndef DTK_BOOST_RANGE_ADAPTERS_HPP
 #define DTK_BOOST_RANGE_ADAPTERS_HPP
 
-#include <DTK_DBC.hpp>
+#include <DTK_Search_Exception.hpp>
 
 #include <Kokkos_Concepts.hpp>
 #include <Kokkos_View.hpp>
@@ -108,7 +108,7 @@ range_end( Kokkos::View<T, P...> &v )
 {
     using View = Kokkos::View<T, P...>;
     DTK_ASSERT_VIEW_COMPATIBLE( View )
-    DTK_REQUIRE( v.span_is_contiguous() );
+    DTK_SEARCH_ASSERT( v.span_is_contiguous() );
     return v.data() + v.span();
 }
 
@@ -118,7 +118,7 @@ range_end( Kokkos::View<T, P...> const &v )
 {
     using View = Kokkos::View<T, P...>;
     DTK_ASSERT_VIEW_COMPATIBLE( View )
-    DTK_REQUIRE( v.span_is_contiguous() );
+    DTK_SEARCH_ASSERT( v.span_is_contiguous() );
     return v.data() + v.span();
 }
 

--- a/packages/Search/test/tstDetailsBatchedQueries.cpp
+++ b/packages/Search/test/tstDetailsBatchedQueries.cpp
@@ -34,7 +34,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( BatchedQueries, permute_offset_and_indices,
 
     TEST_THROW( DataTransferKit::Details::BatchedQueries<
                     DeviceType>::reversePermutation( permute, offset, indices ),
-                DataTransferKit::DataTransferKitException );
+                DataTransferKit::SearchException );
 
     Kokkos::resize( offset, 1 );
     TEST_NOTHROW( DataTransferKit::Details::BatchedQueries<

--- a/packages/Search/test/tstDetailsDistributedSearchTreeImpl.cpp
+++ b/packages/Search/test/tstDetailsDistributedSearchTreeImpl.cpp
@@ -82,7 +82,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DetailsDistributedSearchTreeImpl,
     Kokkos::View<int *, DeviceType> not_sized_properly( "", m );
     TEST_THROW( DataTransferKit::Details::DistributedSearchTreeImpl<
                     DeviceType>::sortResults( ids, not_sized_properly ),
-                DataTransferKit::DataTransferKitException );
+                DataTransferKit::SearchException );
 }
 
 TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DetailsDistributedSearchTreeImpl,

--- a/packages/Search/test/tstDetailsUtils.cpp
+++ b/packages/Search/test/tstDetailsUtils.cpp
@@ -64,7 +64,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DetailsUtils, prefix_sum, DeviceType )
     TEST_INEQUALITY( n, m );
     Kokkos::View<int *, DeviceType> z( "z", m );
     TEST_THROW( DataTransferKit::exclusivePrefixSum( x, z ),
-                DataTransferKit::DataTransferKitException );
+                DataTransferKit::SearchException );
     Kokkos::View<double[3], DeviceType> v( "v" );
     auto v_host = Kokkos::create_mirror_view( v );
     v_host( 0 ) = 1.;
@@ -77,7 +77,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DetailsUtils, prefix_sum, DeviceType )
     TEST_COMPARE_FLOATING_ARRAYS( v_host, v_ref, 1e-14 );
     Kokkos::View<double *, DeviceType> w( "w", 4 );
     TEST_THROW( DataTransferKit::exclusivePrefixSum( v, w ),
-                DataTransferKit::DataTransferKitException );
+                DataTransferKit::SearchException );
     v_host( 0 ) = 1.;
     v_host( 1 ) = 0.;
     v_host( 2 ) = 0.;
@@ -100,7 +100,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DetailsUtils, last_element, DeviceType )
     TEST_EQUALITY( DataTransferKit::lastElement( v ), 24 );
     Kokkos::View<int *, DeviceType> w( "w", 0 );
     TEST_THROW( DataTransferKit::lastElement( w ),
-                DataTransferKit::DataTransferKitException );
+                DataTransferKit::SearchException );
     Kokkos::View<double[1], DeviceType> u( "u", 1 );
     Kokkos::deep_copy( u, 3.14 );
     TEST_FLOATING_EQUALITY( DataTransferKit::lastElement( u ), 3.14, 1e-14 );
@@ -120,7 +120,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DetailsUtils, minmax, DeviceType )
     TEST_FLOATING_EQUALITY( std::get<1>( result_float ), 3.14, 1e-14 );
     Kokkos::View<int *, DeviceType> w( "w" );
     TEST_THROW( DataTransferKit::minMax( w ),
-                DataTransferKit::DataTransferKitException );
+                DataTransferKit::SearchException );
     Kokkos::resize( w, 1 );
     Kokkos::deep_copy( w, 255 );
     auto const result_int = DataTransferKit::minMax( w );
@@ -171,7 +171,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DetailsUtils, adjacent_difference,
     Kokkos::deep_copy( v, v_host );
     // In-place operation is not allowed
     TEST_THROW( DataTransferKit::adjacentDifference( v, v ),
-                DataTransferKit::DataTransferKitException );
+                DataTransferKit::SearchException );
     auto w = Kokkos::create_mirror( DeviceType(), v );
     TEST_NOTHROW( DataTransferKit::adjacentDifference( v, w ) );
     auto w_host = Kokkos::create_mirror_view( w );
@@ -182,7 +182,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DetailsUtils, adjacent_difference,
     Kokkos::View<float *, DeviceType> x( "x", 10 );
     Kokkos::deep_copy( x, 3.14 );
     TEST_THROW( DataTransferKit::adjacentDifference( x, x ),
-                DataTransferKit::DataTransferKitException );
+                DataTransferKit::SearchException );
     Kokkos::View<float[10], DeviceType> y( "y" );
     TEST_NOTHROW( DataTransferKit::adjacentDifference( x, y ) );
     std::vector<float> y_ref( 10 );
@@ -193,7 +193,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DetailsUtils, adjacent_difference,
 
     Kokkos::resize( x, 5 );
     TEST_THROW( DataTransferKit::adjacentDifference( y, x ),
-                DataTransferKit::DataTransferKitException );
+                DataTransferKit::SearchException );
 }
 
 TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DetailsUtils, min_and_max, DeviceType )

--- a/packages/Search/test/tstException.cpp
+++ b/packages/Search/test/tstException.cpp
@@ -1,0 +1,84 @@
+/****************************************************************************
+ * Copyright (c) 2012-2019 by the DataTransferKit authors                   *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the DataTransferKit library. DataTransferKit is     *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+#include <cmath>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <vector>
+
+#include <DTK_Search_Exception.hpp>
+
+#include "Teuchos_UnitTestHarness.hpp"
+
+// Check that a DataTransferKit::SearchException looks different than a
+// std::runtime_error as it inherits from std::logic_error.
+TEUCHOS_UNIT_TEST( SearchException, differentiation_test )
+{
+    try
+    {
+        throw std::runtime_error( "runtime error" );
+    }
+    catch ( const DataTransferKit::SearchException &assertion )
+    {
+        TEST_ASSERT( 0 );
+    }
+    catch ( ... )
+    {
+        TEST_ASSERT( 1 );
+    }
+}
+
+// Check that a DataTransferKit::SearchException can be caught and the
+// appropriate error message is written.
+TEUCHOS_UNIT_TEST( SearchException, message_test )
+{
+    std::string message;
+
+    try
+    {
+        throw DataTransferKit::SearchException( "cond" );
+    }
+    catch ( const DataTransferKit::SearchException &assertion )
+    {
+        message = std::string( assertion.what() );
+    }
+    catch ( ... )
+    {
+        TEST_ASSERT( 0 );
+    }
+
+    const std::string true_message( "DTK Search exception: cond" );
+    TEST_ASSERT( 0 == message.compare( true_message ) );
+}
+
+// Test the assertion check
+TEUCHOS_UNIT_TEST( SearchException, assertion_test )
+{
+    try
+    {
+        DTK_SEARCH_ASSERT( 0 );
+        throw std::runtime_error( "this shouldn't be thrown" );
+    }
+    catch ( const DataTransferKit::SearchException &assertion )
+    {
+        std::string message( assertion.what() );
+        std::string true_message( "DTK Search exception: 0, failed at" );
+        std::string::size_type idx = message.find( true_message );
+        if ( idx == std::string::npos )
+        {
+            TEST_ASSERT( 0 );
+        }
+    }
+    catch ( ... )
+    {
+        TEST_ASSERT( 0 );
+    }
+}

--- a/packages/Search/test/tstLinearBVH.cpp
+++ b/packages/Search/test/tstLinearBVH.cpp
@@ -285,7 +285,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( LinearBVH, buffer_optimization, DeviceType )
     TEST_NOTHROW( bvh.query( queries, indices, offset, +1 ) );
     checkResultsAreFine();
     TEST_THROW( bvh.query( queries, indices, offset, -1 ),
-                DataTransferKit::DataTransferKitException );
+                DataTransferKit::SearchException );
 
     // adequate buffer size
     TEST_COMPARE( max_results_per_query, <, 5 );


### PR DESCRIPTION
I opted for "duplicating" DTK_DBC instead of moving the original inside the search. This would allow us to modify ArborX exception at any time without having to spend time to fix any creeping DTK issues.

I also retained a single ASSERT call, and got rid of helper functions to maintain header-only flavor of the library.