### PR TITLE
Don't list Kokkos as explicit dependency to support external Kokkos in Trilinos

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1,4 +1,4 @@
-SET(${PACKAGE_NAME}_Trilinos_REQUIRED_COMPONENTS Belos Kokkos Intrepid2 Stratimikos Teuchos Thyra Tpetra)
+SET(${PACKAGE_NAME}_Trilinos_REQUIRED_COMPONENTS Belos Intrepid2 Stratimikos Teuchos Thyra Tpetra)
 SET(${PACKAGE_NAME}_Trilinos_OPTIONAL_COMPONENTS "")
 
 IF (${PACKAGE_NAME}_ARBORX_TPL)


### PR DESCRIPTION
Fixes https://github.com/xsdk-project/xsdk-issues/issues/214. In particular, see https://github.com/xsdk-project/xsdk-issues/issues/214#issuecomment-1682800028.
Not listing `Kokkos` as explicit dependency appears to be the simplest solution.