### PR TITLE
Address compile issues in ExodusProblemGenerator GCC10

### DIFF
--- a/packages/Meshfree/src/DTK_SplineOperator_def.hpp
+++ b/packages/Meshfree/src/DTK_SplineOperator_def.hpp
@@ -140,7 +140,6 @@ SplineOperator<DeviceType, CompactlySupportedRadialBasisFunction,
         Teuchos::RCP<const Map> domain_map, Teuchos::RCP<const Map> range_map,
         Kokkos::View<Coordinate const **, DeviceType> points )
 {
-    const int n = points.extent( 0 );
     const int spatial_dim = points.extent( 1 );
 
     DTK_REQUIRE( spatial_dim == 3 );

--- a/packages/Meshfree/test/tstMeshfreeOperatorsSimpleProblem.cpp
+++ b/packages/Meshfree/test/tstMeshfreeOperatorsSimpleProblem.cpp
@@ -113,7 +113,6 @@ void checkResults( std::vector<double> const &values,
 TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( MeshfreeOperatorSimpleProblem, corner_cases,
                                    Operator )
 {
-    using DeviceType = typename Operator::device_type;
     // single point
     {
         std::vector<std::array<DataTransferKit::Coordinate, DIM>>


### PR DESCRIPTION
I ended up having some additional compilation errors using GCC10 on RHEL7 after issue #589 was resolved. Here is a quick PR that gets the code to compile for me. I made two changes in this PR:

1. Address incorrect number of arguments in ArborX::minMax()
and sendAcrossNetwork() calls.

2. Address compilation error from using Kokkos unmanaged views
(hitting static_assert on line 538 of ArborX_DetailsUtils.hpp

I'm not certain that I did the correct thing here, but these changes do point at the issues that I saw so please feel free to give me feedback or do something different here.


All of the tests run for me except for:

        DataTransferKit_Interpolation_MPI_4

Here are the errors I see in that test:
```
Running unit tests ...

0. Interpolation_DeviceTypeKokkos_Compat_KokkosSerialWrapperNode_one_topo_one_fe_three_dim_UnitTest ... [Passed] (0.00168 sec)
1. Interpolation_DeviceTypeKokkos_Compat_KokkosSerialWrapperNode_two_topo_two_dim_UnitTest ... [Passed] (0.00067 sec)
2. Interpolation_DeviceTypeKokkos_Compat_KokkosSerialWrapperNode_one_topo_one_fe_three_dim_hdiv_UnitTest ...
 Y.extent( 0 ) = 5 == ref_size = 5 : passed

 Check: rel_err(ref_sol[i] + dim * j, Y_host( i, j ))
        = rel_err(0, 0) = 0
          <= tol = 1e-06 : passed

Check: rel_err(ref_sol[i] + dim * j, Y_host( i, j ))
        = rel_err(-0.125, -0.5) = 0.75
          <= tol = 1e-06 : FAILED

 Check: rel_err(ref_sol[i] + dim * j, Y_host( i, j ))
        = rel_err(-0.2, -0.8) = 0.75
          <= tol = 1e-06 : FAILED

 Check: rel_err(ref_sol[i] + dim * j, Y_host( i, j ))
        = rel_err(-0.25, -1) = 0.75
          <= tol = 1e-06 : FAILED

 Check: rel_err(ref_sol[i] + dim * j, Y_host( i, j ))
        = rel_err(-0.45, -1.8) = 0.75
          <= tol = 1e-06 : FAILED
NOTE: Unit test failed on processes = {0, 1}
 (rerun with --output-to-root-rank-only=<procID> to see output
 from individual processes where the unit test is failing!)
 [FAILED]  (0.000648 sec) Interpolation_DeviceTypeKokkos_Compat_KokkosSerialWrapperNode_one_topo_one_fe_three_dim_hdiv_UnitTest
 Location: /projects/albany/src/Trilinos/DataTransferKit/packages/Discretization/test/tstInterpolation.cpp:371
```