### PR TITLE
Remove sphinx from the Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,11 +30,6 @@ RUN apt-get update && apt-get install -y \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN curl -s https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
-    python get-pip.py && rm get-pip.py && \
-    pip install --upgrade --no-cache-dir pip && \
-    pip install --no-cache-dir sphinx==1.4 sphinx_rtd_theme breathe==4.7
-
 ENV PREFIX=/scratch
 RUN mkdir -p ${PREFIX} && \
     cd ${PREFIX} && \


### PR DESCRIPTION
There is problem building the docker images because of sphinx. If I remember correctly, the reason to have sphinx in the image is for debugging purpose. So I've removed it. Let's see if that fixes the CI failure.