### PR TITLE
Check less in one_topo_one_fe_three_dim_hdiv

### DIFF
--- a/packages/Discretization/test/tstInterpolation.cpp
+++ b/packages/Discretization/test/tstInterpolation.cpp
@@ -374,7 +374,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( Interpolation,
     MPI_Comm comm = MPI_COMM_WORLD;
     int comm_rank;
     MPI_Comm_rank( comm, &comm_rank );
-    unsigned int constexpr dim = 3;
     Kokkos::View<DTK_CellTopology *, DeviceType> cell_topologies;
     Kokkos::View<unsigned int *, DeviceType> cells;
     Kokkos::View<DataTransferKit::Coordinate **, DeviceType> coordinates;
@@ -414,15 +413,10 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( Interpolation,
 
     Kokkos::View<double **, DeviceType> Y( "Y", n_points, n_fields );
     interpolation.apply( X, Y );
-    if ( comm_rank == 0 )
+
+    if ( comm_rank <= 1 )
     {
-        std::array<double, 5> ref_sol = {{0., -0.125, -0.2, -0.25, -0.45}};
-        checkFieldValue<dim, 5>( ref_sol, Y, success, out, 1e-6 );
-    }
-    else if ( comm_rank == 1 )
-    {
-        std::array<double, 5> ref_sol = {{0., -0.125, -0.2, -0.25, -0.15}};
-        checkFieldValue<dim, 5>( ref_sol, Y, success, out, 1e-6 );
+        TEST_EQUALITY( Y.extent( 0 ), 5 );
     }
     else
     {


### PR DESCRIPTION
Fixes https://github.com/xsdk-project/xsdk-issues/issues/141 partly.
https://github.com/trilinos/Trilinos/commit/3bcdcb8 changed the scaling of the polynomial basis so the output of the tests also changes. A couple of lines we say 
> We set X = 1. I don't know what the FE looks like so this tests just check that we don't crash

Hence, I propose to only check that the sizes of the arrays are correct. Alternatively, we could run a fallback check if the result doesn't match the current reference values.