### PR TITLE
Update ArborX version

### DIFF
--- a/packages/Discretization/src/DTK_PointSearch_def.hpp
+++ b/packages/Discretization/src/DTK_PointSearch_def.hpp
@@ -383,13 +383,15 @@ std::tuple<Kokkos::View<ArborX::Point *, DeviceType>,
 {
     DTK_REQUIRE( points_coord.extent( 1 ) == 3 );
 
-    ArborX::DistributedTree<DeviceType> distributed_tree( _comm,
-                                                          bounding_boxes );
+    using ExecutionSpace = typename DeviceType::execution_space;
+    using MemorySpace = typename DeviceType::memory_space;
+
+    ArborX::DistributedTree<MemorySpace> distributed_tree(
+        _comm, ExecutionSpace{}, bounding_boxes );
 
     unsigned int const n_points = points_coord.extent( 0 );
 
     // Build the queries
-    using ExecutionSpace = typename DeviceType::execution_space;
     Kokkos::View<decltype( ArborX::intersects( ArborX::Sphere{} ) ) *,
                  DeviceType>
         queries( "queries", n_points );
@@ -408,7 +410,7 @@ std::tuple<Kokkos::View<ArborX::Point *, DeviceType>,
     using PairIndexRank = Kokkos::pair<int, int>;
     Kokkos::View<int *, DeviceType> offset( "offset", 0 );
     Kokkos::View<PairIndexRank *, DeviceType> index_rank( "index_rank", 0 );
-    distributed_tree.query( queries, index_rank, offset );
+    distributed_tree.query( ExecutionSpace{}, queries, index_rank, offset );
 
     // Split the pair
     Kokkos::View<int *, DeviceType> indices( "indices", 0 );

--- a/packages/Meshfree/src/DTK_DetailsMovingLeastSquaresOperatorImpl.hpp
+++ b/packages/Meshfree/src/DTK_DetailsMovingLeastSquaresOperatorImpl.hpp
@@ -13,7 +13,6 @@
 #define DTK_DETAILS_MOVING_LEAST_SQUARES_OPERATOR_IMPL_HPP
 
 #include <ArborX.hpp>
-#include <ArborX_DetailsKokkosExt.hpp> // ArithmeticTraits
 #include <DTK_CompactlySupportedRadialBasisFunctions.hpp>
 #include <DTK_DetailsSVDImpl.hpp>
 
@@ -116,8 +115,7 @@ struct MovingLeastSquaresOperatorImpl
                 // divide by the radius in the calculation of the radial basis
                 // function. To avoid this problem, the radius has a minimal
                 // positive value.
-                double distance =
-                    10. * KokkosExt::ArithmeticTraits::epsilon<double>::value;
+                double distance = 10. * DBL_EPSILON;
                 for ( int j = offset( i ); j < offset( i + 1 ); ++j )
                 {
                     double new_distance = ArborX::Details::distance(

--- a/packages/Meshfree/src/DTK_DetailsSVDImpl.hpp
+++ b/packages/Meshfree/src/DTK_DetailsSVDImpl.hpp
@@ -12,8 +12,6 @@
 #ifndef DTK_DETAILS_SVD_IMPL_HPP
 #define DTK_DETAILS_SVD_IMPL_HPP
 
-#include <ArborX_DetailsKokkosExt.hpp> // ArithmeticTraits
-
 #include <Kokkos_Core.hpp>
 
 #include <cassert>
@@ -236,7 +234,7 @@ struct SVDFunctor
             }
 
         auto norm = norm_F_wo_diag( E );
-        auto tol = KokkosExt::ArithmeticTraits::epsilon<double>::value;
+        auto tol = DBL_EPSILON;
 
         while ( norm > tol )
         {

--- a/packages/Meshfree/src/DTK_MovingLeastSquaresOperator_def.hpp
+++ b/packages/Meshfree/src/DTK_MovingLeastSquaresOperator_def.hpp
@@ -41,8 +41,11 @@ MovingLeastSquaresOperator<DeviceType, CompactlySupportedRadialBasisFunction,
     // FIXME for now let's assume 3D
     DTK_REQUIRE( source_points.extent_int( 1 ) == 3 );
 
+    using ExecutionSpace = typename DeviceType::execution_space;
+    using MemorySpace = typename DeviceType::memory_space;
     // Build distributed search tree over the source points.
-    ArborX::DistributedTree<DeviceType> search_tree( _comm, source_points );
+    ArborX::DistributedTree<MemorySpace> search_tree( _comm, ExecutionSpace{},
+                                                      source_points );
     DTK_CHECK( !search_tree.empty() );
 
     // For each target point, query the n_neighbors points closest to the
@@ -54,7 +57,7 @@ MovingLeastSquaresOperator<DeviceType, CompactlySupportedRadialBasisFunction,
     // Perform the actual search.
     using PairIndexRank = Kokkos::pair<int, int>;
     Kokkos::View<PairIndexRank *, DeviceType> index_rank( "index_rank", 0 );
-    search_tree.query( queries, index_rank, _offset );
+    search_tree.query( ExecutionSpace{}, queries, index_rank, _offset );
     // Split the pair
     Details::splitIndexRank( index_rank, _indices, _ranks );
 

--- a/packages/Meshfree/src/DTK_NearestNeighborOperator_def.hpp
+++ b/packages/Meshfree/src/DTK_NearestNeighborOperator_def.hpp
@@ -33,8 +33,11 @@ NearestNeighborOperator<DeviceType>::NearestNeighborOperator(
     // source point passed to one of the rank, we let the tree handle the
     // communication and just check that the tree is not empty.
 
+    using ExecutionSpace = typename DeviceType::execution_space;
+    using MemorySpace = typename DeviceType::memory_space;
     // Build distributed search tree over the source points.
-    ArborX::DistributedTree<DeviceType> search_tree( _comm, source_points );
+    ArborX::DistributedTree<MemorySpace> search_tree( _comm, ExecutionSpace{},
+                                                      source_points );
 
     // Tree must have at least one leaf, otherwise it makes little sense to
     // perform the search for nearest neighbors.
@@ -48,7 +51,7 @@ NearestNeighborOperator<DeviceType>::NearestNeighborOperator(
     using PairIndexRank = Kokkos::pair<int, int>;
     Kokkos::View<int *, DeviceType> offset( "offset", 0 );
     Kokkos::View<PairIndexRank *, DeviceType> index_rank( "index_rank", 0 );
-    search_tree.query( nearest_queries, index_rank, offset );
+    search_tree.query( ExecutionSpace{}, nearest_queries, index_rank, offset );
 
     // Split the pair
     Kokkos::View<int *, DeviceType> indices( "indices", 0 );

--- a/packages/Meshfree/src/DTK_SplineOperator_def.hpp
+++ b/packages/Meshfree/src/DTK_SplineOperator_def.hpp
@@ -55,7 +55,11 @@ SplineOperator<DeviceType, CompactlySupportedRadialBasisFunction,
     int const num_source_points = source_points.extent( 0 );
     int const num_points = target_points.extent( 0 );
 
-    ArborX::DistributedTree<DeviceType> distributed_tree( comm, source_points );
+    using ExecutionSpace = typename DeviceType::execution_space;
+    using MemorySpace = typename DeviceType::memory_space;
+
+    ArborX::DistributedTree<MemorySpace> distributed_tree(
+        comm, ExecutionSpace{}, source_points );
     DTK_CHECK( !distributed_tree.empty() );
 
     // Perform the actual search.
@@ -66,7 +70,7 @@ SplineOperator<DeviceType, CompactlySupportedRadialBasisFunction,
     using PairIndexRank = Kokkos::pair<int, int>;
     Kokkos::View<int *, DeviceType> offset( "offset", 0 );
     Kokkos::View<PairIndexRank *, DeviceType> index_rank( "index_rank", 0 );
-    distributed_tree.query( queries, index_rank, offset );
+    distributed_tree.query( ExecutionSpace{}, queries, index_rank, offset );
 
     // Split the pair
     Kokkos::View<int *, DeviceType> indices( "indices", 0 );


### PR DESCRIPTION
I have replaced `KokkosExt::ArithmeticTraits::epsilon<double>::value` with `DBL_EPSILON` because DTK had a dependency on `ArborX_DetailsKokkosExt.hpp` but that file doesn't exist anymore. Instead of depending on another file in `ArborX/Details`, I just use `DBL_EPSILON` directly.