### PR TITLE
Update ArborX

### DIFF
--- a/packages/Discretization/src/DTK_Interpolation_decl.hpp
+++ b/packages/Discretization/src/DTK_Interpolation_decl.hpp
@@ -178,10 +178,10 @@ Interpolation<DeviceType>::apply( Kokkos::View<Scalar **, DeviceType> X,
         "imported_query_ids", n_imports );
     Kokkos::View<Scalar **, DeviceType> imported_Y( "imported_Y", n_imports,
                                                     n_fields );
-    ArborX::Details::DistributedSearchTreeImpl<DeviceType>::sendAcrossNetwork(
+    ArborX::Details::DistributedTreeImpl<DeviceType>::sendAcrossNetwork(
         space, _point_search._target_to_source_distributor, query_ids,
         imported_query_ids );
-    ArborX::Details::DistributedSearchTreeImpl<DeviceType>::sendAcrossNetwork(
+    ArborX::Details::DistributedTreeImpl<DeviceType>::sendAcrossNetwork(
         space, _point_search._target_to_source_distributor, Y_buffer,
         imported_Y );
 
@@ -194,7 +194,7 @@ Interpolation<DeviceType>::apply( Kokkos::View<Scalar **, DeviceType> X,
         // Because of the MPI communications and the sorting by topologies, all
         // the queries have been reordered. So we put them back in the initial
         // order using the query ids.
-        ArborX::Details::DistributedSearchTreeImpl<DeviceType>::sortResults(
+        ArborX::Details::DistributedTreeImpl<DeviceType>::sortResults(
             space, imported_query_ids, imported_query_ids, imported_Y );
 
         // We have finally all the values in the right order but before we can

--- a/packages/Discretization/src/DTK_PointSearch_def.hpp
+++ b/packages/Discretization/src/DTK_PointSearch_def.hpp
@@ -91,7 +91,7 @@ void sendDataAcrossNetwork(
         &distributor,
     std::pair<ViewType, ViewType> data )
 {
-    ArborX::Details::DistributedSearchTreeImpl<typename ViewType::device_type>::
+    ArborX::Details::DistributedTreeImpl<typename ViewType::device_type>::
         sendAcrossNetwork( typename ViewType::execution_space{}, distributor,
                            data.first, data.second );
 }
@@ -344,7 +344,7 @@ PointSearch<DeviceType>::getSearchResults() const {
         std::make_pair( ref_pts, imported_ref_pts ),
         std::make_pair( query_ids, imported_query_ids ) );
 
-    ArborX::Details::DistributedSearchTreeImpl<DeviceType>::sortResults(
+    ArborX::Details::DistributedTreeImpl<DeviceType>::sortResults(
         ExecutionSpace{}, imported_query_ids, imported_query_ids,
         imported_cell_indices, imported_ranks, imported_ref_pts );
 
@@ -382,8 +382,8 @@ std::tuple<Kokkos::View<ArborX::Point *, DeviceType>,
 {
     DTK_REQUIRE( points_coord.extent( 1 ) == 3 );
 
-    ArborX::DistributedSearchTree<DeviceType> distributed_tree(
-        _comm, bounding_boxes );
+    ArborX::DistributedTree<DeviceType> distributed_tree( _comm,
+                                                          bounding_boxes );
 
     unsigned int const n_points = points_coord.extent( 0 );
 

--- a/packages/Meshfree/src/DTK_DetailsNearestNeighborOperatorImpl.hpp
+++ b/packages/Meshfree/src/DTK_DetailsNearestNeighborOperatorImpl.hpp
@@ -64,27 +64,24 @@ struct NearestNeighborOperatorImpl
         ArborX::iota( ExecutionSpace{}, export_target_indices );
         Kokkos::View<int *, DeviceType> import_target_indices( "target_indices",
                                                                n_imports );
-        ArborX::Details::DistributedSearchTreeImpl<
-            DeviceType>::sendAcrossNetwork( ExecutionSpace{}, distributor,
-                                            export_target_indices,
-                                            import_target_indices );
+        ArborX::Details::DistributedTreeImpl<DeviceType>::sendAcrossNetwork(
+            ExecutionSpace{}, distributor, export_target_indices,
+            import_target_indices );
 
         Kokkos::View<int *, DeviceType> export_source_indices = buffer_indices;
         Kokkos::View<int *, DeviceType> import_source_indices( "source_indices",
                                                                n_imports );
-        ArborX::Details::DistributedSearchTreeImpl<
-            DeviceType>::sendAcrossNetwork( ExecutionSpace{}, distributor,
-                                            export_source_indices,
-                                            import_source_indices );
+        ArborX::Details::DistributedTreeImpl<DeviceType>::sendAcrossNetwork(
+            ExecutionSpace{}, distributor, export_source_indices,
+            import_source_indices );
 
         Kokkos::View<int *, DeviceType> export_ranks( "ranks", n_exports );
         Kokkos::View<int *, DeviceType> import_ranks( "ranks", n_imports );
         int comm_rank;
         MPI_Comm_rank( comm, &comm_rank );
         Kokkos::deep_copy( export_ranks, comm_rank );
-        ArborX::Details::DistributedSearchTreeImpl<
-            DeviceType>::sendAcrossNetwork( ExecutionSpace{}, distributor,
-                                            export_ranks, import_ranks );
+        ArborX::Details::DistributedTreeImpl<DeviceType>::sendAcrossNetwork(
+            ExecutionSpace{}, distributor, export_ranks, import_ranks );
 
         buffer_indices = import_target_indices;
         buffer_ranks = import_ranks;
@@ -127,18 +124,16 @@ struct NearestNeighborOperatorImpl
             View::rank == 1
                 ? View( "source_values", n_imports )
                 : View( "source_values", n_imports, target_values.extent( 1 ) );
-        ArborX::Details::DistributedSearchTreeImpl<
-            DeviceType>::sendAcrossNetwork( ExecutionSpace{}, distributor,
-                                            export_source_values,
-                                            import_source_values );
+        ArborX::Details::DistributedTreeImpl<DeviceType>::sendAcrossNetwork(
+            ExecutionSpace{}, distributor, export_source_values,
+            import_source_values );
 
         Kokkos::View<int *, DeviceType> export_target_indices = buffer_indices;
         Kokkos::View<int *, DeviceType> import_target_indices( "target_indices",
                                                                n_imports );
-        ArborX::Details::DistributedSearchTreeImpl<
-            DeviceType>::sendAcrossNetwork( ExecutionSpace{}, distributor,
-                                            export_target_indices,
-                                            import_target_indices );
+        ArborX::Details::DistributedTreeImpl<DeviceType>::sendAcrossNetwork(
+            ExecutionSpace{}, distributor, export_target_indices,
+            import_target_indices );
 
         Kokkos::parallel_for(
             DTK_MARK_REGION( "set_target_values" ),

--- a/packages/Meshfree/src/DTK_MovingLeastSquaresOperator_def.hpp
+++ b/packages/Meshfree/src/DTK_MovingLeastSquaresOperator_def.hpp
@@ -41,8 +41,7 @@ MovingLeastSquaresOperator<DeviceType, CompactlySupportedRadialBasisFunction,
     DTK_REQUIRE( source_points.extent_int( 1 ) == 3 );
 
     // Build distributed search tree over the source points.
-    ArborX::DistributedSearchTree<DeviceType> search_tree( _comm,
-                                                           source_points );
+    ArborX::DistributedTree<DeviceType> search_tree( _comm, source_points );
     DTK_CHECK( !search_tree.empty() );
 
     // For each target point, query the n_neighbors points closest to the

--- a/packages/Meshfree/src/DTK_NearestNeighborOperator_def.hpp
+++ b/packages/Meshfree/src/DTK_NearestNeighborOperator_def.hpp
@@ -33,8 +33,7 @@ NearestNeighborOperator<DeviceType>::NearestNeighborOperator(
     // communication and just check that the tree is not empty.
 
     // Build distributed search tree over the source points.
-    ArborX::DistributedSearchTree<DeviceType> search_tree( _comm,
-                                                           source_points );
+    ArborX::DistributedTree<DeviceType> search_tree( _comm, source_points );
 
     // Tree must have at least one leaf, otherwise it makes little sense to
     // perform the search for nearest neighbors.

--- a/packages/Meshfree/src/DTK_SplineOperator_def.hpp
+++ b/packages/Meshfree/src/DTK_SplineOperator_def.hpp
@@ -54,8 +54,7 @@ SplineOperator<DeviceType, CompactlySupportedRadialBasisFunction,
     int const num_source_points = source_points.extent( 0 );
     int const num_points = target_points.extent( 0 );
 
-    ArborX::DistributedSearchTree<DeviceType> distributed_tree( comm,
-                                                                source_points );
+    ArborX::DistributedTree<DeviceType> distributed_tree( comm, source_points );
     DTK_CHECK( !distributed_tree.empty() );
 
     // Perform the actual search.

--- a/packages/Meshfree/test/PointCloudProblemGenerator/ExodusProblemGenerator_def.hpp
+++ b/packages/Meshfree/test/PointCloudProblemGenerator/ExodusProblemGenerator_def.hpp
@@ -213,7 +213,7 @@ void ExodusProblemGenerator<Scalar, SourceDevice, TargetDevice>::
     partitioned_coords =
         Kokkos::View<Coordinate **, Kokkos::LayoutLeft, Device>(
             "partitioned_coords", num_node_import, 3 );
-    ArborX::Details::DistributedSearchTreeImpl<Device>::sendAcrossNetwork(
+    ArborX::Details::DistributedTreeImpl<Device>::sendAcrossNetwork(
         distributor, export_coords, partitioned_coords );
 }
 
@@ -368,13 +368,13 @@ void ExodusProblemGenerator<Scalar, SourceDevice, TargetDevice>::
                                                                   num_import );
     Kokkos::View<Coordinate * [3], Kokkos::HostSpace> import_coords(
         "", num_import );
-    ArborX::Details::DistributedSearchTreeImpl<Device>::sendAcrossNetwork(
+    ArborX::Details::DistributedTreeImpl<Device>::sendAcrossNetwork(
         distributor,
         Kokkos::View<GlobalOrdinal /*const*/ *, Kokkos::HostSpace,
                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>(
             export_gids.data(), export_gids.size() ),
         import_gids );
-    ArborX::Details::DistributedSearchTreeImpl<Device>::sendAcrossNetwork(
+    ArborX::Details::DistributedTreeImpl<Device>::sendAcrossNetwork(
         distributor,
         Kokkos::View<Coordinate /*const*/ * [3], Kokkos::HostSpace,
                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>(

--- a/packages/Meshfree/test/tstDetailsCommunicationHelpers.cpp
+++ b/packages/Meshfree/test/tstDetailsCommunicationHelpers.cpp
@@ -64,9 +64,8 @@ struct Helper
         auto v_imp =
             Kokkos::create_mirror( typename View2::memory_space(), v_ref );
 
-        ArborX::Details::DistributedSearchTreeImpl<DeviceType>::
-            sendAcrossNetwork( typename DeviceType::execution_space{},
-                               distributor, v_exp, v_imp );
+        ArborX::Details::DistributedTreeImpl<DeviceType>::sendAcrossNetwork(
+            typename DeviceType::execution_space{}, distributor, v_exp, v_imp );
 
         // FIXME not sure why I need that guy but I do get a bus error when it
         // is not here...
@@ -88,7 +87,7 @@ struct Helper
     }
 };
 
-TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DetailsDistributedSearchTreeImpl,
+TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DetailsDistributedTreeImpl,
                                    send_across_network, DeviceType )
 {
     using ExecutionSpace = typename DeviceType::execution_space;
@@ -228,9 +227,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( DetailsNearestNeighborOperatorImpl, fetch,
 // Create the test group
 #define UNIT_TEST_GROUP( NODE )                                                \
     using DeviceType##NODE = typename NODE::device_type;                       \
-    TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT( DetailsDistributedSearchTreeImpl,    \
-                                          send_across_network,                 \
-                                          DeviceType##NODE )                   \
+    TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT(                                      \
+        DetailsDistributedTreeImpl, send_across_network, DeviceType##NODE )    \
     TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT( DetailsNearestNeighborOperatorImpl,  \
                                           fetch, DeviceType##NODE )
 


### PR DESCRIPTION
Note that I did not fix the deprecated `DistributedTree::query` calls.

Required for #592.