### PR TITLE
Point search clean up

### DIFF
--- a/packages/Discretization/src/DTK_PointSearch_decl.hpp
+++ b/packages/Discretization/src/DTK_PointSearch_decl.hpp
@@ -98,18 +98,13 @@ class PointSearch
      * @note This function should be <b>private</b> but lambda functions can
      * only be called from a public function in CUDA.
      */
-    void filterInCell(
-        std::array<Kokkos::View<bool *, DeviceType>, DTK_N_TOPO> const
-            &filtered_per_topo_point_in_cell,
-        std::array<Kokkos::View<double **, DeviceType>, DTK_N_TOPO> const
-            &filtered_per_topo_reference_points,
-        std::array<Kokkos::View<int *, DeviceType>, DTK_N_TOPO> const
-            &filtered_per_topo_cell_indices,
-        std::array<Kokkos::View<int *, DeviceType>, DTK_N_TOPO> const
-            &filtered_per_topo_query_ids,
-        std::array<Kokkos::View<int *, DeviceType>, DTK_N_TOPO> const &ranks,
-        std::array<Kokkos::View<int *, DeviceType>, DTK_N_TOPO>
-            &filtered_ranks );
+    Kokkos::View<int *, DeviceType> filterInCell(
+        Kokkos::View<bool *, DeviceType> filtered_per_topo_point_in_cell,
+        Kokkos::View<double **, DeviceType> filtered_per_topo_reference_points,
+        Kokkos::View<int *, DeviceType> filtered_per_topo_cell_indices,
+        Kokkos::View<int *, DeviceType> filtered_per_topo_query_ids,
+        Kokkos::View<int *, DeviceType> filtered_per_topo_ranks,
+        unsigned int topo_id );
 
   private:
     /**

--- a/packages/Discretization/src/DTK_PointSearch_decl.hpp
+++ b/packages/Discretization/src/DTK_PointSearch_decl.hpp
@@ -80,17 +80,17 @@ class PointSearch
      * @note This function should be <b>private</b> but lambda functions can
      * only be called from a public function in CUDA.
      */
-    void filterTopology(
+    std::tuple<Kokkos::View<int *, DeviceType>,
+               Kokkos::View<double **, DeviceType>,
+               Kokkos::View<int *, DeviceType>, Kokkos::View<int *, DeviceType>>
+    filterTopology(
         Kokkos::View<unsigned int *, DeviceType> topo, unsigned int topo_id,
+        unsigned int size,
         Kokkos::View<unsigned int **, DeviceType> bounding_box_to_cell,
         Kokkos::View<int *, DeviceType> cell_indices,
         Kokkos::View<ArborX::Point *, DeviceType> points,
         Kokkos::View<int *, DeviceType> query_ids,
-        Kokkos::View<int *, DeviceType> ranks,
-        Kokkos::View<int *, DeviceType> filtered_cell_indices,
-        Kokkos::View<double **, DeviceType> filtered_points,
-        Kokkos::View<int *, DeviceType> filtered_query_ids,
-        Kokkos::View<int *, DeviceType> filtered_ranks );
+        Kokkos::View<int *, DeviceType> ranks );
 
     /**
      * Keep data corresponding to points found inside the reference cell.
@@ -122,7 +122,11 @@ class PointSearch
      * Compute the position in the reference frame of candidates found by the
      * search.
      */
-    void performPointInCell(
+    std::tuple<Kokkos::View<int *, DeviceType>, Kokkos::View<int *, DeviceType>,
+               Kokkos::View<double **, DeviceType>,
+               Kokkos::View<bool *, DeviceType>,
+               Kokkos::View<int *, DeviceType>>
+    performPointInCell(
         Kokkos::View<double ***, DeviceType> cells,
         Kokkos::View<unsigned int **, DeviceType> bounding_box_to_cell,
         Kokkos::View<int *, DeviceType> imported_cell_indices,
@@ -130,12 +134,7 @@ class PointSearch
         Kokkos::View<int *, DeviceType> imported_query_ids,
         Kokkos::View<int *, DeviceType> imported_ranks,
         Kokkos::View<unsigned int *, DeviceType> topo, unsigned int topo_id,
-        Kokkos::View<double **, DeviceType> filtered_points,
-        Kokkos::View<int *, DeviceType> filtered_cell_indices,
-        Kokkos::View<int *, DeviceType> filtered_query_ids,
-        Kokkos::View<double **, DeviceType> reference_points,
-        Kokkos::View<bool *, DeviceType> point_in_cell,
-        Kokkos::View<int *, DeviceType> ranks );
+        unsigned int size );
 
     /**
      * Build the target-to-source distributor.

--- a/packages/Discretization/src/DTK_PointSearch_decl.hpp
+++ b/packages/Discretization/src/DTK_PointSearch_decl.hpp
@@ -117,11 +117,7 @@ class PointSearch
      * Compute the position in the reference frame of candidates found by the
      * search.
      */
-    std::tuple<Kokkos::View<int *, DeviceType>, Kokkos::View<int *, DeviceType>,
-               Kokkos::View<double **, DeviceType>,
-               Kokkos::View<bool *, DeviceType>,
-               Kokkos::View<int *, DeviceType>>
-    performPointInCell(
+    Kokkos::View<int *, DeviceType> performPointInCell(
         Kokkos::View<double ***, DeviceType> cells,
         Kokkos::View<unsigned int **, DeviceType> bounding_box_to_cell,
         Kokkos::View<int *, DeviceType> imported_cell_indices,

--- a/packages/Discretization/src/DTK_PointSearch_decl.hpp
+++ b/packages/Discretization/src/DTK_PointSearch_decl.hpp
@@ -66,13 +66,12 @@ class PointSearch
      * @note This function should be <b>private</b> but lambda functions can
      * only be called from a public function in CUDA.
      */
-    void performDistributedSearch(
+    std::tuple<Kokkos::View<ArborX::Point *, DeviceType>,
+               Kokkos::View<int *, DeviceType>, Kokkos::View<int *, DeviceType>,
+               Kokkos::View<int *, DeviceType>>
+    performDistributedSearch(
         Kokkos::View<double **, DeviceType> points_coord,
-        Kokkos::View<ArborX::Box *, DeviceType> bounding_boxes,
-        Kokkos::View<ArborX::Point *, DeviceType> &imported_points,
-        Kokkos::View<int *, DeviceType> &imported_query_ids,
-        Kokkos::View<int *, DeviceType> &imported_cell_indices,
-        Kokkos::View<int *, DeviceType> &ranks );
+        Kokkos::View<ArborX::Box *, DeviceType> bounding_boxes );
 
     /**
      * Keep cell_indices, points, query_ids, and ranks that satisfy a given

--- a/packages/Discretization/src/DTK_PointSearch_def.hpp
+++ b/packages/Discretization/src/DTK_PointSearch_def.hpp
@@ -383,14 +383,11 @@ PointSearch<DeviceType>::getSearchResults() const
     Kokkos::View<unsigned int *, DeviceType> imported_query_ids(
         "imported_query_ids", n_imports );
 
-    ArborX::Details::DistributedSearchTreeImpl<DeviceType>::sendAcrossNetwork(
-        _target_to_source_distributor, ranks, imported_ranks );
-    ArborX::Details::DistributedSearchTreeImpl<DeviceType>::sendAcrossNetwork(
-        _target_to_source_distributor, cell_indices, imported_cell_indices );
-    ArborX::Details::DistributedSearchTreeImpl<DeviceType>::sendAcrossNetwork(
-        _target_to_source_distributor, ref_pts, imported_ref_pts );
-    ArborX::Details::DistributedSearchTreeImpl<DeviceType>::sendAcrossNetwork(
-        _target_to_source_distributor, query_ids, imported_query_ids );
+    internal::sendDataAcrossNetwork(
+        _target_to_source_distributor, std::make_pair( ranks, imported_ranks ),
+        std::make_pair( cell_indices, imported_cell_indices ),
+        std::make_pair( ref_pts, imported_ref_pts ),
+        std::make_pair( query_ids, imported_query_ids ) );
 
     ArborX::Details::DistributedSearchTreeImpl<DeviceType>::sortResults(
         imported_query_ids, imported_query_ids, imported_cell_indices,


### PR DESCRIPTION
Simplify code in `PointSearch`. Mainly move code around and return the output of functions instead of passing the output by reference. We might move the function `sendDataAcrossNetwork` to ArborX. There are not that many changes but because it looks by because of the indentations. You should hide the whitespace changes when reviewing this PR.