### PR TITLE
Instantiate for linear basis function instead of quadratic

### DIFF
--- a/packages/Meshfree/src/DTK_SplineOperator_def.hpp
+++ b/packages/Meshfree/src/DTK_SplineOperator_def.hpp
@@ -299,8 +299,7 @@ void SplineOperator<DeviceType, CompactlySupportedRadialBasisFunction,
 
 // Explicit instantiation macro
 #define DTK_SPLINE_OPERATOR_INSTANT( NODE )                                    \
-    template class SplineOperator<typename NODE::device_type>;                 \
     template class SplineOperator<typename NODE::device_type, Wendland<0>,     \
-                                  MultivariatePolynomialBasis<Quadratic, 3>>;
+                                  MultivariatePolynomialBasis<Linear, 3>>;
 
 #endif


### PR DESCRIPTION
We have a `static_assert` [here](https://github.com/ORNL-CEES/DataTransferKit/blob/master/packages/Meshfree/src/DTK_SplineOperator_decl.hpp#L45-L47) that checks that we are using linear basis function but the explicit instantiation is using quadratic basis function.

closes #587 