### PR TITLE
Update build system and fix warnings

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -37,8 +37,7 @@ pipeline {
                   -D TPL_Trilinos_DIR=${TRILINOS_DIR} \
                   -D TPL_BoostOrg_INCLUDE_DIRS=${BOOST_DIR}/include \
                   -D CMAKE_CXX_EXTENSIONS=OFF \
-                  -D DataTransferKit_CXX11_FLAGS="-std=c++14 --expt-extended-lambda" \
-                  -D CMAKE_CXX_STANDARD=14 \
+                  -D CMAKE_CXX_FLAGS="--expt-extended-lambda" \
                   -D DataTransferKit_ENABLE_OpenMP=ON \
                   ..
                 '''

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ IF (NOT TRIBITS_PROCESSING_PACKAGE)
     ## FLAGS
     ##---------------------------------------------------------------------------##
 
-    SET(${PACKAGE_NAME}_ENABLE_CXX11_DEFAULT ON)
+    SET(CMAKE_CXX_STANDARD 14)
 
     ##---------------------------------------------------------------------------##
     ## TriBITS package processing

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,8 @@ IF (NOT TRIBITS_PROCESSING_PACKAGE)
         CACHE PATH "By default assume TriBITS Core is snapshotted in DataTransferKit")
     INCLUDE("${CMAKE_CURRENT_SOURCE_DIR}/cmake/tribits/tribits/TriBITS.cmake")
 
+    SET(${PROJECT_NAME}_ENABLE_INSTALL_CMAKE_CONFIG_FILES_DEFAULT ON)
+
     ##---------------------------------------------------------------------------##
     ## Setup Trilinos as TPL
     ##---------------------------------------------------------------------------##

--- a/packages/Meshfree/src/DTK_MovingLeastSquaresOperator_def.hpp
+++ b/packages/Meshfree/src/DTK_MovingLeastSquaresOperator_def.hpp
@@ -16,6 +16,7 @@
 #include <DTK_DBC.hpp>
 #include <DTK_DetailsMovingLeastSquaresOperatorImpl.hpp>
 #include <DTK_DetailsNearestNeighborOperatorImpl.hpp> // fetch
+#include <DTK_DetailsUtils.hpp>
 
 namespace DataTransferKit
 {
@@ -51,7 +52,11 @@ MovingLeastSquaresOperator<DeviceType, CompactlySupportedRadialBasisFunction,
             target_points, PolynomialBasis::size );
 
     // Perform the actual search.
-    search_tree.query( queries, _indices, _offset, _ranks );
+    using PairIndexRank = Kokkos::pair<int, int>;
+    Kokkos::View<PairIndexRank *, DeviceType> index_rank( "index_rank", 0 );
+    search_tree.query( queries, index_rank, _offset );
+    // Split the pair
+    Details::splitIndexRank( index_rank, _indices, _ranks );
 
     // Retrieve the coordinates of all source points that met the predicates.
     // NOTE: This is the last collective.

--- a/packages/Utils/src/CMakeLists.txt
+++ b/packages/Utils/src/CMakeLists.txt
@@ -6,6 +6,7 @@ APPEND_SET(HEADERS
   DTK_ConfigDefs.hpp
   DTK_Core.hpp
   DTK_DBC.hpp
+  DTK_DetailsUtils.hpp
   DTK_SanitizerMacros.hpp
   DTK_Types.h
   DTK_Version.hpp

--- a/packages/Utils/src/DTK_DetailsUtils.hpp
+++ b/packages/Utils/src/DTK_DetailsUtils.hpp
@@ -1,0 +1,41 @@
+/****************************************************************************
+ * Copyright (c) 2012-2021 by the DataTransferKit authors                   *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the DataTransferKit library. DataTransferKit is     *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#ifndef DTK_DETAILS_UTILS_HPP
+#define DTK_DETAILS_UTILS_HPP
+
+#include <Kokkos_Core.hpp>
+
+namespace DataTransferKit
+{
+namespace Details
+{
+template <typename DeviceType>
+void splitIndexRank(
+    Kokkos::View<Kokkos::pair<int, int> *, DeviceType> index_rank,
+    Kokkos::View<int *, DeviceType> &indices,
+    Kokkos::View<int *, DeviceType> &ranks )
+{
+    using ExecutionSpace = typename DeviceType::execution_space;
+
+    auto const n_pairs = index_rank.extent( 0 );
+    Kokkos::realloc( indices, n_pairs );
+    Kokkos::realloc( ranks, n_pairs );
+    Kokkos::parallel_for( DTK_MARK_REGION( "split_pairs" ),
+                          Kokkos::RangePolicy<ExecutionSpace>( 0, n_pairs ),
+                          KOKKOS_LAMBDA( int i ) {
+                              indices( i ) = index_rank( i ).first;
+                              ranks( i ) = index_rank( i ).second;
+                          } );
+}
+} // namespace Details
+} // namespace DataTransferKit
+#endif


### PR DESCRIPTION
I was helping a user when I realized that we do not install our CMake configuration files. We only install DTK version files. This PR fixes that. Since I was changing the build system I updated Tribits. In newer versions of Tribits, we don't need to hack the C++11 flags to use C++14. So I fixed this at the same time. Finally, I fixed a bunch or warnings. 

Locally, I have test failing for this PR and for master. Let's see if this PR passes with our CI.