### PR TITLE
Enable view comparisons in unit tests

### DIFF
--- a/packages/Search/test/CMakeLists.txt
+++ b/packages/Search/test/CMakeLists.txt
@@ -87,20 +87,11 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
 
 IF (HAVE_DTK_BOOST)
   TRIBITS_ADD_EXECUTABLE_AND_TEST(
-    BoostRangeAdapters
-    SOURCES tstBoostRangeAdapters.cpp DTK_BoostRangeAdapters.hpp unit_test_main.cpp
+    BoostAdapters
+    SOURCES tstBoostGeometryAdapters.cpp tstBoostRangeAdapters.cpp utf_main.cpp
     COMM serial mpi
     NUM_MPI_PROCS 1
-    STANDARD_PASS_OUTPUT
-    FAIL_REGULAR_EXPRESSION "data race;leak;runtime error"
+    ADDED_EXE_TARGET_NAME_OUT boost_adapters_exe
     )
-
-  TRIBITS_ADD_EXECUTABLE_AND_TEST(
-    BoostGeometryAdapters
-    SOURCES tstBoostGeometryAdapters.cpp DTK_BoostGeometryAdapters.hpp unit_test_main.cpp
-    COMM serial mpi
-    NUM_MPI_PROCS 1
-    STANDARD_PASS_OUTPUT
-    FAIL_REGULAR_EXPRESSION "data race;leak;runtime error"
-    )
+    target_compile_definitions(${boost_adapters_exe} PRIVATE BOOST_TEST_DYN_LINK)
 ENDIF()

--- a/packages/Search/test/DTK_EnableViewComparison.hpp
+++ b/packages/Search/test/DTK_EnableViewComparison.hpp
@@ -1,0 +1,43 @@
+#ifndef DTK_ENABLE_VIEW_COMPARISON_HPP
+#define DTK_ENABLE_VIEW_COMPARISON_HPP
+
+#include <DTK_DetailsKokkosExt.hpp> // is_accessible_from_host
+
+#include <boost/test/utils/is_forward_iterable.hpp>
+
+// Enable element-wise comparison for views that are accessible from the host
+namespace boost
+{
+namespace unit_test
+{
+
+template <typename T, typename... P>
+struct is_forward_iterable<Kokkos::View<T, P...>> : public boost::mpl::true_
+{
+    // NOTE Prefer static assertion to SFINAE because error message about no
+    // operator== for the operands is not is not as clear.
+    static_assert(
+        Kokkos::View<T, P...>::rank == 1 &&
+            KokkosExt::is_accessible_from_host<Kokkos::View<T, P...>>::value,
+        "Restricted to rank-one host-accessible views" );
+};
+
+template <typename T, typename... P>
+struct bt_iterator_traits<Kokkos::View<T, P...>, true>
+{
+    using view_type = Kokkos::View<T, P...>;
+    using value_type = typename view_type::value_type;
+    using const_iterator =
+        typename std::add_pointer<typename view_type::const_value_type>::type;
+    static const_iterator begin( view_type const &v ) { return v.data(); }
+    static const_iterator end( view_type const &v )
+    {
+        return v.data() + v.size();
+    }
+    static std::size_t size( view_type const &v ) { return v.size(); }
+};
+
+} // namespace unit_test
+} // namespace boost
+
+#endif

--- a/packages/Search/test/DTK_EnableViewComparison.hpp
+++ b/packages/Search/test/DTK_EnableViewComparison.hpp
@@ -15,7 +15,7 @@ template <typename T, typename... P>
 struct is_forward_iterable<Kokkos::View<T, P...>> : public boost::mpl::true_
 {
     // NOTE Prefer static assertion to SFINAE because error message about no
-    // operator== for the operands is not is not as clear.
+    // operator== for the operands is not as clear.
     static_assert(
         Kokkos::View<T, P...>::rank == 1 &&
             KokkosExt::is_accessible_from_host<Kokkos::View<T, P...>>::value,

--- a/packages/Search/test/tstBoostGeometryAdapters.cpp
+++ b/packages/Search/test/tstBoostGeometryAdapters.cpp
@@ -9,11 +9,13 @@
  * SPDX-License-Identifier: BSD-3-Clause                                    *
  ****************************************************************************/
 
+#include "DTK_BoostGeometryAdapters.hpp"
+
 #include <DTK_DetailsAlgorithms.hpp>
 
-#include <Teuchos_UnitTestHarness.hpp>
+#include <boost/test/unit_test.hpp>
 
-#include "DTK_BoostGeometryAdapters.hpp"
+#define BOOST_TEST_MODULE BoostGeometryAdapters
 
 namespace bg = boost::geometry;
 namespace dtk = DataTransferKit::Details;
@@ -37,88 +39,88 @@ using Box = model::box<Point>;
 } // namespace geometry
 } // namespace boost
 
-TEUCHOS_UNIT_TEST( BoostGeometryAdapters, equals )
+BOOST_AUTO_TEST_CASE( equals )
 {
     dtk::Point point = {{1., 2., 3.}};
-    TEST_ASSERT( dtk::equals( point, {{1., 2., 3.}} ) );
-    TEST_ASSERT( !dtk::equals( point, {{0., 0., 0.}} ) );
-    TEST_ASSERT( bg::equals( point, bg::make<dtk::Point>( 1., 2., 3. ) ) );
-    TEST_ASSERT( !bg::equals( point, bg::make<dtk::Point>( 4., 5., 6. ) ) );
-    TEST_ASSERT( bg::equals( point, bg::make<bg::Point>( 1., 2., 3. ) ) );
-    TEST_ASSERT( !bg::equals( point, bg::make<bg::Point>( 0., 0., 0. ) ) );
+    BOOST_TEST( dtk::equals( point, {{1., 2., 3.}} ) );
+    BOOST_TEST( !dtk::equals( point, {{0., 0., 0.}} ) );
+    BOOST_TEST( bg::equals( point, bg::make<dtk::Point>( 1., 2., 3. ) ) );
+    BOOST_TEST( !bg::equals( point, bg::make<dtk::Point>( 4., 5., 6. ) ) );
+    BOOST_TEST( bg::equals( point, bg::make<bg::Point>( 1., 2., 3. ) ) );
+    BOOST_TEST( !bg::equals( point, bg::make<bg::Point>( 0., 0., 0. ) ) );
 
     dtk::Box box = {{{1., 2., 3.}}, {{4., 5., 6.}}};
-    TEST_ASSERT( dtk::equals( box, {{{1., 2., 3.}}, {{4., 5., 6.}}} ) );
-    TEST_ASSERT( !dtk::equals( box, {{{0., 0., 0.}}, {{1., 1., 1.}}} ) );
-    TEST_ASSERT( bg::equals( box, dtk::Box{{{1., 2., 3.}}, {{4., 5., 6.}}} ) );
-    TEST_ASSERT( !bg::equals( box, dtk::Box{{{0., 0., 0.}}, {{1., 1., 1.}}} ) );
-    TEST_ASSERT(
+    BOOST_TEST( dtk::equals( box, {{{1., 2., 3.}}, {{4., 5., 6.}}} ) );
+    BOOST_TEST( !dtk::equals( box, {{{0., 0., 0.}}, {{1., 1., 1.}}} ) );
+    BOOST_TEST( bg::equals( box, dtk::Box{{{1., 2., 3.}}, {{4., 5., 6.}}} ) );
+    BOOST_TEST( !bg::equals( box, dtk::Box{{{0., 0., 0.}}, {{1., 1., 1.}}} ) );
+    BOOST_TEST(
         bg::equals( box, bg::Box( bg::make<bg::Point>( 1., 2., 3. ),
                                   bg::make<bg::Point>( 4., 5., 6. ) ) ) );
-    TEST_ASSERT(
+    BOOST_TEST(
         !bg::equals( box, bg::Box( bg::make<bg::Point>( 0., 0., 0. ),
                                    bg::make<bg::Point>( 1., 1., 1. ) ) ) );
     // Now just for fun compare the DTK box to a Boost.Geometry box composed of
     // DTK points.
-    TEST_ASSERT( bg::equals(
+    BOOST_TEST( bg::equals(
         box, bg::model::box<dtk::Point>( {{1., 2., 3.}}, {{4., 5., 6.}} ) ) );
-    TEST_ASSERT( !bg::equals(
+    BOOST_TEST( !bg::equals(
         box, bg::model::box<dtk::Point>( {{0., 0., 0.}}, {{0., 0., 0.}} ) ) );
 }
 
-TEUCHOS_UNIT_TEST( BoostGeometryAdapters, distance )
+BOOST_AUTO_TEST_CASE( distance )
 {
     // NOTE unsure if should test for floating point equality here
     dtk::Point a = {{0., 0., 0.}};
     dtk::Point b = {{0., 1., 0.}};
-    TEST_EQUALITY( dtk::distance( a, b ), 1. );
-    TEST_EQUALITY( bg::distance( a, b ), 1. );
+    BOOST_TEST( dtk::distance( a, b ) == 1. );
+    BOOST_TEST( bg::distance( a, b ) == 1. );
 
     std::tie( a, b ) = std::make_pair<dtk::Point, dtk::Point>( {{0., 0., 0.}},
                                                                {{1., 1., 1.}} );
-    TEST_EQUALITY( dtk::distance( a, b ), std::sqrt( 3. ) );
-    TEST_EQUALITY( bg::distance( a, b ), std::sqrt( 3. ) );
+    BOOST_TEST( dtk::distance( a, b ) == std::sqrt( 3. ) );
+    BOOST_TEST( bg::distance( a, b ) == std::sqrt( 3. ) );
 
-    TEST_EQUALITY( dtk::distance( a, a ), 0. );
-    TEST_EQUALITY( bg::distance( a, a ), 0. );
+    BOOST_TEST( dtk::distance( a, a ) == 0. );
+    BOOST_TEST( bg::distance( a, a ) == 0. );
 
     dtk::Box unit_box = {{{0., 0., 0.}}, {{1., 1., 1.}}};
     dtk::Point p = {{.5, .5, .5}};
     // NOTE DTK has no overload distance( Box, Point )
-    TEST_EQUALITY( dtk::distance( p, unit_box ), 0. );
-    // TEST_EQUALITY( dtk::distance( unit_box, p ), 0. );
-    TEST_EQUALITY( bg::distance( p, unit_box ), 0. );
-    TEST_EQUALITY( bg::distance( unit_box, p ), 0. );
+    BOOST_TEST( dtk::distance( p, unit_box ) == 0. );
+    // BOOST_TEST( dtk::distance( unit_box, p ) == 0. );
+    BOOST_TEST( bg::distance( p, unit_box ) == 0. );
+    BOOST_TEST( bg::distance( unit_box, p ) == 0. );
 
     p = {{-1., -1., -1.}};
-    TEST_EQUALITY( dtk::distance( p, unit_box ), std::sqrt( 3. ) );
-    TEST_EQUALITY( bg::distance( p, unit_box ), std::sqrt( 3. ) );
+    BOOST_TEST( dtk::distance( p, unit_box ) == std::sqrt( 3. ) );
+    BOOST_TEST( bg::distance( p, unit_box ) == std::sqrt( 3. ) );
 
     p = {{-1., .5, -1.}};
-    TEST_EQUALITY( dtk::distance( p, unit_box ), std::sqrt( 2. ) );
-    TEST_EQUALITY( bg::distance( p, unit_box ), std::sqrt( 2. ) );
+    BOOST_TEST( dtk::distance( p, unit_box ) == std::sqrt( 2. ) );
+    BOOST_TEST( bg::distance( p, unit_box ) == std::sqrt( 2. ) );
 
     p = {{-1., .5, .5}};
-    TEST_EQUALITY( dtk::distance( p, unit_box ), 1. );
-    TEST_EQUALITY( bg::distance( p, unit_box ), 1. );
+    BOOST_TEST( dtk::distance( p, unit_box ) == 1. );
+    BOOST_TEST( bg::distance( p, unit_box ) == 1. );
 }
 
-TEUCHOS_UNIT_TEST( BoostGeometryAdapters, expand )
+BOOST_AUTO_TEST_CASE( expand )
 {
     using dtk::equals;
     dtk::Box box;
     // NOTE even though not considered valid, default constructed DTK box can be
     // expanded using Boost.Geometry algorithm.
-    TEST_ASSERT( !bg::is_valid( box ) );
+    BOOST_TEST( !bg::is_valid( box ) );
     bg::expand( box, dtk::Point{{0., 0., 0.}} );
     dtk::expand( box, {{1., 1., 1.}} );
-    TEST_ASSERT( equals( box, {{{0., 0., 0.}}, {{1., 1., 1.}}} ) );
+    BOOST_TEST( equals( box, {{{0., 0., 0.}}, {{1., 1., 1.}}} ) );
     bg::expand( box, dtk::Box{{{1., 2., 3.}}, {{4., 5., 6.}}} );
     dtk::expand( box, {{{-1., -2., -3.}}, {{0., 0., 0.}}} );
-    TEST_ASSERT( equals( box, {{{-1., -2., -3.}}, {{4., 5., 6.}}} ) );
+    BOOST_TEST( equals( box, {{{-1., -2., -3.}}, {{4., 5., 6.}}} ) );
 }
 
-TEUCHOS_UNIT_TEST( BoostGeometryAdapters, centroid )
+BOOST_AUTO_TEST_CASE( centroid )
 {
     using dtk::equals;
     // For convenience define a function that returns the centroid.
@@ -134,22 +136,21 @@ TEUCHOS_UNIT_TEST( BoostGeometryAdapters, centroid )
     // constructed "empty" box is not valid, it will still calculate its
     // centroid.  Admittedly, the result (centroid at origin) is garbage :)
     dtk::Box empty_box = {};
-    TEST_ASSERT( !bg::is_valid( empty_box ) );
-    TEST_ASSERT( equals( bg::return_centroid<dtk::Point>( empty_box ),
-                         {{0., 0., 0.}} ) );
-    TEST_ASSERT( equals( dtkReturnCentroid( empty_box ), {{0., 0., 0.}} ) );
+    BOOST_TEST( !bg::is_valid( empty_box ) );
+    BOOST_TEST( equals( bg::return_centroid<dtk::Point>( empty_box ),
+                        {{0., 0., 0.}} ) );
+    BOOST_TEST( equals( dtkReturnCentroid( empty_box ), {{0., 0., 0.}} ) );
 
     dtk::Box unit_box = {{{0., 0., 0.}}, {{1., 1., 1.}}};
-    TEST_ASSERT(
+    BOOST_TEST(
         equals( bg::return_centroid<dtk::Point>( unit_box ), {{.5, .5, .5}} ) );
-    TEST_ASSERT( equals( dtkReturnCentroid( unit_box ), {{.5, .5, .5}} ) );
+    BOOST_TEST( equals( dtkReturnCentroid( unit_box ), {{.5, .5, .5}} ) );
 
     // NOTE DTK does not have an overload of centroid() for Point at the
     // moment.
     dtk::Point a_point = {{1., 2., 3.}};
-    TEST_ASSERT(
-        equals( bg::return_centroid<dtk::Point>( a_point ), a_point ) );
-    // TEST_ASSERT( equals( dtk::centroid(
+    BOOST_TEST( equals( bg::return_centroid<dtk::Point>( a_point ), a_point ) );
+    // BOOST_TEST( equals( dtk::centroid(
     //     []( dtk::Point p ) {
     //         dtk::Point c;
     //         dtk::centroid( p, c );
@@ -158,91 +159,89 @@ TEUCHOS_UNIT_TEST( BoostGeometryAdapters, centroid )
     //     a_point ) ) );
 }
 
-TEUCHOS_UNIT_TEST( BoostGeometryAdapters, is_valid )
+BOOST_AUTO_TEST_CASE( is_valid )
 {
     // NOTE "empty" box is considered as valid in DataTransferKit but it is
     // not according to Boost.Geometry
     dtk::Box empty_box = {};
-    TEST_ASSERT( dtk::isValid( empty_box ) );
+    BOOST_TEST( dtk::isValid( empty_box ) );
     std::string message;
-    TEST_ASSERT( !bg::is_valid( empty_box, message ) );
-    TEST_EQUALITY( message, "Box has corners in wrong order" );
+    BOOST_TEST( !bg::is_valid( empty_box, message ) );
+    BOOST_TEST( message == "Box has corners in wrong order" );
 
     // Same issue with infinitesimal box around a point (here the origin)
     dtk::Box a_box = {{{0., 0., 0.}}, {{0., 0., 0.}}};
-    TEST_ASSERT( dtk::isValid( a_box ) );
-    TEST_ASSERT( !bg::is_valid( a_box, message ) );
-    TEST_EQUALITY( message, "Geometry has wrong topological dimension" );
+    BOOST_TEST( dtk::isValid( a_box ) );
+    BOOST_TEST( !bg::is_valid( a_box, message ) );
+    BOOST_TEST( message == "Geometry has wrong topological dimension" );
 
     dtk::Box unit_box = {{{0., 0., 0.}}, {{1., 1., 1.}}};
-    TEST_ASSERT( dtk::isValid( unit_box ) );
-    TEST_ASSERT( bg::is_valid( unit_box ) );
+    BOOST_TEST( dtk::isValid( unit_box ) );
+    BOOST_TEST( bg::is_valid( unit_box ) );
 
     dtk::Box invalid_box = {{{1., 2., 3.}}, {{4., NAN, 6.}}};
-    TEST_ASSERT( !dtk::isValid( invalid_box ) );
-    TEST_ASSERT( !bg::is_valid( invalid_box, message ) );
-    TEST_EQUALITY( message,
-                   "Geometry has point(s) with invalid coordinate(s)" );
+    BOOST_TEST( !dtk::isValid( invalid_box ) );
+    BOOST_TEST( !bg::is_valid( invalid_box, message ) );
+    BOOST_TEST( message == "Geometry has point(s) with invalid coordinate(s)" );
 
     dtk::Point a_point = {{1., 2., 3.}};
-    TEST_ASSERT( dtk::isValid( a_point ) );
-    TEST_ASSERT( bg::is_valid( a_point ) );
+    BOOST_TEST( dtk::isValid( a_point ) );
+    BOOST_TEST( bg::is_valid( a_point ) );
 
     auto const infty = std::numeric_limits<double>::infinity();
     dtk::Point invalid_point = {{infty, 1.41, 3.14}};
-    TEST_ASSERT( !dtk::isValid( invalid_point ) );
-    TEST_ASSERT( !bg::is_valid( invalid_point, message ) );
-    TEST_EQUALITY( message,
-                   "Geometry has point(s) with invalid coordinate(s)" );
+    BOOST_TEST( !dtk::isValid( invalid_point ) );
+    BOOST_TEST( !bg::is_valid( invalid_point, message ) );
+    BOOST_TEST( message == "Geometry has point(s) with invalid coordinate(s)" );
 
     // Also Boost.Geometry has a is_empty() algorithm but it has a different
     // meaning, it checks whether a geometry is an empty set and always returns
     // false for a point or a box.
-    TEST_ASSERT( !bg::is_empty( empty_box ) );
-    TEST_ASSERT( !bg::is_empty( a_box ) );
-    TEST_ASSERT( !bg::is_empty( unit_box ) );
+    BOOST_TEST( !bg::is_empty( empty_box ) );
+    BOOST_TEST( !bg::is_empty( a_box ) );
+    BOOST_TEST( !bg::is_empty( unit_box ) );
 }
 
-TEUCHOS_UNIT_TEST( BoostGeometryAdapters, intersects )
+BOOST_AUTO_TEST_CASE( intersects )
 {
     dtk::Box const unit_box = {{{0., 0., 0.}}, {{1., 1., 1.}}};
 
     // self-intersection
-    TEST_ASSERT( dtk::intersects( unit_box, unit_box ) );
-    TEST_ASSERT( bg::intersects( unit_box, unit_box ) );
+    BOOST_TEST( dtk::intersects( unit_box, unit_box ) );
+    BOOST_TEST( bg::intersects( unit_box, unit_box ) );
 
     // share a corner
     dtk::Box other_box = {{{1., 1., 1.}}, {{2., 2., 2.}}};
-    TEST_ASSERT( dtk::intersects( unit_box, other_box ) );
-    TEST_ASSERT( bg::intersects( unit_box, other_box ) );
+    BOOST_TEST( dtk::intersects( unit_box, other_box ) );
+    BOOST_TEST( bg::intersects( unit_box, other_box ) );
 
     // share an edge
     other_box = {{{1., 0., 1.}}, {{2., 1., 2.}}};
-    TEST_ASSERT( dtk::intersects( unit_box, other_box ) );
-    TEST_ASSERT( bg::intersects( unit_box, other_box ) );
+    BOOST_TEST( dtk::intersects( unit_box, other_box ) );
+    BOOST_TEST( bg::intersects( unit_box, other_box ) );
 
     // share a face
     other_box = {{{0., -1., 0.}}, {{1., 0., 1.}}};
-    TEST_ASSERT( dtk::intersects( unit_box, other_box ) );
-    TEST_ASSERT( bg::intersects( unit_box, other_box ) );
+    BOOST_TEST( dtk::intersects( unit_box, other_box ) );
+    BOOST_TEST( bg::intersects( unit_box, other_box ) );
 
     // contains the other box
     other_box = {{{.3, .3, .3}}, {{.6, .6, .6}}};
-    TEST_ASSERT( dtk::intersects( unit_box, other_box ) );
-    TEST_ASSERT( bg::intersects( unit_box, other_box ) );
+    BOOST_TEST( dtk::intersects( unit_box, other_box ) );
+    BOOST_TEST( bg::intersects( unit_box, other_box ) );
 
     // within the other box
     other_box = {{{-1., -1., -1.}}, {{2., 2., 2.}}};
-    TEST_ASSERT( dtk::intersects( unit_box, other_box ) );
-    TEST_ASSERT( bg::intersects( unit_box, other_box ) );
+    BOOST_TEST( dtk::intersects( unit_box, other_box ) );
+    BOOST_TEST( bg::intersects( unit_box, other_box ) );
 
     // overlapping
     other_box = {{{.5, .5, .5}}, {{2., 2., 2.}}};
-    TEST_ASSERT( dtk::intersects( unit_box, other_box ) );
-    TEST_ASSERT( bg::intersects( unit_box, other_box ) );
+    BOOST_TEST( dtk::intersects( unit_box, other_box ) );
+    BOOST_TEST( bg::intersects( unit_box, other_box ) );
 
     // disjoint
     other_box = {{{1., 2., 3.}}, {{4., 5., 6.}}};
-    TEST_ASSERT( !dtk::intersects( unit_box, other_box ) );
-    TEST_ASSERT( !bg::intersects( unit_box, other_box ) );
+    BOOST_TEST( !dtk::intersects( unit_box, other_box ) );
+    BOOST_TEST( !bg::intersects( unit_box, other_box ) );
 }

--- a/packages/Search/test/tstBoostGeometryAdapters.cpp
+++ b/packages/Search/test/tstBoostGeometryAdapters.cpp
@@ -123,14 +123,6 @@ BOOST_AUTO_TEST_CASE( expand )
 BOOST_AUTO_TEST_CASE( centroid )
 {
     using dtk::equals;
-    // For convenience define a function that returns the centroid.
-    // Boost.Geometry defines both `void centroid(Geometry const & geometry,
-    // Point &c )` and `Point return_centroid(Geometry const& geometry)`
-    auto const dtkReturnCentroid = []( dtk::Box b ) {
-        dtk::Point c;
-        dtk::centroid( b, c );
-        return c;
-    };
 
     // Interestingly enough, even though for Boost.Geometry, the DTK default
     // constructed "empty" box is not valid, it will still calculate its
@@ -139,24 +131,16 @@ BOOST_AUTO_TEST_CASE( centroid )
     BOOST_TEST( !bg::is_valid( empty_box ) );
     BOOST_TEST( equals( bg::return_centroid<dtk::Point>( empty_box ),
                         {{0., 0., 0.}} ) );
-    BOOST_TEST( equals( dtkReturnCentroid( empty_box ), {{0., 0., 0.}} ) );
+    BOOST_TEST( equals( dtk::returnCentroid( empty_box ), {{0., 0., 0.}} ) );
 
     dtk::Box unit_box = {{{0., 0., 0.}}, {{1., 1., 1.}}};
     BOOST_TEST(
         equals( bg::return_centroid<dtk::Point>( unit_box ), {{.5, .5, .5}} ) );
-    BOOST_TEST( equals( dtkReturnCentroid( unit_box ), {{.5, .5, .5}} ) );
+    BOOST_TEST( equals( dtk::returnCentroid( unit_box ), {{.5, .5, .5}} ) );
 
-    // NOTE DTK does not have an overload of centroid() for Point at the
-    // moment.
     dtk::Point a_point = {{1., 2., 3.}};
     BOOST_TEST( equals( bg::return_centroid<dtk::Point>( a_point ), a_point ) );
-    // BOOST_TEST( equals( dtk::centroid(
-    //     []( dtk::Point p ) {
-    //         dtk::Point c;
-    //         dtk::centroid( p, c );
-    //         return c;
-    //     }( a_point ),
-    //     a_point ) ) );
+    BOOST_TEST( equals( dtk::returnCentroid( a_point ), a_point ) );
 }
 
 BOOST_AUTO_TEST_CASE( is_valid )

--- a/packages/Search/test/tstBoostRangeAdapters.cpp
+++ b/packages/Search/test/tstBoostRangeAdapters.cpp
@@ -10,6 +10,7 @@
  ****************************************************************************/
 
 #include "DTK_BoostRangeAdapters.hpp"
+#include "DTK_EnableViewComparison.hpp"
 
 #include <DTK_Box.hpp>
 #include <DTK_DetailsAlgorithms.hpp>
@@ -21,27 +22,32 @@
 #include <boost/range/algorithm.hpp> // reverse_copy, replace_if, count, generate, count_if
 #include <boost/range/algorithm_ext.hpp> // iota
 #include <boost/range/numeric.hpp>       // accumulate
+#include <boost/test/unit_test.hpp>
 
 #include <random>
 #include <sstream>
 
-TEUCHOS_UNIT_TEST( BoostGeometryAdapters, Range )
+#define BOOST_TEST_MODULE BoostRangeAdapters
+
+namespace tt = boost::test_tools;
+
+BOOST_AUTO_TEST_CASE( range_algorithms )
 {
     Kokkos::View<int[4], Kokkos::HostSpace> w( "w" );
 
     boost::iota( w, 0 );
     std::stringstream ss;
     boost::reverse_copy( w, std::ostream_iterator<int>( ss, " " ) );
-    TEST_EQUALITY( ss.str(), "3 2 1 0 " );
+    BOOST_TEST( ss.str() == "3 2 1 0 " );
 
     boost::replace_if( w, []( int i ) { return ( i > 1 ); }, -1 );
-    TEST_COMPARE_ARRAYS( w, std::vector<int>( {0, 1, -1, -1} ) );
+    BOOST_TEST( w == std::vector<int>( {0, 1, -1, -1} ), tt::per_element() );
 
-    TEST_EQUALITY( boost::count( w, -1 ), 2 );
-    TEST_EQUALITY( boost::accumulate( w, 5 ), 4 );
+    BOOST_TEST( boost::count( w, -1 ), 2 );
+    BOOST_TEST( boost::accumulate( w, 5 ), 4 );
 }
 
-TEUCHOS_UNIT_TEST( BoostGeometryAdapters, PointCloud )
+BOOST_AUTO_TEST_CASE( point_cloud )
 {
     using DataTransferKit::Point;
     using DataTransferKit::Details::distance;
@@ -70,5 +76,5 @@ TEUCHOS_UNIT_TEST( BoostGeometryAdapters, PointCloud )
                       static_cast<double>( n );
 
     double const relative_tolerance = .05;
-    TEST_FLOATING_EQUALITY( pi, 3.14, relative_tolerance );
+    BOOST_TEST( pi == 3.14, tt::tolerance( relative_tolerance ) );
 }


### PR DESCRIPTION
Following up on https://github.com/ORNL-CEES/DataTransferKit/pull/546#issuecomment-479912752

The changes proposed convert/update two tests to the Boost unit test framework and, more importantly, enable element-wise comparison of Kokkos views with other sequence of values.