### PR TITLE
Use a MPL list to specify the types to instantiate test case templates

### DIFF
--- a/packages/Search/test/CMakeLists.txt
+++ b/packages/Search/test/CMakeLists.txt
@@ -39,7 +39,6 @@ if(Kokkos_ENABLE_Cuda)
   list(APPEND DTK_SEARCH_DEVICE_TYPES Kokkos::Cuda::device_type)
 endif()
 string(REPLACE ";" "," DTK_SEARCH_DEVICE_TYPES "${DTK_SEARCH_DEVICE_TYPES}")
-set(DTK_SEARCH_DEVICE_TYPES "std::tuple<${DTK_SEARCH_DEVICE_TYPES}>")
 configure_file(DTK_EnableDeviceTypes.hpp.in ${CMAKE_CURRENT_BINARY_DIR}/DTK_EnableDeviceTypes.hpp @ONLY)
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   DetailsUtils

--- a/packages/Search/test/DTK_EnableDeviceTypes.hpp.in
+++ b/packages/Search/test/DTK_EnableDeviceTypes.hpp.in
@@ -1,9 +1,10 @@
 #ifndef DTK_ENABLE_DEVICE_TYPES_HPP
 #define DTK_ENABLE_DEVICE_TYPES_HPP
 
+#include <boost/mpl/list.hpp>
 #include <boost/utility/identity_type.hpp>
 
 // clang-format off
-#cmakedefine DTK_SEARCH_DEVICE_TYPES BOOST_IDENTITY_TYPE((@DTK_SEARCH_DEVICE_TYPES@))
+#cmakedefine DTK_SEARCH_DEVICE_TYPES BOOST_IDENTITY_TYPE((boost::mpl::list<@DTK_SEARCH_DEVICE_TYPES@>))
 
 #endif


### PR DESCRIPTION
I had to switch from `std::tuple` to `boost::mpl::list` to get it to work with Clang.  I am not sure why but I don't feel like wasting more time investigating.