### PR TITLE
Allow Kokkos with deprecated code disabled

### DIFF
--- a/packages/Interface/test/tstInit.cpp
+++ b/packages/Interface/test/tstInit.cpp
@@ -55,53 +55,51 @@ int main( int argc, char *argv[] )
 #endif
 
     auto check = [&status]( bool cond ) { status = ( status && cond ); };
+    auto is_initialized = []() {
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
+        return default_space::is_initialized();
+#else
+        return default_space::impl_is_initialized();
+#endif
+    };
 
     if ( t == 1 )
     {
-        check(
-            !DataTransferKit::isInitialized() &&
-            ( kokkos_always_initialized || !default_space::is_initialized() ) );
+        check( !DataTransferKit::isInitialized() &&
+               ( kokkos_always_initialized || !is_initialized() ) );
 
         DataTransferKit::initialize( &argc, &argv );
-        check( DataTransferKit::isInitialized() &&
-               default_space::is_initialized() );
+        check( DataTransferKit::isInitialized() && is_initialized() );
 
         DataTransferKit::finalize();
-        check(
-            !DataTransferKit::isInitialized() &&
-            ( kokkos_always_initialized || !default_space::is_initialized() ) );
+        check( !DataTransferKit::isInitialized() &&
+               ( kokkos_always_initialized || !is_initialized() ) );
     }
     else if ( t == 2 )
     {
         Kokkos::initialize( argc, argv );
-        check( !DataTransferKit::isInitialized() &&
-               default_space::is_initialized() );
+        check( !DataTransferKit::isInitialized() && is_initialized() );
 
         DataTransferKit::initialize( &argc, &argv );
-        check( DataTransferKit::isInitialized() &&
-               default_space::is_initialized() );
+        check( DataTransferKit::isInitialized() && is_initialized() );
 
         DataTransferKit::finalize();
-        check( !DataTransferKit::isInitialized() &&
-               default_space::is_initialized() );
+        check( !DataTransferKit::isInitialized() && is_initialized() );
 
         Kokkos::finalize();
-        check( kokkos_always_initialized || !default_space::is_initialized() );
+        check( kokkos_always_initialized || !is_initialized() );
     }
     else if ( t == 3 )
     {
-        check(
-            !DataTransferKit::isInitialized() &&
-            ( kokkos_always_initialized || !default_space::is_initialized() ) );
+        check( !DataTransferKit::isInitialized() &&
+               ( kokkos_always_initialized || !is_initialized() ) );
 
         DataTransferKit::initialize();
-        check( DataTransferKit::isInitialized() &&
-               default_space::is_initialized() );
+        check( DataTransferKit::isInitialized() && is_initialized() );
 
         DataTransferKit::finalize();
-        check(
-            !DataTransferKit::isInitialized() &&
-            ( kokkos_always_initialized || !default_space::is_initialized() ) );
+        check( !DataTransferKit::isInitialized() &&
+               ( kokkos_always_initialized || !is_initialized() ) );
     }
     else
     {

--- a/packages/Interface/test/tstView.cpp
+++ b/packages/Interface/test/tstView.cpp
@@ -17,9 +17,9 @@
 
 #include "DTK_View.hpp"
 
-#if defined( KOKKOS_HAVE_CUDA )
+#if defined( KOKKOS_ENABLE_CUDA )
 #include "ViewTestCudaHelpers.hpp"
-#endif // defined( KOKKOS_HAVE_CUDA )
+#endif // defined( KOKKOS_ENABLE_CUDA )
 
 #include <Kokkos_Core.hpp>
 
@@ -43,7 +43,7 @@ class FillView
 
 //---------------------------------------------------------------------------//
 // Serial implementation.
-#if defined( KOKKOS_HAVE_SERIAL )
+#if defined( KOKKOS_ENABLE_SERIAL )
 template <class Scalar>
 class FillView<Scalar, Kokkos::Serial>
 {
@@ -86,11 +86,11 @@ class FillView<Scalar, Kokkos::Serial>
         }
     }
 };
-#endif // defined( KOKKOS_HAVE_SERIAL )
+#endif // defined( KOKKOS_ENABLE_SERIAL )
 
 //---------------------------------------------------------------------------//
 // OpenMP implementation.
-#if defined( KOKKOS_HAVE_OPENMP )
+#if defined( KOKKOS_ENABLE_OPENMP )
 template <class Scalar>
 class FillView<Scalar, Kokkos::OpenMP>
 {
@@ -141,11 +141,11 @@ class FillView<Scalar, Kokkos::OpenMP>
         }
     }
 };
-#endif // defined ( KOKKOS_HAVE_OPENMP )
+#endif // defined ( KOKKOS_ENABLE_OPENMP )
 
 //---------------------------------------------------------------------------//
 // Cuda implementation.
-#if defined( KOKKOS_HAVE_CUDA )
+#if defined( KOKKOS_ENABLE_CUDA )
 template <class Scalar>
 class FillView<Scalar, Kokkos::Cuda>
 {
@@ -156,7 +156,7 @@ class FillView<Scalar, Kokkos::Cuda>
         ViewTestCudaHelpers::fillViewCuda( dtk_view, dims );
     }
 };
-#endif // defined( KOKKOS_HAVE_CUDA )
+#endif // defined( KOKKOS_ENABLE_CUDA )
 
 //---------------------------------------------------------------------------//
 // TEST TEMPLATE DECLARATIONS

--- a/packages/Meshfree/src/DTK_DetailsNearestNeighborOperatorImpl.hpp
+++ b/packages/Meshfree/src/DTK_DetailsNearestNeighborOperatorImpl.hpp
@@ -85,15 +85,14 @@ struct NearestNeighborOperatorImpl
 
         buffer_indices = import_target_indices;
         buffer_ranks = import_ranks;
-        Kokkos::realloc( buffer_values, n_imports,
-                         source_values.dimension_1() );
+        Kokkos::realloc( buffer_values, n_imports, source_values.extent( 1 ) );
         Kokkos::parallel_for(
             DTK_MARK_REGION( "get_source_values" ),
             Kokkos::RangePolicy<ExecutionSpace>( 0, n_imports ),
             KOKKOS_LAMBDA( int i ) {
-                for ( int j = 0; j < (int)source_values.dimension_1(); ++j )
-                    buffer_values( i, j ) =
-                        source_values( import_source_indices( i ), j );
+                for ( int j = 0; j < (int)source_values.extent( 1 ); ++j )
+                    buffer_values.access( i, j ) =
+                        source_values.access( import_source_indices( i ), j );
             } );
         Kokkos::fence();
     }
@@ -113,7 +112,7 @@ struct NearestNeighborOperatorImpl
 
         View export_source_values = buffer_values;
         View import_source_values( "source_values", n_imports,
-                                   target_values.dimension_1() );
+                                   target_values.extent( 1 ) );
         ArborX::Details::DistributedSearchTreeImpl<
             DeviceType>::sendAcrossNetwork( distributor, export_source_values,
                                             import_source_values );
@@ -129,9 +128,9 @@ struct NearestNeighborOperatorImpl
             DTK_MARK_REGION( "set_target_values" ),
             Kokkos::RangePolicy<ExecutionSpace>( 0, n_imports ),
             KOKKOS_LAMBDA( int i ) {
-                for ( int j = 0; j < (int)target_values.dimension_1(); ++j )
-                    target_values( import_target_indices( i ), j ) =
-                        import_source_values( i, j );
+                for ( int j = 0; j < (int)target_values.extent( 1 ); ++j )
+                    target_values.access( import_target_indices( i ), j ) =
+                        import_source_values.access( i, j );
             } );
         Kokkos::fence();
     }

--- a/packages/Meshfree/src/DTK_DetailsNearestNeighborOperatorImpl.hpp
+++ b/packages/Meshfree/src/DTK_DetailsNearestNeighborOperatorImpl.hpp
@@ -90,6 +90,9 @@ struct NearestNeighborOperatorImpl
             DTK_MARK_REGION( "get_source_values" ),
             Kokkos::RangePolicy<ExecutionSpace>( 0, n_imports ),
             KOKKOS_LAMBDA( int i ) {
+                // TODO Using Kokkos::View::access() is a workaround.
+                // We should write specializations for rank-1 and rank-2
+                // objects.
                 for ( int j = 0; j < (int)source_values.extent( 1 ); ++j )
                     buffer_values.access( i, j ) =
                         source_values.access( import_source_indices( i ), j );
@@ -128,6 +131,9 @@ struct NearestNeighborOperatorImpl
             DTK_MARK_REGION( "set_target_values" ),
             Kokkos::RangePolicy<ExecutionSpace>( 0, n_imports ),
             KOKKOS_LAMBDA( int i ) {
+                // TODO Using Kokkos::View::access() is a workaround.
+                // We should write specializations for rank-1 and rank-2
+                // objects.
                 for ( int j = 0; j < (int)target_values.extent( 1 ); ++j )
                     target_values.access( import_target_indices( i ), j ) =
                         import_source_values.access( i, j );

--- a/packages/Meshfree/test/tstNearestNeighborOperator.cpp
+++ b/packages/Meshfree/test/tstNearestNeighborOperator.cpp
@@ -264,8 +264,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( NearestNeighborOperator, mixed_clouds,
         double ref_value = round( target_points( i, 0 ) / Lx * nx ) * Lx / nx;
         if ( ref_value == Lx * comm_size )
             ref_value -= Lx / nx;
-        TEST_FLOATING_EQUALITY( target_values_host.access( i, 0 ), ref_value,
-                                1e-14 );
+        TEST_FLOATING_EQUALITY( target_values_host( i ), ref_value, 1e-14 );
     }
 }
 

--- a/packages/Meshfree/test/tstNearestNeighborOperator.cpp
+++ b/packages/Meshfree/test/tstNearestNeighborOperator.cpp
@@ -264,7 +264,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( NearestNeighborOperator, mixed_clouds,
         double ref_value = round( target_points( i, 0 ) / Lx * nx ) * Lx / nx;
         if ( ref_value == Lx * comm_size )
             ref_value -= Lx / nx;
-        TEST_FLOATING_EQUALITY( target_values_host( i, 0 ), ref_value, 1e-14 );
+        TEST_FLOATING_EQUALITY( target_values_host.access( i, 0 ), ref_value,
+                                1e-14 );
     }
 }
 

--- a/packages/Utils/src/DTK_Core.cpp
+++ b/packages/Utils/src/DTK_Core.cpp
@@ -34,7 +34,11 @@ void initKokkos( Args &&... args )
         // Kokkos::initialize() always initializes the default execution
         // space, so it suffices to check whether that was initialized.
         const bool kokkosIsInitialized =
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
             Kokkos::DefaultExecutionSpace::is_initialized();
+#else
+            Kokkos::DefaultExecutionSpace::impl_is_initialized();
+#endif
 
         if ( !kokkosIsInitialized )
         {
@@ -46,7 +50,11 @@ void initKokkos( Args &&... args )
     }
 
     const bool kokkosIsInitialized =
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
         Kokkos::DefaultExecutionSpace::is_initialized();
+#else
+        Kokkos::DefaultExecutionSpace::impl_is_initialized();
+#endif
 
     if ( !kokkosIsInitialized )
         throw DataTransferKitException( "At the end of initKokkos, Kokkos"


### PR DESCRIPTION
This pull request allows building `DTK` if the underlying `Kokkos` library has deprecated code disabled.

`Intrepid2` still needs to be fixed upstream, though.