### PR TITLE
Do not check for trailing whitespace in Search directory

### DIFF
--- a/scripts/check_no_trailing_whitespaces_or_tabs.sh
+++ b/scripts/check_no_trailing_whitespaces_or_tabs.sh
@@ -7,6 +7,7 @@ grep \
   --exclude=.gitmodules \
   --exclude=DTK_Fortran_wrap.cpp \
   --exclude-dir=data \
+  --exclude-dir=Search \
   --regexp '[[:blank:]]$' \
   --regexp $'\t' \
   --line-number $(git ls-files)


### PR DESCRIPTION
Travis does not pass on #560 because we check for trailing space in `Search`. We should not check for that in `Search`, it should be done in Arborx